### PR TITLE
[HU-034] EN/ES localization foundation for auth baseline

### DIFF
--- a/android/Reguerta/app/src/main/java/com/reguerta/user/domain/access/AccessResolutionResult.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/domain/access/AccessResolutionResult.kt
@@ -1,7 +1,11 @@
 package com.reguerta.user.domain.access
 
+enum class UnauthorizedReason {
+    USER_NOT_AUTHORIZED,
+}
+
 sealed interface AccessResolutionResult {
     data class Authorized(val member: Member) : AccessResolutionResult
 
-    data class Unauthorized(val message: String) : AccessResolutionResult
+    data class Unauthorized(val reason: UnauthorizedReason) : AccessResolutionResult
 }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/domain/access/ResolveAuthorizedSessionUseCase.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/domain/access/ResolveAuthorizedSessionUseCase.kt
@@ -6,10 +6,10 @@ class ResolveAuthorizedSessionUseCase(
     suspend operator fun invoke(authPrincipal: AuthPrincipal): AccessResolutionResult {
         val normalizedEmail = normalizeEmail(authPrincipal.email)
         val member = memberRepository.findByEmailNormalized(normalizedEmail)
-            ?: return AccessResolutionResult.Unauthorized(message = "Unauthorized user")
+            ?: return AccessResolutionResult.Unauthorized(reason = UnauthorizedReason.USER_NOT_AUTHORIZED)
 
         if (!member.isActive) {
-            return AccessResolutionResult.Unauthorized(message = "Unauthorized user")
+            return AccessResolutionResult.Unauthorized(reason = UnauthorizedReason.USER_NOT_AUTHORIZED)
         }
 
         val linkedMember = when {
@@ -18,7 +18,7 @@ class ResolveAuthorizedSessionUseCase(
             }
 
             member.authUid == authPrincipal.uid -> member
-            else -> return AccessResolutionResult.Unauthorized(message = "Unauthorized user")
+            else -> return AccessResolutionResult.Unauthorized(reason = UnauthorizedReason.USER_NOT_AUTHORIZED)
         }
 
         return AccessResolutionResult.Authorized(linkedMember)

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRoot.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRoot.kt
@@ -1,5 +1,7 @@
 package com.reguerta.user.presentation.access
 
+import android.annotation.SuppressLint
+import android.content.Context
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -24,18 +25,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.firebase.firestore.FirebaseFirestore
+import com.reguerta.user.R
 import com.reguerta.user.data.access.ChainedMemberRepository
 import com.reguerta.user.data.access.FirestoreMemberRepository
 import com.reguerta.user.data.access.InMemoryMemberRepository
 import com.reguerta.user.domain.access.Member
 import com.reguerta.user.domain.access.MemberRole
 import com.reguerta.user.domain.access.ResolveAuthorizedSessionUseCase
+import com.reguerta.user.domain.access.UnauthorizedReason
 import com.reguerta.user.domain.access.UpsertMemberByAdminUseCase
 
 @Composable
@@ -55,17 +60,19 @@ fun rememberSessionViewModel(): SessionViewModel {
 }
 
 @Composable
+@SuppressLint("LocalContextGetResourceValueCall")
 fun ReguertaRoot(
     viewModel: SessionViewModel = rememberSessionViewModel(),
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
 
     LaunchedEffect(viewModel) {
         viewModel.uiEvents.collect { event ->
             if (event is SessionUiEvent.ShowMessage) {
-                snackbarHostState.showSnackbar(event.message)
+                snackbarHostState.showSnackbar(context.getString(event.messageRes))
             }
         }
     }
@@ -83,7 +90,7 @@ fun ReguertaRoot(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Text(
-                text = "Members and Roles",
+                text = stringResource(R.string.access_members_roles_title),
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold,
             )
@@ -93,7 +100,7 @@ fun ReguertaRoot(
             when (val mode = state.mode) {
                 is SessionMode.SignedOut -> {
                     Text(
-                        text = "Sign in with a pre-authorized member email to unlock operational modules.",
+                        text = stringResource(R.string.access_signed_out_hint),
                         style = MaterialTheme.typography.bodyMedium,
                     )
                 }
@@ -127,19 +134,19 @@ private fun SignInCard(state: SessionUiState, viewModel: SessionViewModel) {
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Text("Authentication")
+            Text(stringResource(R.string.access_card_authentication))
             OutlinedTextField(
                 value = state.emailInput,
                 onValueChange = viewModel::onEmailChanged,
                 modifier = Modifier.fillMaxWidth(),
-                label = { Text("Email") },
+                label = { Text(stringResource(R.string.common_input_email_label)) },
                 singleLine = true,
             )
             OutlinedTextField(
                 value = state.uidInput,
                 onValueChange = viewModel::onUidChanged,
                 modifier = Modifier.fillMaxWidth(),
-                label = { Text("Auth UID") },
+                label = { Text(stringResource(R.string.access_input_auth_uid_label)) },
                 singleLine = true,
             )
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -147,10 +154,18 @@ private fun SignInCard(state: SessionUiState, viewModel: SessionViewModel) {
                     onClick = viewModel::signIn,
                     enabled = !state.isAuthenticating,
                 ) {
-                    Text(if (state.isAuthenticating) "Signing in..." else "Sign in")
+                    Text(
+                        stringResource(
+                            if (state.isAuthenticating) {
+                                R.string.access_action_signing_in
+                            } else {
+                                R.string.access_action_sign_in
+                            },
+                        ),
+                    )
                 }
                 Button(onClick = viewModel::signOut) {
-                    Text("Sign out")
+                    Text(stringResource(R.string.access_action_sign_out))
                 }
             }
         }
@@ -166,10 +181,17 @@ private fun UnauthorizedCard(mode: SessionMode.Unauthorized) {
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Text("Unauthorized user", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-            Text("Signed in email: ${mode.email}")
-            Text("Operational modules remain disabled until an admin pre-authorizes this email.")
-            Text("Reason: ${mode.message}", style = MaterialTheme.typography.bodySmall)
+            Text(
+                stringResource(R.string.auth_error_member_unauthorized),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(stringResource(R.string.access_signed_in_email_format, mode.email))
+            Text(stringResource(R.string.auth_info_member_restricted_mode))
+            Text(
+                stringResource(R.string.common_reason_format, stringResource(mode.reason.toMessageResId())),
+                style = MaterialTheme.typography.bodySmall,
+            )
         }
     }
 }
@@ -190,10 +212,20 @@ private fun AuthorizedHome(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Text("Home", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-            Text("Welcome ${mode.member.displayName}")
-            Text("Roles: ${mode.member.roles.toPrettyRoles()}")
-            Text("Status: ${if (mode.member.isActive) "Active" else "Inactive"}")
+            val context = LocalContext.current
+            Text(
+                stringResource(R.string.home_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(stringResource(R.string.home_welcome_format, mode.member.displayName))
+            Text(stringResource(R.string.common_roles_format, mode.member.roles.toPrettyRoles(context)))
+            Text(
+                stringResource(
+                    R.string.common_status_format,
+                    stringResource(if (mode.member.isActive) R.string.common_status_active else R.string.common_status_inactive),
+                ),
+            )
         }
     }
 
@@ -220,15 +252,15 @@ private fun OperationalModules(enabled: Boolean) {
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
-            Text("Operational modules")
+            Text(stringResource(R.string.operational_modules_title))
             Button(onClick = {}, enabled = enabled, modifier = Modifier.fillMaxWidth()) {
-                Text("My order")
+                Text(stringResource(R.string.module_my_order))
             }
             Button(onClick = {}, enabled = enabled, modifier = Modifier.fillMaxWidth()) {
-                Text("Catalog")
+                Text(stringResource(R.string.module_catalog))
             }
             Button(onClick = {}, enabled = enabled, modifier = Modifier.fillMaxWidth()) {
-                Text("Shifts")
+                Text(stringResource(R.string.module_shifts))
             }
         }
     }
@@ -250,54 +282,58 @@ private fun AdminMembersCard(
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Text("Admin | Manage members", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
-            Text("Create / edit / deactivate members and roles")
+            Text(
+                stringResource(R.string.admin_manage_members_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(stringResource(R.string.admin_manage_members_subtitle))
 
             members.forEach { member ->
                 MemberRow(member = member, onToggleAdmin = onToggleAdmin, onToggleActive = onToggleActive)
             }
 
             Spacer(modifier = Modifier.height(8.dp))
-            Text("Create pre-authorized member", fontWeight = FontWeight.Medium)
+            Text(stringResource(R.string.admin_create_pre_authorized_member), fontWeight = FontWeight.Medium)
 
             OutlinedTextField(
                 value = draft.displayName,
                 onValueChange = { onDraftChanged(draft.copy(displayName = it)) },
                 modifier = Modifier.fillMaxWidth(),
-                label = { Text("Display name") },
+                label = { Text(stringResource(R.string.admin_input_display_name_label)) },
                 singleLine = true,
             )
             OutlinedTextField(
                 value = draft.email,
                 onValueChange = { onDraftChanged(draft.copy(email = it)) },
                 modifier = Modifier.fillMaxWidth(),
-                label = { Text("Email") },
+                label = { Text(stringResource(R.string.common_input_email_label)) },
                 singleLine = true,
             )
 
             RoleCheckboxRow(
                 checked = draft.isMember,
-                label = "Member",
+                label = stringResource(R.string.role_member),
                 onCheckedChange = { onDraftChanged(draft.copy(isMember = it)) },
             )
             RoleCheckboxRow(
                 checked = draft.isProducer,
-                label = "Producer",
+                label = stringResource(R.string.role_producer),
                 onCheckedChange = { onDraftChanged(draft.copy(isProducer = it)) },
             )
             RoleCheckboxRow(
                 checked = draft.isAdmin,
-                label = "Admin",
+                label = stringResource(R.string.role_admin),
                 onCheckedChange = { onDraftChanged(draft.copy(isAdmin = it)) },
             )
             RoleCheckboxRow(
                 checked = draft.isActive,
-                label = "Active",
+                label = stringResource(R.string.role_active),
                 onCheckedChange = { onDraftChanged(draft.copy(isActive = it)) },
             )
 
             Button(onClick = onCreateMember, modifier = Modifier.fillMaxWidth()) {
-                Text("Create member")
+                Text(stringResource(R.string.admin_action_create_member))
             }
         }
     }
@@ -324,6 +360,7 @@ private fun MemberRow(
     onToggleAdmin: (String) -> Unit,
     onToggleActive: (String) -> Unit,
 ) {
+    val context = LocalContext.current
     Card {
         Column(
             modifier = Modifier
@@ -333,26 +370,57 @@ private fun MemberRow(
         ) {
             Text(member.displayName, fontWeight = FontWeight.Medium)
             Text(member.normalizedEmail)
-            Text("Roles: ${member.roles.toPrettyRoles()}")
-            Text("Auth linked: ${if (member.authUid == null) "No" else "Yes"}")
-            Text("Status: ${if (member.isActive) "Active" else "Inactive"}")
+            Text(stringResource(R.string.common_roles_format, member.roles.toPrettyRoles(context)))
+            Text(
+                stringResource(
+                    R.string.member_auth_linked_format,
+                    stringResource(if (member.authUid == null) R.string.common_no else R.string.common_yes),
+                ),
+            )
+            Text(
+                stringResource(
+                    R.string.common_status_format,
+                    stringResource(if (member.isActive) R.string.common_status_active else R.string.common_status_inactive),
+                ),
+            )
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(onClick = { onToggleAdmin(member.id) }) {
-                    Text(if (member.isAdmin) "Revoke admin" else "Grant admin")
+                    Text(
+                        stringResource(
+                            if (member.isAdmin) {
+                                R.string.admin_action_revoke_admin
+                            } else {
+                                R.string.admin_action_grant_admin
+                            },
+                        ),
+                    )
                 }
                 Button(onClick = { onToggleActive(member.id) }) {
-                    Text(if (member.isActive) "Deactivate" else "Activate")
+                    Text(
+                        stringResource(
+                            if (member.isActive) {
+                                R.string.admin_action_deactivate
+                            } else {
+                                R.string.admin_action_activate
+                            },
+                        ),
+                    )
                 }
             }
         }
     }
 }
 
-private fun Set<MemberRole>.toPrettyRoles(): String =
+private fun Set<MemberRole>.toPrettyRoles(context: Context): String =
     this.joinToString(separator = ", ") { role ->
         when (role) {
-            MemberRole.MEMBER -> "member"
-            MemberRole.PRODUCER -> "producer"
-            MemberRole.ADMIN -> "admin"
+            MemberRole.MEMBER -> context.getString(R.string.role_value_member)
+            MemberRole.PRODUCER -> context.getString(R.string.role_value_producer)
+            MemberRole.ADMIN -> context.getString(R.string.role_value_admin)
         }
+    }
+
+private fun UnauthorizedReason.toMessageResId(): Int =
+    when (this) {
+        UnauthorizedReason.USER_NOT_AUTHORIZED -> R.string.auth_error_member_unauthorized
     }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionViewModel.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionViewModel.kt
@@ -1,7 +1,9 @@
 package com.reguerta.user.presentation.access
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.reguerta.user.R
 import com.reguerta.user.domain.access.AccessResolutionResult
 import com.reguerta.user.domain.access.AuthPrincipal
 import com.reguerta.user.domain.access.Member
@@ -9,6 +11,7 @@ import com.reguerta.user.domain.access.MemberManagementException
 import com.reguerta.user.domain.access.MemberRepository
 import com.reguerta.user.domain.access.MemberRole
 import com.reguerta.user.domain.access.ResolveAuthorizedSessionUseCase
+import com.reguerta.user.domain.access.UnauthorizedReason
 import com.reguerta.user.domain.access.UpsertMemberByAdminUseCase
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,7 +42,7 @@ sealed interface SessionMode {
 
     data class Unauthorized(
         val email: String,
-        val message: String,
+        val reason: UnauthorizedReason,
     ) : SessionMode
 }
 
@@ -52,7 +55,7 @@ data class SessionUiState(
 )
 
 sealed interface SessionUiEvent {
-    data class ShowMessage(val message: String) : SessionUiEvent
+    data class ShowMessage(@param:StringRes val messageRes: Int) : SessionUiEvent
 }
 
 class SessionViewModel(
@@ -80,7 +83,7 @@ class SessionViewModel(
         val uid = currentState.uidInput.trim()
 
         if (email.isBlank() || uid.isBlank()) {
-            emitMessage("Email and UID are required")
+            emitMessage(R.string.feedback_email_uid_required)
             return
         }
 
@@ -108,7 +111,7 @@ class SessionViewModel(
                             isAuthenticating = false,
                             mode = SessionMode.Unauthorized(
                                 email = email,
-                                message = result.message,
+                                reason = result.reason,
                             ),
                         )
                     }
@@ -134,13 +137,13 @@ class SessionViewModel(
     fun createAuthorizedMember() {
         val mode = _uiState.value.mode as? SessionMode.Authorized ?: return
         if (!mode.member.isAdmin) {
-            emitMessage("Only admins can create members")
+            emitMessage(R.string.feedback_only_admin_create)
             return
         }
 
         val draft = _uiState.value.memberDraft
         if (draft.displayName.isBlank() || draft.email.isBlank()) {
-            emitMessage("Display name and email are required")
+            emitMessage(R.string.feedback_display_name_email_required)
             return
         }
 
@@ -148,13 +151,13 @@ class SessionViewModel(
         val allMembers = mode.members
         val memberId = buildMemberId(normalizedEmail)
         if (allMembers.any { it.id == memberId || it.normalizedEmail == normalizedEmail }) {
-            emitMessage("Member already exists")
+            emitMessage(R.string.feedback_member_exists)
             return
         }
 
         val roles = buildRoles(draft)
         if (roles.isEmpty()) {
-            emitMessage("Select at least one role")
+            emitMessage(R.string.feedback_select_role)
             return
         }
 
@@ -176,7 +179,7 @@ class SessionViewModel(
     fun toggleAdmin(memberId: String) {
         val mode = _uiState.value.mode as? SessionMode.Authorized ?: return
         if (!mode.member.isAdmin) {
-            emitMessage("Only admins can edit roles")
+            emitMessage(R.string.feedback_only_admin_edit_roles)
             return
         }
 
@@ -199,7 +202,7 @@ class SessionViewModel(
     fun toggleActive(memberId: String) {
         val mode = _uiState.value.mode as? SessionMode.Authorized ?: return
         if (!mode.member.isAdmin) {
-            emitMessage("Only admins can activate or deactivate")
+            emitMessage(R.string.feedback_only_admin_toggle_active)
             return
         }
 
@@ -217,10 +220,13 @@ class SessionViewModel(
             val updatedMember = try {
                 upsertMemberByAdmin(actorAuthUid = mode.principal.uid, target = target)
             } catch (_: MemberManagementException.AccessDenied) {
-                emitMessage("Only admins can manage members")
+                emitMessage(R.string.feedback_only_admin_manage_members)
                 return@launch
             } catch (_: MemberManagementException.LastAdminRemoval) {
-                emitMessage("Cannot leave the app without active admins")
+                emitMessage(R.string.feedback_cannot_remove_last_admin)
+                return@launch
+            } catch (_: Exception) {
+                emitMessage(R.string.feedback_unable_save_changes)
                 return@launch
             }
 
@@ -245,9 +251,9 @@ class SessionViewModel(
         }
     }
 
-    private fun emitMessage(message: String) {
+    private fun emitMessage(@StringRes messageRes: Int) {
         viewModelScope.launch {
-            _uiEvents.emit(SessionUiEvent.ShowMessage(message))
+            _uiEvents.emit(SessionUiEvent.ShowMessage(messageRes))
         }
     }
 

--- a/android/Reguerta/app/src/main/res/values-es/strings.xml
+++ b/android/Reguerta/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,62 @@
+<resources>
+    <string name="app_name">Reguerta</string>
+
+    <string name="access_members_roles_title">Miembros y roles</string>
+    <string name="access_signed_out_hint">Inicia sesion con un email de miembro preautorizado para desbloquear los modulos operativos.</string>
+    <string name="access_card_authentication">Autenticacion</string>
+    <string name="common_input_email_label">Email</string>
+    <string name="access_input_auth_uid_label">Auth UID</string>
+    <string name="access_action_signing_in">Iniciando sesion...</string>
+    <string name="access_action_sign_in">Iniciar sesion</string>
+    <string name="access_action_sign_out">Cerrar sesion</string>
+    <string name="access_action_dismiss_message">Cerrar mensaje</string>
+
+    <string name="auth_error_member_unauthorized">Usuario no autorizado</string>
+    <string name="access_signed_in_email_format">Email de sesion: %1$s</string>
+    <string name="auth_info_member_restricted_mode">Los modulos operativos seguiran desactivados hasta que un admin preautorice este email.</string>
+    <string name="common_reason_format">Motivo: %1$s</string>
+
+    <string name="home_title">Inicio</string>
+    <string name="home_welcome_format">Bienvenido %1$s</string>
+    <string name="common_roles_format">Roles: %1$s</string>
+    <string name="common_status_format">Estado: %1$s</string>
+    <string name="common_status_active">Activo</string>
+    <string name="common_status_inactive">Inactivo</string>
+
+    <string name="operational_modules_title">Modulos operativos</string>
+    <string name="module_my_order">Mi pedido</string>
+    <string name="module_catalog">Catalogo</string>
+    <string name="module_shifts">Turnos</string>
+
+    <string name="admin_manage_members_title">Admin | Gestion de miembros</string>
+    <string name="admin_manage_members_subtitle">Crear / editar / desactivar miembros y roles</string>
+    <string name="admin_create_pre_authorized_member">Crear miembro preautorizado</string>
+    <string name="admin_input_display_name_label">Nombre visible</string>
+    <string name="role_member">Miembro</string>
+    <string name="role_producer">Productor</string>
+    <string name="role_admin">Admin</string>
+    <string name="role_active">Activo</string>
+    <string name="admin_action_create_member">Crear miembro</string>
+    <string name="member_auth_linked_format">Auth vinculada: %1$s</string>
+    <string name="common_yes">Si</string>
+    <string name="common_no">No</string>
+    <string name="admin_action_revoke_admin">Quitar admin</string>
+    <string name="admin_action_grant_admin">Dar admin</string>
+    <string name="admin_action_deactivate">Desactivar</string>
+    <string name="admin_action_activate">Activar</string>
+
+    <string name="feedback_email_uid_required">Email y UID son obligatorios</string>
+    <string name="feedback_only_admin_create">Solo los admins pueden crear miembros</string>
+    <string name="feedback_display_name_email_required">Nombre visible y email son obligatorios</string>
+    <string name="feedback_member_exists">El miembro ya existe</string>
+    <string name="feedback_select_role">Selecciona al menos un rol</string>
+    <string name="feedback_only_admin_edit_roles">Solo los admins pueden editar roles</string>
+    <string name="feedback_only_admin_toggle_active">Solo los admins pueden activar o desactivar</string>
+    <string name="feedback_only_admin_manage_members">Solo los admins pueden gestionar miembros</string>
+    <string name="feedback_cannot_remove_last_admin">No se puede dejar la app sin admins activos</string>
+    <string name="feedback_unable_save_changes">No se pudieron guardar los cambios</string>
+
+    <string name="role_value_member">miembro</string>
+    <string name="role_value_producer">productor</string>
+    <string name="role_value_admin">admin</string>
+</resources>

--- a/android/Reguerta/app/src/main/res/values/strings.xml
+++ b/android/Reguerta/app/src/main/res/values/strings.xml
@@ -1,3 +1,62 @@
 <resources>
     <string name="app_name">Reguerta</string>
+
+    <string name="access_members_roles_title">Members and Roles</string>
+    <string name="access_signed_out_hint">Sign in with a pre-authorized member email to unlock operational modules.</string>
+    <string name="access_card_authentication">Authentication</string>
+    <string name="common_input_email_label">Email</string>
+    <string name="access_input_auth_uid_label">Auth UID</string>
+    <string name="access_action_signing_in">Signing in...</string>
+    <string name="access_action_sign_in">Sign in</string>
+    <string name="access_action_sign_out">Sign out</string>
+    <string name="access_action_dismiss_message">Dismiss message</string>
+
+    <string name="auth_error_member_unauthorized">Unauthorized user</string>
+    <string name="access_signed_in_email_format">Signed in email: %1$s</string>
+    <string name="auth_info_member_restricted_mode">Operational modules remain disabled until an admin pre-authorizes this email.</string>
+    <string name="common_reason_format">Reason: %1$s</string>
+
+    <string name="home_title">Home</string>
+    <string name="home_welcome_format">Welcome %1$s</string>
+    <string name="common_roles_format">Roles: %1$s</string>
+    <string name="common_status_format">Status: %1$s</string>
+    <string name="common_status_active">Active</string>
+    <string name="common_status_inactive">Inactive</string>
+
+    <string name="operational_modules_title">Operational modules</string>
+    <string name="module_my_order">My order</string>
+    <string name="module_catalog">Catalog</string>
+    <string name="module_shifts">Shifts</string>
+
+    <string name="admin_manage_members_title">Admin | Manage members</string>
+    <string name="admin_manage_members_subtitle">Create / edit / deactivate members and roles</string>
+    <string name="admin_create_pre_authorized_member">Create pre-authorized member</string>
+    <string name="admin_input_display_name_label">Display name</string>
+    <string name="role_member">Member</string>
+    <string name="role_producer">Producer</string>
+    <string name="role_admin">Admin</string>
+    <string name="role_active">Active</string>
+    <string name="admin_action_create_member">Create member</string>
+    <string name="member_auth_linked_format">Auth linked: %1$s</string>
+    <string name="common_yes">Yes</string>
+    <string name="common_no">No</string>
+    <string name="admin_action_revoke_admin">Revoke admin</string>
+    <string name="admin_action_grant_admin">Grant admin</string>
+    <string name="admin_action_deactivate">Deactivate</string>
+    <string name="admin_action_activate">Activate</string>
+
+    <string name="feedback_email_uid_required">Email and UID are required</string>
+    <string name="feedback_only_admin_create">Only admins can create members</string>
+    <string name="feedback_display_name_email_required">Display name and email are required</string>
+    <string name="feedback_member_exists">Member already exists</string>
+    <string name="feedback_select_role">Select at least one role</string>
+    <string name="feedback_only_admin_edit_roles">Only admins can edit roles</string>
+    <string name="feedback_only_admin_toggle_active">Only admins can activate or deactivate</string>
+    <string name="feedback_only_admin_manage_members">Only admins can manage members</string>
+    <string name="feedback_cannot_remove_last_admin">Cannot leave the app without active admins</string>
+    <string name="feedback_unable_save_changes">Unable to save changes</string>
+
+    <string name="role_value_member">member</string>
+    <string name="role_value_producer">producer</string>
+    <string name="role_value_admin">admin</string>
 </resources>

--- a/ios/Reguerta/Reguerta.xcodeproj/project.pbxproj
+++ b/ios/Reguerta/Reguerta.xcodeproj/project.pbxproj
@@ -213,10 +213,11 @@
 			buildConfigurationList = E03FA03D2F353C1A0038B8EB /* Build configuration list for PBXProject "Reguerta" */;
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-				Base,
-			);
+				knownRegions = (
+					en,
+					es,
+					Base,
+				);
 			mainGroup = E03FA0392F353C1A0038B8EB;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (

--- a/ios/Reguerta/Reguerta/ContentView.swift
+++ b/ios/Reguerta/Reguerta/ContentView.swift
@@ -7,59 +7,65 @@ struct ContentView: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    Text("Members and Roles")
+                    Text(localizedKey(AccessL10nKey.membersRolesTitle))
                         .font(.title2.bold())
 
                     signInCard
 
                     switch viewModel.mode {
                     case .signedOut:
-                        Text("Sign in with a pre-authorized member email to unlock operational modules.")
+                        Text(localizedKey(AccessL10nKey.signedOutHint))
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
-                    case .unauthorized(let email, let message):
-                        unauthorizedCard(email: email, message: message)
+                    case .unauthorized(let email, let reason):
+                        unauthorizedCard(email: email, reason: reason)
                         operationalModules(enabled: false)
                     case .authorized(let session):
                         authorizedHome(session: session)
                     }
 
-                    if let feedback = viewModel.feedbackMessage {
-                        Text(feedback)
+                    if let feedbackKey = viewModel.feedbackMessageKey {
+                        Text(l10n(feedbackKey))
                             .font(.footnote)
                             .foregroundStyle(.red)
-                        Button("Dismiss message") {
+                        Button {
                             viewModel.clearFeedbackMessage()
+                        } label: {
+                            Text(localizedKey(AccessL10nKey.dismissMessage))
                         }
                     }
                 }
                 .padding()
             }
-            .navigationTitle("Reguerta")
+            .navigationTitle(localizedKey(AccessL10nKey.brandReguerta))
         }
     }
 
     private var signInCard: some View {
         cardContainer {
             VStack(alignment: .leading, spacing: 12) {
-                Text("Authentication")
+                Text(localizedKey(AccessL10nKey.authenticationCardTitle))
                     .font(.headline)
 
-                TextField("Email", text: binding(\.emailInput))
+                TextField(localizedKey(AccessL10nKey.emailLabel), text: binding(\.emailInput))
                     .textInputAutocapitalization(.never)
                     .textFieldStyle(.roundedBorder)
-                TextField("Auth UID", text: binding(\.uidInput))
+                TextField(localizedKey(AccessL10nKey.authUidLabel), text: binding(\.uidInput))
                     .textInputAutocapitalization(.never)
                     .textFieldStyle(.roundedBorder)
 
                 HStack {
-                    Button(viewModel.isAuthenticating ? "Signing in..." : "Sign in") {
+                    Button {
                         viewModel.signIn()
+                    } label: {
+                        Text(localizedKey(viewModel.isAuthenticating ? AccessL10nKey.signingIn : AccessL10nKey.signIn))
                     }
                     .disabled(viewModel.isAuthenticating)
 
-                    Button("Sign out") {
+                    Button {
                         viewModel.signOut()
+                    } label: {
+                        Text(localizedKey(AccessL10nKey.signOut))
                     }
                 }
             }
@@ -67,14 +73,14 @@ struct ContentView: View {
     }
 
     @ViewBuilder
-    private func unauthorizedCard(email: String, message: String) -> some View {
+    private func unauthorizedCard(email: String, reason: UnauthorizedReason) -> some View {
         cardContainer {
             VStack(alignment: .leading, spacing: 8) {
-                Text("Unauthorized user")
+                Text(localizedKey(AccessL10nKey.unauthorized))
                     .font(.headline)
-                Text("Signed in email: \(email)")
-                Text("Operational modules remain disabled until an admin pre-authorizes this email.")
-                Text("Reason: \(message)")
+                Text(l10n(AccessL10nKey.signedInEmail, email))
+                Text(localizedKey(AccessL10nKey.restrictedModeInfo))
+                Text(l10n(AccessL10nKey.reason, localizedUnauthorizedReason(reason)))
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }
@@ -85,11 +91,16 @@ struct ContentView: View {
     private func authorizedHome(session: AuthorizedSession) -> some View {
         cardContainer {
             VStack(alignment: .leading, spacing: 8) {
-                Text("Home")
+                Text(localizedKey(AccessL10nKey.homeTitle))
                     .font(.headline)
-                Text("Welcome \(session.member.displayName)")
-                Text("Roles: \(session.member.roles.prettyList)")
-                Text("Status: \(session.member.isActive ? "Active" : "Inactive")")
+                Text(l10n(AccessL10nKey.homeWelcome, session.member.displayName))
+                Text(l10n(AccessL10nKey.roles, session.member.roles.prettyListLocalized))
+                Text(
+                    l10n(
+                        AccessL10nKey.status,
+                        l10n(session.member.isActive ? AccessL10nKey.statusActive : AccessL10nKey.statusInactive)
+                    )
+                )
             }
         }
 
@@ -104,14 +115,23 @@ struct ContentView: View {
     private func operationalModules(enabled: Bool) -> some View {
         cardContainer {
             VStack(alignment: .leading, spacing: 10) {
-                Text("Operational modules")
+                Text(localizedKey(AccessL10nKey.operationalModulesTitle))
                     .font(.headline)
-                Button("My order") {}
-                    .disabled(!enabled)
-                Button("Catalog") {}
-                    .disabled(!enabled)
-                Button("Shifts") {}
-                    .disabled(!enabled)
+                Button {
+                } label: {
+                    Text(localizedKey(AccessL10nKey.myOrder))
+                }
+                .disabled(!enabled)
+                Button {
+                } label: {
+                    Text(localizedKey(AccessL10nKey.catalog))
+                }
+                .disabled(!enabled)
+                Button {
+                } label: {
+                    Text(localizedKey(AccessL10nKey.shifts))
+                }
+                .disabled(!enabled)
             }
         }
     }
@@ -120,9 +140,9 @@ struct ContentView: View {
     private func adminMembersCard(session: AuthorizedSession) -> some View {
         cardContainer {
             VStack(alignment: .leading, spacing: 12) {
-                Text("Admin | Manage members")
+                Text(localizedKey(AccessL10nKey.adminManageMembersTitle))
                     .font(.headline)
-                Text("Create / edit / deactivate members and roles")
+                Text(localizedKey(AccessL10nKey.adminManageMembersSubtitle))
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
 
@@ -132,21 +152,23 @@ struct ContentView: View {
 
                 Divider()
 
-                Text("Create pre-authorized member")
+                Text(localizedKey(AccessL10nKey.adminCreatePreAuthorizedTitle))
                     .font(.headline)
-                TextField("Display name", text: draftBinding(\.displayName))
+                TextField(localizedKey(AccessL10nKey.displayNameLabel), text: draftBinding(\.displayName))
                     .textFieldStyle(.roundedBorder)
-                TextField("Email", text: draftBinding(\.email))
+                TextField(localizedKey(AccessL10nKey.emailLabel), text: draftBinding(\.email))
                     .textInputAutocapitalization(.never)
                     .textFieldStyle(.roundedBorder)
 
-                Toggle("Member", isOn: draftBinding(\.isMember))
-                Toggle("Producer", isOn: draftBinding(\.isProducer))
-                Toggle("Admin", isOn: draftBinding(\.isAdmin))
-                Toggle("Active", isOn: draftBinding(\.isActive))
+                Toggle(localizedKey(AccessL10nKey.roleMember), isOn: draftBinding(\.isMember))
+                Toggle(localizedKey(AccessL10nKey.roleProducer), isOn: draftBinding(\.isProducer))
+                Toggle(localizedKey(AccessL10nKey.roleAdmin), isOn: draftBinding(\.isAdmin))
+                Toggle(localizedKey(AccessL10nKey.roleActive), isOn: draftBinding(\.isActive))
 
-                Button("Create member") {
+                Button {
                     viewModel.createAuthorizedMember()
+                } label: {
+                    Text(localizedKey(AccessL10nKey.createMember))
                 }
             }
         }
@@ -159,19 +181,28 @@ struct ContentView: View {
                 .font(.subheadline.bold())
             Text(member.normalizedEmail)
                 .font(.subheadline)
-            Text("Roles: \(member.roles.prettyList)")
+            Text(l10n(AccessL10nKey.roles, member.roles.prettyListLocalized))
                 .font(.footnote)
-            Text("Auth linked: \(member.authUid == nil ? "No" : "Yes")")
+            Text(l10n(AccessL10nKey.authLinked, l10n(member.authUid == nil ? AccessL10nKey.no : AccessL10nKey.yes)))
                 .font(.footnote)
-            Text("Status: \(member.isActive ? "Active" : "Inactive")")
-                .font(.footnote)
+            Text(
+                l10n(
+                    AccessL10nKey.status,
+                    l10n(member.isActive ? AccessL10nKey.statusActive : AccessL10nKey.statusInactive)
+                )
+            )
+            .font(.footnote)
 
             HStack {
-                Button(member.isAdmin ? "Revoke admin" : "Grant admin") {
+                Button {
                     viewModel.toggleAdmin(memberId: member.id)
+                } label: {
+                    Text(localizedKey(member.isAdmin ? AccessL10nKey.revokeAdmin : AccessL10nKey.grantAdmin))
                 }
-                Button(member.isActive ? "Deactivate" : "Activate") {
+                Button {
                     viewModel.toggleActive(memberId: member.id)
+                } label: {
+                    Text(localizedKey(member.isActive ? AccessL10nKey.deactivate : AccessL10nKey.activate))
                 }
             }
         }
@@ -222,12 +253,16 @@ struct ContentView: View {
             }
         )
     }
+
+    private func localizedKey(_ key: String) -> LocalizedStringKey {
+        LocalizedStringKey(key)
+    }
 }
 
 private extension Set<MemberRole> {
-    var prettyList: String {
+    var prettyListLocalized: String {
         sorted { lhs, rhs in lhs.rawValue < rhs.rawValue }
-            .map(\.rawValue)
+            .map(localizedRoleValue(_:))
             .joined(separator: ", ")
     }
 }

--- a/ios/Reguerta/Reguerta/Domain/Access/AccessResolutionResult.swift
+++ b/ios/Reguerta/Reguerta/Domain/Access/AccessResolutionResult.swift
@@ -1,6 +1,10 @@
 import Foundation
 
+enum UnauthorizedReason: Equatable, Sendable {
+    case userNotAuthorized
+}
+
 enum AccessResolutionResult: Equatable, Sendable {
     case authorized(Member)
-    case unauthorized(String)
+    case unauthorized(UnauthorizedReason)
 }

--- a/ios/Reguerta/Reguerta/Domain/Access/ResolveAuthorizedSessionUseCase.swift
+++ b/ios/Reguerta/Reguerta/Domain/Access/ResolveAuthorizedSessionUseCase.swift
@@ -11,13 +11,13 @@ struct ResolveAuthorizedSessionUseCase: Sendable {
         let normalizedEmail = normalizeEmail(authPrincipal.email)
 
         guard let member = await repository.findByEmailNormalized(normalizedEmail), member.isActive else {
-            return .unauthorized("Unauthorized user")
+            return .unauthorized(.userNotAuthorized)
         }
 
         let linkedMember: Member?
         if let authUid = member.authUid {
             guard authUid == authPrincipal.uid else {
-                return .unauthorized("Unauthorized user")
+                return .unauthorized(.userNotAuthorized)
             }
             linkedMember = member
         } else {
@@ -25,7 +25,7 @@ struct ResolveAuthorizedSessionUseCase: Sendable {
         }
 
         guard let linkedMember else {
-            return .unauthorized("Unauthorized user")
+            return .unauthorized(.userNotAuthorized)
         }
 
         return .authorized(linkedMember)

--- a/ios/Reguerta/Reguerta/Presentation/Access/AccessLocalization.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/AccessLocalization.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+enum AccessL10nKey {
+    static let brandReguerta = "common.brand.reguerta"
+
+    static let membersRolesTitle = "access.members_roles.title"
+    static let signedOutHint = "access.signed_out.hint"
+    static let authenticationCardTitle = "access.card.authentication"
+    static let emailLabel = "common.input.email.label"
+    static let authUidLabel = "access.input.auth_uid.label"
+    static let signingIn = "access.action.signing_in"
+    static let signIn = "access.action.sign_in"
+    static let signOut = "access.action.sign_out"
+    static let dismissMessage = "access.action.dismiss_message"
+
+    static let unauthorized = "auth_error.member.unauthorized"
+    static let signedInEmail = "access.signed_in_email"
+    static let restrictedModeInfo = "auth_info.member.restricted_mode"
+    static let reason = "common.reason"
+
+    static let homeTitle = "home.title"
+    static let homeWelcome = "home.welcome"
+    static let roles = "common.roles"
+    static let status = "common.status"
+    static let statusActive = "common.status.active"
+    static let statusInactive = "common.status.inactive"
+
+    static let operationalModulesTitle = "operational_modules.title"
+    static let myOrder = "operational_modules.my_order"
+    static let catalog = "operational_modules.catalog"
+    static let shifts = "operational_modules.shifts"
+
+    static let adminManageMembersTitle = "admin.manage_members.title"
+    static let adminManageMembersSubtitle = "admin.manage_members.subtitle"
+    static let adminCreatePreAuthorizedTitle = "admin.create_pre_authorized_member.title"
+    static let displayNameLabel = "admin.input.display_name.label"
+    static let roleMember = "role.member"
+    static let roleProducer = "role.producer"
+    static let roleAdmin = "role.admin"
+    static let roleActive = "role.active"
+    static let createMember = "admin.action.create_member"
+    static let authLinked = "member.auth_linked"
+    static let yes = "common.yes"
+    static let no = "common.no"
+    static let revokeAdmin = "admin.action.revoke_admin"
+    static let grantAdmin = "admin.action.grant_admin"
+    static let deactivate = "admin.action.deactivate"
+    static let activate = "admin.action.activate"
+
+    static let feedbackEmailUidRequired = "feedback.email_uid_required"
+    static let feedbackOnlyAdminCreate = "feedback.only_admin_create"
+    static let feedbackDisplayNameEmailRequired = "feedback.display_name_email_required"
+    static let feedbackMemberExists = "feedback.member_exists"
+    static let feedbackSelectRole = "feedback.select_role"
+    static let feedbackOnlyAdminEditRoles = "feedback.only_admin_edit_roles"
+    static let feedbackOnlyAdminToggleActive = "feedback.only_admin_toggle_active"
+    static let feedbackOnlyAdminManageMembers = "feedback.only_admin_manage_members"
+    static let feedbackCannotRemoveLastAdmin = "feedback.cannot_remove_last_admin"
+    static let feedbackUnableSaveChanges = "feedback.unable_save_changes"
+
+    static let roleValueMember = "role.value.member"
+    static let roleValueProducer = "role.value.producer"
+    static let roleValueAdmin = "role.value.admin"
+}
+
+func l10n(_ key: String) -> String {
+    NSLocalizedString(key, comment: "")
+}
+
+func l10n(_ key: String, _ arguments: CVarArg...) -> String {
+    String(format: NSLocalizedString(key, comment: ""), locale: Locale.current, arguments: arguments)
+}
+
+func localizedUnauthorizedReason(_ reason: UnauthorizedReason) -> String {
+    switch reason {
+    case .userNotAuthorized:
+        return l10n(AccessL10nKey.unauthorized)
+    }
+}
+
+func localizedRoleValue(_ role: MemberRole) -> String {
+    switch role {
+    case .member:
+        return l10n(AccessL10nKey.roleValueMember)
+    case .producer:
+        return l10n(AccessL10nKey.roleValueProducer)
+    case .admin:
+        return l10n(AccessL10nKey.roleValueAdmin)
+    }
+}

--- a/ios/Reguerta/Reguerta/Presentation/Access/SessionViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/SessionViewModel.swift
@@ -18,7 +18,7 @@ struct AuthorizedSession: Equatable, Sendable {
 
 enum SessionMode: Equatable, Sendable {
     case signedOut
-    case unauthorized(email: String, message: String)
+    case unauthorized(email: String, reason: UnauthorizedReason)
     case authorized(AuthorizedSession)
 }
 
@@ -30,7 +30,7 @@ final class SessionViewModel {
     var isAuthenticating = false
     var mode: SessionMode = .signedOut
     var memberDraft = MemberDraft()
-    var feedbackMessage: String?
+    var feedbackMessageKey: String?
 
     private let repository: any MemberRepository
     private let resolveAuthorizedSession: ResolveAuthorizedSessionUseCase
@@ -54,7 +54,7 @@ final class SessionViewModel {
         let email = emailInput.trimmingCharacters(in: .whitespacesAndNewlines)
         let uid = uidInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !email.isEmpty, !uid.isEmpty else {
-            feedbackMessage = "Email and UID are required"
+            feedbackMessageKey = AccessL10nKey.feedbackEmailUidRequired
             return
         }
 
@@ -74,8 +74,8 @@ final class SessionViewModel {
                         members: members
                     )
                 )
-            case .unauthorized(let message):
-                mode = .unauthorized(email: email, message: message)
+            case .unauthorized(let reason):
+                mode = .unauthorized(email: email, reason: reason)
             }
 
             isAuthenticating = false
@@ -93,25 +93,25 @@ final class SessionViewModel {
             return
         }
         guard session.member.isAdmin else {
-            feedbackMessage = "Only admins can create members"
+            feedbackMessageKey = AccessL10nKey.feedbackOnlyAdminCreate
             return
         }
 
         let normalizedEmail = normalizeEmail(memberDraft.email)
         guard !memberDraft.displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               !normalizedEmail.isEmpty else {
-            feedbackMessage = "Display name and email are required"
+            feedbackMessageKey = AccessL10nKey.feedbackDisplayNameEmailRequired
             return
         }
 
         let roles = buildRoles(from: memberDraft)
         guard !roles.isEmpty else {
-            feedbackMessage = "Select at least one role"
+            feedbackMessageKey = AccessL10nKey.feedbackSelectRole
             return
         }
 
         if session.members.contains(where: { $0.normalizedEmail == normalizedEmail }) {
-            feedbackMessage = "Member already exists"
+            feedbackMessageKey = AccessL10nKey.feedbackMemberExists
             return
         }
 
@@ -136,7 +136,7 @@ final class SessionViewModel {
             return
         }
         guard session.member.isAdmin else {
-            feedbackMessage = "Only admins can edit roles"
+            feedbackMessageKey = AccessL10nKey.feedbackOnlyAdminEditRoles
             return
         }
         guard let target = session.members.first(where: { $0.id == memberId }) else {
@@ -173,7 +173,7 @@ final class SessionViewModel {
             return
         }
         guard session.member.isAdmin else {
-            feedbackMessage = "Only admins can activate or deactivate"
+            feedbackMessageKey = AccessL10nKey.feedbackOnlyAdminToggleActive
             return
         }
         guard let target = session.members.first(where: { $0.id == memberId }) else {
@@ -196,7 +196,7 @@ final class SessionViewModel {
     }
 
     func clearFeedbackMessage() {
-        feedbackMessage = nil
+        feedbackMessageKey = nil
     }
 
     private func persistMember(target: Member, session: AuthorizedSession) async {
@@ -215,11 +215,11 @@ final class SessionViewModel {
                 )
             )
         } catch MemberManagementError.accessDenied {
-            feedbackMessage = "Only admins can manage members"
+            feedbackMessageKey = AccessL10nKey.feedbackOnlyAdminManageMembers
         } catch MemberManagementError.lastAdminRemoval {
-            feedbackMessage = "Cannot leave the app without active admins"
+            feedbackMessageKey = AccessL10nKey.feedbackCannotRemoveLastAdmin
         } catch {
-            feedbackMessage = "Unable to save changes"
+            feedbackMessageKey = AccessL10nKey.feedbackUnableSaveChanges
         }
     }
 

--- a/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
+++ b/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
@@ -1,0 +1,854 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "access.action.dismiss_message" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dismiss message"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar mensaje"
+          }
+        }
+      }
+    },
+    "access.action.sign_in" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar sesion"
+          }
+        }
+      }
+    },
+    "access.action.sign_out" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign out"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cerrar sesion"
+          }
+        }
+      }
+    },
+    "access.action.signing_in" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signing in..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciando sesion..."
+          }
+        }
+      }
+    },
+    "access.card.authentication" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autenticacion"
+          }
+        }
+      }
+    },
+    "access.input.auth_uid.label" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auth UID"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auth UID"
+          }
+        }
+      }
+    },
+    "access.members_roles.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Members and Roles"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Miembros y roles"
+          }
+        }
+      }
+    },
+    "access.signed_in_email" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signed in email: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Email de sesion: %@"
+          }
+        }
+      }
+    },
+    "access.signed_out.hint" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in with a pre-authorized member email to unlock operational modules."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inicia sesion con un email de miembro preautorizado para desbloquear los modulos operativos."
+          }
+        }
+      }
+    },
+    "admin.action.activate" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activate"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar"
+          }
+        }
+      }
+    },
+    "admin.action.create_member" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create member"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crear miembro"
+          }
+        }
+      }
+    },
+    "admin.action.deactivate" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deactivate"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desactivar"
+          }
+        }
+      }
+    },
+    "admin.action.grant_admin" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grant admin"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dar admin"
+          }
+        }
+      }
+    },
+    "admin.action.revoke_admin" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revoke admin"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quitar admin"
+          }
+        }
+      }
+    },
+    "admin.create_pre_authorized_member.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create pre-authorized member"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crear miembro preautorizado"
+          }
+        }
+      }
+    },
+    "admin.input.display_name.label" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Display name"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre visible"
+          }
+        }
+      }
+    },
+    "admin.manage_members.subtitle" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create / edit / deactivate members and roles"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crear / editar / desactivar miembros y roles"
+          }
+        }
+      }
+    },
+    "admin.manage_members.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Admin | Manage members"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Admin | Gestion de miembros"
+          }
+        }
+      }
+    },
+    "auth_error.member.unauthorized" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unauthorized user"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuario no autorizado"
+          }
+        }
+      }
+    },
+    "auth_info.member.restricted_mode" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Operational modules remain disabled until an admin pre-authorizes this email."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Los modulos operativos seguiran desactivados hasta que un admin preautorice este email."
+          }
+        }
+      }
+    },
+    "common.brand.reguerta" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reguerta"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reguerta"
+          }
+        }
+      }
+    },
+    "common.input.email.label" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Email"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Email"
+          }
+        }
+      }
+    },
+    "common.no" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No"
+          }
+        }
+      }
+    },
+    "common.reason" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reason: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Motivo: %@"
+          }
+        }
+      }
+    },
+    "common.roles" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roles: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roles: %@"
+          }
+        }
+      }
+    },
+    "common.status" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado: %@"
+          }
+        }
+      }
+    },
+    "common.status.active" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activo"
+          }
+        }
+      }
+    },
+    "common.status.inactive" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inactive"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inactivo"
+          }
+        }
+      }
+    },
+    "common.yes" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yes"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Si"
+          }
+        }
+      }
+    },
+    "feedback.cannot_remove_last_admin" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cannot leave the app without active admins"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede dejar la app sin admins activos"
+          }
+        }
+      }
+    },
+    "feedback.display_name_email_required" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Display name and email are required"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nombre visible y email son obligatorios"
+          }
+        }
+      }
+    },
+    "feedback.email_uid_required" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Email and UID are required"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Email y UID son obligatorios"
+          }
+        }
+      }
+    },
+    "feedback.member_exists" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Member already exists"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El miembro ya existe"
+          }
+        }
+      }
+    },
+    "feedback.only_admin_create" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only admins can create members"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo los admins pueden crear miembros"
+          }
+        }
+      }
+    },
+    "feedback.only_admin_edit_roles" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only admins can edit roles"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo los admins pueden editar roles"
+          }
+        }
+      }
+    },
+    "feedback.only_admin_manage_members" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only admins can manage members"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo los admins pueden gestionar miembros"
+          }
+        }
+      }
+    },
+    "feedback.only_admin_toggle_active" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only admins can activate or deactivate"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solo los admins pueden activar o desactivar"
+          }
+        }
+      }
+    },
+    "feedback.select_role" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select at least one role"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecciona al menos un rol"
+          }
+        }
+      }
+    },
+    "feedback.unable_save_changes" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to save changes"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron guardar los cambios"
+          }
+        }
+      }
+    },
+    "home.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inicio"
+          }
+        }
+      }
+    },
+    "home.welcome" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Welcome %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bienvenido %@"
+          }
+        }
+      }
+    },
+    "member.auth_linked" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auth linked: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auth vinculada: %@"
+          }
+        }
+      }
+    },
+    "operational_modules.catalog" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catalog"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Catalogo"
+          }
+        }
+      }
+    },
+    "operational_modules.my_order" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "My order"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mi pedido"
+          }
+        }
+      }
+    },
+    "operational_modules.shifts" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shifts"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Turnos"
+          }
+        }
+      }
+    },
+    "operational_modules.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Operational modules"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modulos operativos"
+          }
+        }
+      }
+    },
+    "role.active" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activo"
+          }
+        }
+      }
+    },
+    "role.admin" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Admin"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Admin"
+          }
+        }
+      }
+    },
+    "role.member" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Member"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Miembro"
+          }
+        }
+      }
+    },
+    "role.producer" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Producer"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Productor"
+          }
+        }
+      }
+    },
+    "role.value.admin" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "admin"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "admin"
+          }
+        }
+      }
+    },
+    "role.value.member" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "member"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "miembro"
+          }
+        }
+      }
+    },
+    "role.value.producer" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "producer"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "productor"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/ios/Reguerta/ReguertaTests/ReguertaTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaTests.swift
@@ -13,7 +13,7 @@ struct ReguertaTests {
             authPrincipal: AuthPrincipal(uid: "uid_unknown", email: "unknown@reguerta.app")
         )
 
-        #expect(result == .unauthorized("Unauthorized user"))
+        #expect(result == .unauthorized(.userNotAuthorized))
     }
 
     @Test

--- a/ios/Reguerta/ReguertaUITests/ReguertaUITests.swift
+++ b/ios/Reguerta/ReguertaUITests/ReguertaUITests.swift
@@ -24,7 +24,7 @@ final class ReguertaUITests: XCTestCase {
 
     @MainActor
     func testUnauthorizedUserShowsRestrictedMode() throws {
-        let app = XCUIApplication()
+        let app = configuredApp()
         app.launch()
 
         let emailField = app.textFields["Email"]
@@ -46,7 +46,7 @@ final class ReguertaUITests: XCTestCase {
 
     @MainActor
     func testPreAuthorizedAdminEntersHomeWithModulesEnabled() throws {
-        let app = XCUIApplication()
+        let app = configuredApp()
         app.launch()
 
         let emailField = app.textFields["Email"]
@@ -82,7 +82,13 @@ final class ReguertaUITests: XCTestCase {
     func testLaunchPerformance() throws {
         // This measures how long it takes to launch your application.
         measure(metrics: [XCTApplicationLaunchMetric()]) {
-            XCUIApplication().launch()
+            configuredApp().launch()
         }
+    }
+
+    private func configuredApp() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+        return app
     }
 }


### PR DESCRIPTION
## Summary
- add Android localization resources with EN fallback (`values/strings.xml`) and ES translations (`values-es/strings.xml`)
- replace auth/access hardcoded UI copy on Android with `R.string` usage
- add iOS `Localizable.xcstrings` with EN/ES and a shared localization key helper
- replace auth/access hardcoded UI copy on iOS with localized keys and formatted localization helpers
- remove domain-level literal unauthorized text by introducing typed unauthorized reason on Android and iOS
- make iOS UI tests locale-deterministic (`en_US`) so assertions remain stable

## Validation
- `cd android/Reguerta && ./gradlew app:testDebugUnitTest app:lintDebug`
- `cd android/Reguerta && ./gradlew app:connectedDebugAndroidTest`
- `cd ios/Reguerta && xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' test`

## Notes
- attempted iOS run first with `iPhone 16` as per baseline command, but that destination was unavailable locally; reran on `iPhone 17`.

Closes #34
