### PR TITLE
[HU-036] Core components v1 for auth/onboarding

### DIFF
--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRoot.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRoot.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,7 +20,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -57,6 +55,12 @@ import com.reguerta.user.domain.access.MemberRole
 import com.reguerta.user.domain.access.ResolveAuthorizedSessionUseCase
 import com.reguerta.user.domain.access.UnauthorizedReason
 import com.reguerta.user.domain.access.UpsertMemberByAdminUseCase
+import com.reguerta.user.ui.components.auth.ReguertaButton
+import com.reguerta.user.ui.components.auth.ReguertaButtonVariant
+import com.reguerta.user.ui.components.auth.ReguertaCard
+import com.reguerta.user.ui.components.auth.ReguertaFeedbackKind
+import com.reguerta.user.ui.components.auth.ReguertaInlineFeedback
+import com.reguerta.user.ui.components.auth.ReguertaInputField
 import com.reguerta.user.ui.theme.ReguertaThemeTokens
 
 private const val SplashAnimationDurationMillis = 1_500
@@ -211,7 +215,6 @@ private fun SplashRoute(
     onAnimationFinished: () -> Unit,
 ) {
     val spacing = ReguertaThemeTokens.spacing
-    val radius = ReguertaThemeTokens.radius
     val progress = remember { Animatable(0f) }
     var completed by remember { mutableStateOf(false) }
     val latestOnAnimationFinished by rememberUpdatedState(onAnimationFinished)
@@ -236,10 +239,7 @@ private fun SplashRoute(
     val rotation = lerp(-6f, 8f, fraction)
     val alpha = lerp(0.94f, 0f, fraction)
 
-    Card(
-        shape = RoundedCornerShape(radius.md),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-    ) {
+    ReguertaCard {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -281,11 +281,7 @@ private fun WelcomeRoute(
     onContinue: () -> Unit,
 ) {
     val spacing = ReguertaThemeTokens.spacing
-    val radius = ReguertaThemeTokens.radius
-    Card(
-        shape = RoundedCornerShape(radius.md),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-    ) {
+    ReguertaCard {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -305,12 +301,10 @@ private fun WelcomeRoute(
                 text = stringResource(R.string.welcome_subtitle),
                 style = MaterialTheme.typography.bodyMedium,
             )
-            Button(
+            ReguertaButton(
+                label = stringResource(R.string.welcome_cta_enter),
                 onClick = onContinue,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(stringResource(R.string.welcome_cta_enter))
-            }
+            )
         }
     }
 }
@@ -325,11 +319,7 @@ private fun LoginRoute(
     onUidChanged: (String) -> Unit,
 ) {
     val spacing = ReguertaThemeTokens.spacing
-    val radius = ReguertaThemeTokens.radius
-    Card(
-        shape = RoundedCornerShape(radius.md),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-    ) {
+    ReguertaCard {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -341,9 +331,9 @@ private fun LoginRoute(
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
             )
-            Text(
-                text = stringResource(R.string.access_signed_out_hint),
-                style = MaterialTheme.typography.bodySmall,
+            ReguertaInlineFeedback(
+                message = stringResource(R.string.access_signed_out_hint),
+                kind = ReguertaFeedbackKind.INFO,
             )
         }
     }
@@ -356,12 +346,18 @@ private fun LoginRoute(
     )
 
     Row(horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
-        TextButton(onClick = onOpenRegister) {
-            Text(stringResource(R.string.login_link_register))
-        }
-        TextButton(onClick = onOpenRecover) {
-            Text(stringResource(R.string.login_link_forgot_password))
-        }
+        ReguertaButton(
+            label = stringResource(R.string.login_link_register),
+            onClick = onOpenRegister,
+            variant = ReguertaButtonVariant.TEXT,
+            fullWidth = false,
+        )
+        ReguertaButton(
+            label = stringResource(R.string.login_link_forgot_password),
+            onClick = onOpenRecover,
+            variant = ReguertaButtonVariant.TEXT,
+            fullWidth = false,
+        )
     }
 }
 
@@ -373,11 +369,7 @@ private fun PlaceholderAuthRoute(
     onAction: () -> Unit,
 ) {
     val spacing = ReguertaThemeTokens.spacing
-    val radius = ReguertaThemeTokens.radius
-    Card(
-        shape = RoundedCornerShape(radius.md),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-    ) {
+    ReguertaCard {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -393,12 +385,10 @@ private fun PlaceholderAuthRoute(
                 text = stringResource(subtitleRes),
                 style = MaterialTheme.typography.bodyMedium,
             )
-            Button(
+            ReguertaButton(
+                label = stringResource(actionLabelRes),
                 onClick = onAction,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(stringResource(actionLabelRes))
-            }
+            )
         }
     }
 }
@@ -463,11 +453,10 @@ private fun SignInCard(
     onUidChanged: (String) -> Unit,
 ) {
     val spacing = ReguertaThemeTokens.spacing
-    val radius = ReguertaThemeTokens.radius
-    Card(
-        shape = RoundedCornerShape(radius.md),
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-    ) {
+    var submitAttempted by remember { mutableStateOf(false) }
+    val missingCredentials = submitAttempted && (state.emailInput.isBlank() || state.uidInput.isBlank())
+
+    ReguertaCard {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -475,34 +464,45 @@ private fun SignInCard(
             verticalArrangement = Arrangement.spacedBy(spacing.md),
         ) {
             Text(stringResource(R.string.access_card_authentication))
-            OutlinedTextField(
+            ReguertaInputField(
+                label = stringResource(R.string.common_input_email_label),
                 value = state.emailInput,
-                onValueChange = onEmailChanged,
-                modifier = Modifier.fillMaxWidth(),
-                label = { Text(stringResource(R.string.common_input_email_label)) },
-                singleLine = true,
+                onValueChange = {
+                    onEmailChanged(it)
+                    if (submitAttempted) submitAttempted = false
+                },
+                helperMessage = stringResource(R.string.access_signed_out_hint),
+                keyboardType = androidx.compose.ui.text.input.KeyboardType.Email,
+                errorMessage = if (missingCredentials) {
+                    stringResource(R.string.feedback_email_uid_required)
+                } else {
+                    null
+                },
             )
-            OutlinedTextField(
+            ReguertaInputField(
+                label = stringResource(R.string.access_input_auth_uid_label),
                 value = state.uidInput,
-                onValueChange = onUidChanged,
-                modifier = Modifier.fillMaxWidth(),
-                label = { Text(stringResource(R.string.access_input_auth_uid_label)) },
-                singleLine = true,
+                onValueChange = {
+                    onUidChanged(it)
+                    if (submitAttempted) submitAttempted = false
+                },
+                keyboardType = androidx.compose.ui.text.input.KeyboardType.Ascii,
             )
-            Button(
-                onClick = onSignIn,
+            ReguertaButton(
+                label = stringResource(
+                    if (state.isAuthenticating) {
+                        R.string.access_action_signing_in
+                    } else {
+                        R.string.access_action_sign_in
+                    },
+                ),
+                onClick = {
+                    submitAttempted = true
+                    onSignIn()
+                },
                 enabled = !state.isAuthenticating,
-            ) {
-                Text(
-                    stringResource(
-                        if (state.isAuthenticating) {
-                            R.string.access_action_signing_in
-                        } else {
-                            R.string.access_action_sign_in
-                        },
-                    ),
-                )
-            }
+                loading = state.isAuthenticating,
+            )
         }
     }
 }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaButton.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaButton.kt
@@ -1,0 +1,78 @@
+package com.reguerta.user.ui.components.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.reguerta.user.ui.theme.ReguertaThemeTokens
+
+enum class ReguertaButtonVariant {
+    PRIMARY,
+    SECONDARY,
+    TEXT,
+}
+
+@Composable
+fun ReguertaButton(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    variant: ReguertaButtonVariant = ReguertaButtonVariant.PRIMARY,
+    enabled: Boolean = true,
+    fullWidth: Boolean = true,
+    loading: Boolean = false,
+) {
+    val buttonModifier = if (fullWidth) modifier.fillMaxWidth() else modifier
+    val isEnabled = enabled && !loading
+    val spacing = ReguertaThemeTokens.spacing
+
+    val content: @Composable RowScope.() -> Unit = {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        ) {
+            if (loading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                )
+            }
+            Text(label)
+        }
+    }
+
+    when (variant) {
+        ReguertaButtonVariant.PRIMARY -> Button(
+            onClick = onClick,
+            modifier = buttonModifier,
+            enabled = isEnabled,
+            content = content,
+        )
+
+        ReguertaButtonVariant.SECONDARY -> OutlinedButton(
+            onClick = onClick,
+            modifier = buttonModifier,
+            enabled = isEnabled,
+            content = content,
+        )
+
+        ReguertaButtonVariant.TEXT -> TextButton(
+            onClick = onClick,
+            modifier = buttonModifier,
+            enabled = isEnabled,
+            content = content,
+        )
+    }
+}

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaCard.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaCard.kt
@@ -1,0 +1,37 @@
+package com.reguerta.user.ui.components.auth
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.shape.RoundedCornerShape
+import com.reguerta.user.ui.theme.ReguertaThemeTokens
+
+@Composable
+fun ReguertaCard(
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    val spacing = ReguertaThemeTokens.spacing
+    val radius = ReguertaThemeTokens.radius
+    val elevation = ReguertaThemeTokens.elevation
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(radius.md),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = elevation.level1),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(spacing.lg),
+            content = content,
+        )
+    }
+}

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaInlineFeedback.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaInlineFeedback.kt
@@ -1,0 +1,49 @@
+package com.reguerta.user.ui.components.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import com.reguerta.user.ui.theme.ReguertaThemeTokens
+
+enum class ReguertaFeedbackKind {
+    INFO,
+    WARNING,
+    ERROR,
+}
+
+@Composable
+fun ReguertaInlineFeedback(
+    message: String,
+    modifier: Modifier = Modifier,
+    kind: ReguertaFeedbackKind = ReguertaFeedbackKind.ERROR,
+) {
+    val spacing = ReguertaThemeTokens.spacing
+    val color = when (kind) {
+        ReguertaFeedbackKind.INFO -> MaterialTheme.colorScheme.onSurface
+        ReguertaFeedbackKind.WARNING -> MaterialTheme.colorScheme.tertiary
+        ReguertaFeedbackKind.ERROR -> MaterialTheme.colorScheme.error
+    }
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "•",
+            color = color,
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = message,
+            color = color,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaInputField.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaInputField.kt
@@ -1,0 +1,107 @@
+package com.reguerta.user.ui.components.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.text.input.KeyboardType
+import com.reguerta.user.ui.theme.ReguertaThemeTokens
+
+enum class ReguertaInputState {
+    DEFAULT,
+    FOCUSED,
+    ERROR,
+    DISABLED,
+}
+
+@Composable
+fun ReguertaInputField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String? = null,
+    helperMessage: String? = null,
+    enabled: Boolean = true,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    errorMessage: String? = null,
+    trailing: (@Composable () -> Unit)? = null,
+) {
+    var focused by remember { mutableStateOf(false) }
+    val spacing = ReguertaThemeTokens.spacing
+    val hasError = !errorMessage.isNullOrBlank()
+    val state = when {
+        !enabled -> ReguertaInputState.DISABLED
+        hasError -> ReguertaInputState.ERROR
+        focused -> ReguertaInputState.FOCUSED
+        else -> ReguertaInputState.DEFAULT
+    }
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(spacing.xs),
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            enabled = enabled,
+            modifier = Modifier
+                .fillMaxWidth()
+                .onFocusChanged { focused = it.isFocused },
+            label = { Text(label) },
+            placeholder = placeholder?.let { text ->
+                { Text(text) }
+            },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+            trailingIcon = trailing,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = stateBorderColor(ReguertaInputState.FOCUSED),
+                unfocusedBorderColor = stateBorderColor(ReguertaInputState.DEFAULT),
+                errorBorderColor = stateBorderColor(ReguertaInputState.ERROR),
+                disabledBorderColor = stateBorderColor(ReguertaInputState.DISABLED),
+                focusedLabelColor = stateBorderColor(state),
+                errorLabelColor = stateBorderColor(ReguertaInputState.ERROR),
+                disabledLabelColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
+            ),
+            isError = hasError,
+        )
+
+        if (hasError) {
+            Text(
+                text = errorMessage.orEmpty(),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(horizontal = spacing.xs),
+            )
+        } else if (!helperMessage.isNullOrBlank()) {
+            Text(
+                text = helperMessage,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = spacing.xs),
+            )
+        }
+    }
+}
+
+@Composable
+private fun stateBorderColor(state: ReguertaInputState) =
+    when (state) {
+        ReguertaInputState.DEFAULT -> MaterialTheme.colorScheme.outline
+        ReguertaInputState.FOCUSED -> MaterialTheme.colorScheme.primary
+        ReguertaInputState.ERROR -> MaterialTheme.colorScheme.error
+        ReguertaInputState.DISABLED -> MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+    }

--- a/docs-es/design-system/components.md
+++ b/docs-es/design-system/components.md
@@ -1,38 +1,45 @@
 # Components
 
-Este catalogo define intencion compartida y estado de paridad.
+Este catálogo define el contrato actual de componentes y su estado de paridad para auth/onboarding.
 
 ## 1. Leyenda de estado
 
-- `stable`: listo como default para features nuevas.
-- `candidate`: casi alineado, pendiente de normalizacion.
-- `experimental`: util, pero API/naming puede cambiar.
-- `deprecated`: no usar en codigo nuevo.
+- `stable`: listo como valor por defecto para nuevas features.
+- `candidate`: casi alineado, pendiente de pulir API.
+- `experimental`: útil, pero el naming/API puede cambiar.
+- `deprecated`: no usar en código nuevo.
 
-## 2. Matriz cross-platform
+## 2. Core Components V1 (HU-036)
 
-| Componente | Android | iOS | Intencion compartida | Estado | Notas |
+| Componente | Android | iOS | Intención compartida | Estado | Notas |
 |---|---|---|---|---|---|
-| Theme wrapper | `ReguertaTheme` | estilos/tokens globales app | Baseline visual global | candidate | Falta alinear naming |
-| Screen scaffold | `Screen` + `ReguertaScaffold` | wrappers de vista | Estructura base de pantalla | candidate | Equivalente iOS menos explicito |
-| Top bar | `ReguertaTopBar` | `HeaderView` | Titulo + back/acciones | candidate | Normalizar API |
-| Buttons | familia `ReguertaButton` | `FullStyle`, `FlatStyle`, `MainStyle` | Acciones primaria/secundaria/destructiva | candidate | Mantener variantes semanticas |
-| Inputs | `ReguertaEmailInput`, `ReguertaPasswordInput`, `TextReguertaInput` | `InputView`, `CustomTextField` | Formulario con validacion | candidate | Normalizar modelo de estado |
-| Dialogs | `ReguertaAlertDialog` | `GenericDialogView` | Confirmacion/feedback con variantes | candidate | Alinear modelo de botones |
-| Card | `ReguertaCard` | estilos wrapper de celdas/vistas | Agrupar contenido relacionado | candidate | Normalizar niveles/tipos |
-| Checkbox | `ReguertaCheckBox` | `CheckBoxView` | Seleccion booleana | stable | Baja variacion |
-| Counter | `ReguertaCounter` | controles de cantidad | Patron incremento/decremento | candidate | Consolidar reglas disabled |
-| Dropdown/select | `DropdownSelectable` | patrones picker custom | Selector de opcion unica | experimental | Definir API compartida |
-| Remote image | `ImageUrl`, `ProductImage` | patron `URLImage` | Carga async + fallback | candidate | Estandarizar contrato fallback |
-| Loading animation | `LoadingAnimation` | estilos de progreso | Feedback de carga | experimental | Decidir regla lottie vs nativo |
+| Card/contenedor | `ui/components/auth/ReguertaCard.kt` | `DesignSystem/Components/ReguertaCard.swift` | Agrupar contenido con surface + borde/radio semánticos | stable | Shell principal de splash/welcome/login/register/recover |
+| Button | `ReguertaButton` + `ReguertaButtonVariant` | `ReguertaButton` + `ReguertaButtonVariant` | Modelo unificado primaria/secundaria/texto con loading y disabled | stable | Variantes: `primary`, `secondary`, `text` |
+| Input/Auth field | `ReguertaInputField` | `ReguertaInputField` | Label, placeholder, helper/error text, trailing action, estados focus/disabled/error | stable | `keyboardType` expuesto en ambas plataformas |
+| Feedback inline | `ReguertaInlineFeedback` + `ReguertaFeedbackKind` | `ReguertaInlineFeedback` + `ReguertaFeedbackKind` | Mensajes reutilizables de info/warning/error | stable | Uso en auth shell y zonas de feedback |
 
-## 3. Reglas de contrato
+## 3. Referencia de uso en Auth
 
-- Definir APIs por comportamiento y estados, no por contexto de pantalla.
-- Mantener `enabled`, `disabled`, `loading`, `error`, `focus` explicitos en contratos.
-- Preferir wrappers composables/swiftui frente a duplicar logica visual por feature.
+Flujo de referencia implementado de extremo a extremo con los componentes V1:
 
-## 4. Exclusiones legacy explicitas
+- Android: `presentation/access/ReguertaRoot.kt`
+  - Splash usa `ReguertaCard`.
+  - Welcome usa `ReguertaCard` + `ReguertaButton`.
+  - Login usa `ReguertaCard`, `ReguertaInputField`, `ReguertaInlineFeedback`, `ReguertaButton`.
+  - Placeholders de registro/recuperar usan `ReguertaCard` + `ReguertaButton`.
+- iOS: `ContentView.swift`
+  - Splash usa `ReguertaCard`.
+  - Welcome usa `ReguertaCard` + `ReguertaButton`.
+  - Login usa `ReguertaCard`, `ReguertaInputField`, `ReguertaInlineFeedback`, `ReguertaButton`.
+  - Placeholders de registro/recuperar usan `ReguertaCard` + `ReguertaButton`.
+
+## 4. Reglas de contrato
+
+- Definir APIs por comportamiento y estados explícitos, no por contexto de una pantalla concreta.
+- Mantener `enabled`, `disabled`, `loading`, `focus` y `error` visibles en el contrato del componente.
+- Consumir solo theme/tokens semánticos. Evitar colores y medidas hardcodeadas en vistas de feature.
+
+## 5. Exclusiones legacy explícitas
 
 - Android `NavigationDrawerInfo` (deprecated).
 - Android params legacy en `InverseReguertaButton` (`borderSize`, `cornerSize`).

--- a/docs-es/design-system/migration-backlog.md
+++ b/docs-es/design-system/migration-backlog.md
@@ -10,14 +10,14 @@ Trabajo priorizado para pasar del estado actual a un design-system cross-platfor
 
 ## P1 (Siguiente)
 
-- Normalizar variantes y naming de botones entre Android/iOS.
-- Normalizar modelo de estado de inputs (`touched`, `error`, `focus`, `disabled`).
+- [x] Normalizar variantes y naming de botones entre Android/iOS.
+- [x] Normalizar modelo de estado de inputs (`error`, `focus`, `disabled`, helper text).
 - Normalizar API de dialogs y modelo de acciones.
 - Retirar o aislar elementos explicitamente deprecated/sin uso.
 
 ## P2 (Cuando entre Auth/Onboarding UI)
 
-- Construir splash/welcome/auth solo con primitivas stable/candidate del design-system.
+- [x] Construir splash/welcome/auth solo con primitivas stable/candidate del design-system.
 - Validar responsive en dispositivos compactos y grandes.
 - Anadir pantalla catalogo/sandbox para regresion visual.
 

--- a/docs/design-system/components.md
+++ b/docs/design-system/components.md
@@ -1,38 +1,45 @@
 # Components
 
-This catalog defines shared component intent and parity status.
+This catalog defines the current component contract and parity status for auth/onboarding.
 
 ## 1. Status Legend
 
 - `stable`: ready for default use in new features.
-- `candidate`: mostly aligned, pending normalization.
-- `experimental`: useful but API/name can change.
+- `candidate`: mostly aligned, pending minor API polish.
+- `experimental`: useful but API/name can still change.
 - `deprecated`: do not use in new code.
 
-## 2. Cross-Platform Matrix
+## 2. Core Components V1 (HU-036)
 
 | Component | Android | iOS | Shared intent | Status | Notes |
 |---|---|---|---|---|---|
-| Theme wrapper | `ReguertaTheme` | app-level SwiftUI style/tokens | Provide global visual baseline | candidate | Align token naming |
-| Screen scaffold | `Screen` + `ReguertaScaffold` | view wrappers | Shared screen structure | candidate | iOS equivalent less explicit |
-| Top bar | `ReguertaTopBar` | `HeaderView` | Title + back/navigation actions | candidate | API normalization pending |
-| Buttons | `ReguertaButton` family | `FullStyle`, `FlatStyle`, `MainStyle` | Primary/secondary/destructive actions | candidate | Keep semantic variants |
-| Inputs | `ReguertaEmailInput`, `ReguertaPasswordInput`, `TextReguertaInput` | `InputView`, `CustomTextField` | Form input with validation states | candidate | Normalize state model |
-| Dialogs | `ReguertaAlertDialog` | `GenericDialogView` | Confirmation/feedback with intent variants | candidate | Align button model |
-| Card | `ReguertaCard` | cell/view style wrappers | Group related content | candidate | Normalize levels/kinds |
-| Checkbox | `ReguertaCheckBox` | `CheckBoxView` | Boolean selection | stable | Low variance |
-| Counter | `ReguertaCounter` | quantity controls | Increment/decrement pattern | candidate | Consolidate disabled rules |
-| Dropdown/select | `DropdownSelectable` | custom picker patterns | Single-choice selector | experimental | Define shared API |
-| Remote image | `ImageUrl`, `ProductImage` | `URLImage` pattern | Async image + fallback | candidate | Standardize fallback contract |
-| Loading animation | `LoadingAnimation` | progress styles | Loading feedback | experimental | Decide lottie vs native rule |
+| Card/container shell | `ui/components/auth/ReguertaCard.kt` | `DesignSystem/Components/ReguertaCard.swift` | Group related content using semantic surface + border/radius tokens | stable | Main shell for splash/welcome/login/register/recover |
+| Button | `ReguertaButton` + `ReguertaButtonVariant` | `ReguertaButton` + `ReguertaButtonVariant` | Unified primary/secondary/text action model with loading and disabled support | stable | Variants: `primary`, `secondary`, `text` |
+| Input/Auth field | `ReguertaInputField` | `ReguertaInputField` | Label, placeholder, helper/error text, trailing action, focus/disabled/error states | stable | Keyboard type exposed in both platforms |
+| Inline feedback | `ReguertaInlineFeedback` + `ReguertaFeedbackKind` | `ReguertaInlineFeedback` + `ReguertaFeedbackKind` | Reusable inline info/warning/error messages | stable | Used in auth shell and generic feedback areas |
 
-## 3. Contract Rules
+## 3. Auth Flow Reference Wiring
 
-- Define component APIs by behavior and states, not by screen-specific context.
-- Keep `enabled`, `disabled`, `loading`, `error`, `focus` explicit in contracts.
-- Prefer composable/swiftui wrappers over duplicating style logic per feature.
+Implemented reference flow (end-to-end) using the V1 components:
 
-## 4. Explicit Legacy Exclusions
+- Android: `presentation/access/ReguertaRoot.kt`
+  - Splash route uses `ReguertaCard`.
+  - Welcome route uses `ReguertaCard` + `ReguertaButton`.
+  - Login route uses `ReguertaCard`, `ReguertaInputField`, `ReguertaInlineFeedback`, `ReguertaButton`.
+  - Register/recover placeholders use `ReguertaCard` + `ReguertaButton`.
+- iOS: `ContentView.swift`
+  - Splash route uses `ReguertaCard`.
+  - Welcome route uses `ReguertaCard` + `ReguertaButton`.
+  - Login route uses `ReguertaCard`, `ReguertaInputField`, `ReguertaInlineFeedback`, `ReguertaButton`.
+  - Register/recover placeholders use `ReguertaCard` + `ReguertaButton`.
+
+## 4. Contract Rules
+
+- Define component APIs by behavior and explicit state, not by a single screen context.
+- Keep `enabled`, `disabled`, `loading`, `focus`, and `error` visible in the component contract.
+- Consume semantic theme/tokens only. Avoid raw colors and ad-hoc dimensions in feature views.
+
+## 5. Explicit Legacy Exclusions
 
 - Android `NavigationDrawerInfo` (deprecated).
 - Android legacy params in `InverseReguertaButton` (`borderSize`, `cornerSize`).

--- a/docs/design-system/migration-backlog.md
+++ b/docs/design-system/migration-backlog.md
@@ -10,14 +10,14 @@ Prioritized tasks to move from current state to a cleaner cross-platform design-
 
 ## P1 (Next)
 
-- Normalize button variants and naming across Android/iOS.
-- Normalize input state model (`touched`, `error`, `focus`, `disabled`).
+- [x] Normalize button variants and naming across Android/iOS.
+- [x] Normalize input state model (`error`, `focus`, `disabled`, helper text).
 - Normalize dialog API and action model.
 - Remove or isolate explicitly deprecated/unused elements.
 
 ## P2 (After Auth/Onboarding UI work starts)
 
-- Build splash/welcome/auth screens only with stable/candidate design-system primitives.
+- [x] Build splash/welcome/auth screens only with stable/candidate design-system primitives.
 - Validate responsive behavior in compact and large devices.
 - Add UI catalog/sandbox screen for visual regression checks.
 

--- a/ios/Reguerta/Reguerta/ContentView.swift
+++ b/ios/Reguerta/Reguerta/ContentView.swift
@@ -39,13 +39,17 @@ struct ContentView: View {
                     }
 
                     if let feedbackKey = viewModel.feedbackMessageKey {
-                        Text(l10n(feedbackKey))
-                            .font(tokens.typography.label)
-                            .foregroundStyle(tokens.colors.feedbackError)
-                        Button {
-                            viewModel.clearFeedbackMessage()
-                        } label: {
-                            Text(localizedKey(AccessL10nKey.dismissMessage))
+                        ReguertaCard {
+                            VStack(alignment: .leading, spacing: tokens.spacing.sm) {
+                                ReguertaInlineFeedback(localizedKey(feedbackKey))
+                                ReguertaButton(
+                                    localizedKey(AccessL10nKey.dismissMessage),
+                                    variant: .text,
+                                    fullWidth: false
+                                ) {
+                                    viewModel.clearFeedbackMessage()
+                                }
+                            }
                         }
                     }
                 }
@@ -80,7 +84,7 @@ struct ContentView: View {
     }
 
     private var splashRoute: some View {
-        cardContainer {
+        ReguertaCard {
             VStack(alignment: .center, spacing: tokens.spacing.lg) {
                 Text(localizedKey(AccessL10nKey.membersRolesTitle))
                     .font(tokens.typography.titleSection)
@@ -104,7 +108,7 @@ struct ContentView: View {
     }
 
     private var welcomeRoute: some View {
-        cardContainer {
+        ReguertaCard {
             VStack(alignment: .leading, spacing: tokens.spacing.md) {
                 Text(localizedKey(AccessL10nKey.welcomeTitlePrefix))
                     .font(tokens.typography.titleCard)
@@ -115,45 +119,43 @@ struct ContentView: View {
                 Text(localizedKey(AccessL10nKey.welcomeSubtitle))
                     .font(tokens.typography.bodySecondary)
                     .foregroundStyle(tokens.colors.textSecondary)
-                Button {
+                ReguertaButton(localizedKey(AccessL10nKey.welcomeCtaEnter)) {
                     dispatchShell(.continueFromWelcome)
-                } label: {
-                    Text(localizedKey(AccessL10nKey.welcomeCtaEnter))
                 }
-                .buttonStyle(.borderedProminent)
             }
         }
     }
 
     private var loginRoute: some View {
         VStack(alignment: .leading, spacing: tokens.spacing.md) {
-            cardContainer {
+            ReguertaCard {
                 VStack(alignment: .leading, spacing: tokens.spacing.md) {
                     Text(localizedKey(AccessL10nKey.loginTitle))
                         .font(tokens.typography.titleCard)
                         .foregroundStyle(tokens.colors.textPrimary)
-                    Text(localizedKey(AccessL10nKey.signedOutHint))
-                        .font(tokens.typography.bodySecondary)
-                        .foregroundStyle(tokens.colors.textSecondary)
+                    ReguertaInlineFeedback(localizedKey(AccessL10nKey.signedOutHint), kind: .info)
                 }
             }
 
             signInCard
 
             HStack {
-                Button {
+                ReguertaButton(
+                    localizedKey(AccessL10nKey.loginLinkRegister),
+                    variant: .text,
+                    fullWidth: false
+                ) {
                     dispatchShell(.openRegisterFromLogin)
-                } label: {
-                    Text(localizedKey(AccessL10nKey.loginLinkRegister))
                 }
 
-                Button {
+                ReguertaButton(
+                    localizedKey(AccessL10nKey.loginLinkForgotPassword),
+                    variant: .text,
+                    fullWidth: false
+                ) {
                     dispatchShell(.openRecoverFromLogin)
-                } label: {
-                    Text(localizedKey(AccessL10nKey.loginLinkForgotPassword))
                 }
             }
-            .buttonStyle(.plain)
         }
     }
 
@@ -188,24 +190,36 @@ struct ContentView: View {
     }
 
     private var signInCard: some View {
-        cardContainer {
+        ReguertaCard {
             VStack(alignment: .leading, spacing: tokens.spacing.md) {
                 Text(localizedKey(AccessL10nKey.authenticationCardTitle))
                     .font(tokens.typography.titleCard)
 
-                TextField(localizedKey(AccessL10nKey.emailLabel), text: binding(\.emailInput))
-                    .textInputAutocapitalization(.never)
-                    .textFieldStyle(.roundedBorder)
-                TextField(localizedKey(AccessL10nKey.authUidLabel), text: binding(\.uidInput))
-                    .textInputAutocapitalization(.never)
-                    .textFieldStyle(.roundedBorder)
+                ReguertaInputField(
+                    localizedKey(AccessL10nKey.emailLabel),
+                    text: binding(\.emailInput),
+                    placeholder: localizedKey(AccessL10nKey.emailLabel),
+                    helperMessage: localizedKey(AccessL10nKey.signedOutHint),
+                    errorMessage: signInValidationError,
+                    isEnabled: !viewModel.isAuthenticating,
+                    keyboardType: .emailAddress
+                )
 
-                Button {
+                ReguertaInputField(
+                    localizedKey(AccessL10nKey.authUidLabel),
+                    text: binding(\.uidInput),
+                    placeholder: localizedKey(AccessL10nKey.authUidLabel),
+                    isEnabled: !viewModel.isAuthenticating,
+                    keyboardType: .asciiCapable
+                )
+
+                ReguertaButton(
+                    localizedKey(viewModel.isAuthenticating ? AccessL10nKey.signingIn : AccessL10nKey.signIn),
+                    isEnabled: !viewModel.isAuthenticating,
+                    isLoading: viewModel.isAuthenticating
+                ) {
                     viewModel.signIn()
-                } label: {
-                    Text(localizedKey(viewModel.isAuthenticating ? AccessL10nKey.signingIn : AccessL10nKey.signIn))
                 }
-                .disabled(viewModel.isAuthenticating)
             }
         }
     }
@@ -350,20 +364,25 @@ struct ContentView: View {
 
     @ViewBuilder
     private func placeholderRoute(titleKey: String, subtitleKey: String) -> some View {
-        cardContainer {
+        ReguertaCard {
             VStack(alignment: .leading, spacing: tokens.spacing.md) {
                 Text(localizedKey(titleKey))
                     .font(tokens.typography.titleSection)
                 Text(localizedKey(subtitleKey))
                     .font(tokens.typography.bodySecondary)
                     .foregroundStyle(tokens.colors.textSecondary)
-                Button {
+                ReguertaButton(localizedKey(AccessL10nKey.commonBack)) {
                     dispatchShell(.back)
-                } label: {
-                    Text(localizedKey(AccessL10nKey.commonBack))
                 }
             }
         }
+    }
+
+    private var signInValidationError: LocalizedStringKey? {
+        guard viewModel.feedbackMessageKey == AccessL10nKey.feedbackEmailUidRequired else {
+            return nil
+        }
+        return localizedKey(AccessL10nKey.feedbackEmailUidRequired)
     }
 
     @ViewBuilder

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaButton.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaButton.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+enum ReguertaButtonVariant {
+    case primary
+    case secondary
+    case text
+}
+
+struct ReguertaButton: View {
+    @Environment(\.reguertaTokens) private var tokens
+
+    let title: LocalizedStringKey
+    let variant: ReguertaButtonVariant
+    let isEnabled: Bool
+    let isLoading: Bool
+    let fullWidth: Bool
+    let action: () -> Void
+
+    init(
+        _ title: LocalizedStringKey,
+        variant: ReguertaButtonVariant = .primary,
+        isEnabled: Bool = true,
+        isLoading: Bool = false,
+        fullWidth: Bool = true,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.variant = variant
+        self.isEnabled = isEnabled
+        self.isLoading = isLoading
+        self.fullWidth = fullWidth
+        self.action = action
+    }
+
+    var body: some View {
+        switch variant {
+        case .primary:
+            baseButton.buttonStyle(.borderedProminent)
+        case .secondary:
+            baseButton.buttonStyle(.bordered)
+        case .text:
+            baseButton.buttonStyle(.plain)
+        }
+    }
+
+    private var baseButton: some View {
+        Button(action: action) {
+            HStack(spacing: tokens.spacing.sm) {
+                if isLoading {
+                    ProgressView()
+                        .tint(variant == .primary ? tokens.colors.actionOnPrimary : tokens.colors.actionPrimary)
+                }
+                Text(title)
+            }
+            .frame(maxWidth: fullWidth ? .infinity : nil)
+        }
+        .disabled(!isEnabled || isLoading)
+    }
+}

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaCard.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaCard.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct ReguertaCard<Content: View>: View {
+    @Environment(\.reguertaTokens) private var tokens
+    private let content: () -> Content
+
+    init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    var body: some View {
+        content()
+            .padding(tokens.spacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(tokens.colors.surfacePrimary)
+            .overlay(
+                RoundedRectangle(cornerRadius: tokens.radius.md)
+                    .stroke(tokens.colors.borderSubtle, lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: tokens.radius.md))
+    }
+}

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaInlineFeedback.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaInlineFeedback.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+enum ReguertaFeedbackKind {
+    case info
+    case warning
+    case error
+}
+
+struct ReguertaInlineFeedback: View {
+    @Environment(\.reguertaTokens) private var tokens
+
+    let message: LocalizedStringKey
+    let kind: ReguertaFeedbackKind
+
+    init(_ message: LocalizedStringKey, kind: ReguertaFeedbackKind = .error) {
+        self.message = message
+        self.kind = kind
+    }
+
+    var body: some View {
+        HStack(spacing: tokens.spacing.sm) {
+            Text("•")
+                .font(tokens.typography.body)
+                .foregroundStyle(color)
+            Text(message)
+                .font(tokens.typography.label)
+                .foregroundStyle(color)
+        }
+    }
+
+    private var color: Color {
+        switch kind {
+        case .info:
+            tokens.colors.textSecondary
+        case .warning:
+            tokens.colors.feedbackWarning
+        case .error:
+            tokens.colors.feedbackError
+        }
+    }
+}

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaInputField.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaInputField.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+
+enum ReguertaInputState {
+    case `default`
+    case focused
+    case error
+    case disabled
+}
+
+struct ReguertaInputField: View {
+    @Environment(\.reguertaTokens) private var tokens
+    @FocusState private var isFocused: Bool
+
+    let label: LocalizedStringKey
+    @Binding var text: String
+    let placeholder: LocalizedStringKey?
+    let helperMessage: LocalizedStringKey?
+    let errorMessage: LocalizedStringKey?
+    let isEnabled: Bool
+    let keyboardType: UIKeyboardType
+    let trailingIcon: Image?
+    let onTrailingTap: (() -> Void)?
+
+    init(
+        _ label: LocalizedStringKey,
+        text: Binding<String>,
+        placeholder: LocalizedStringKey? = nil,
+        helperMessage: LocalizedStringKey? = nil,
+        errorMessage: LocalizedStringKey? = nil,
+        isEnabled: Bool = true,
+        keyboardType: UIKeyboardType = .default,
+        trailingIcon: Image? = nil,
+        onTrailingTap: (() -> Void)? = nil
+    ) {
+        self.label = label
+        self._text = text
+        self.placeholder = placeholder
+        self.helperMessage = helperMessage
+        self.errorMessage = errorMessage
+        self.isEnabled = isEnabled
+        self.keyboardType = keyboardType
+        self.trailingIcon = trailingIcon
+        self.onTrailingTap = onTrailingTap
+    }
+
+    private var visualState: ReguertaInputState {
+        if !isEnabled { return .disabled }
+        if errorMessage != nil { return .error }
+        if isFocused { return .focused }
+        return .default
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: tokens.spacing.xs) {
+            Text(label)
+                .font(tokens.typography.label)
+                .foregroundStyle(labelColor(for: visualState))
+
+            HStack(spacing: tokens.spacing.sm) {
+                ZStack(alignment: .leading) {
+                    if let placeholder {
+                        Text(placeholder)
+                            .font(tokens.typography.body)
+                            .foregroundStyle(tokens.colors.textSecondary.opacity(0.65))
+                            .opacity(text.isEmpty ? 1 : 0)
+                    }
+                    TextField("", text: $text)
+                        .font(tokens.typography.body)
+                        .disabled(!isEnabled)
+                        .focused($isFocused)
+                        .textInputAutocapitalization(.never)
+                        .keyboardType(keyboardType)
+                        .accessibilityLabel(Text(label))
+                }
+
+                if let trailingIcon {
+                    if let onTrailingTap {
+                        Button(action: onTrailingTap) {
+                            trailingIcon
+                                .foregroundStyle(tokens.colors.textSecondary)
+                        }
+                        .buttonStyle(.plain)
+                    } else {
+                        trailingIcon
+                            .foregroundStyle(tokens.colors.textSecondary)
+                    }
+                }
+            }
+            .padding(.horizontal, tokens.spacing.md)
+            .padding(.vertical, tokens.spacing.sm + 2)
+            .background(tokens.colors.surfacePrimary)
+            .overlay(
+                RoundedRectangle(cornerRadius: tokens.radius.sm)
+                    .stroke(borderColor(for: visualState), lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: tokens.radius.sm))
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(tokens.typography.label)
+                    .foregroundStyle(tokens.colors.feedbackError)
+            } else if let helperMessage {
+                Text(helperMessage)
+                    .font(tokens.typography.label)
+                    .foregroundStyle(tokens.colors.textSecondary)
+            }
+        }
+    }
+
+    private func borderColor(for state: ReguertaInputState) -> Color {
+        switch state {
+        case .default:
+            tokens.colors.borderSubtle
+        case .focused:
+            tokens.colors.actionPrimary
+        case .error:
+            tokens.colors.feedbackError
+        case .disabled:
+            tokens.colors.borderSubtle.opacity(0.5)
+        }
+    }
+
+    private func labelColor(for state: ReguertaInputState) -> Color {
+        switch state {
+        case .focused:
+            tokens.colors.actionPrimary
+        case .error:
+            tokens.colors.feedbackError
+        case .default, .disabled:
+            tokens.colors.textSecondary
+        }
+    }
+}

--- a/ios/Reguerta/ReguertaUITests/ReguertaUITests.swift
+++ b/ios/Reguerta/ReguertaUITests/ReguertaUITests.swift
@@ -16,6 +16,7 @@ final class ReguertaUITests: XCTestCase {
         continueAfterFailure = false
 
         // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        XCUIApplication().terminate()
     }
 
     override func tearDownWithError() throws {
@@ -25,11 +26,8 @@ final class ReguertaUITests: XCTestCase {
     @MainActor
     func testUnauthorizedUserShowsRestrictedMode() throws {
         let app = configuredApp()
-        app.launch()
-        app.buttons["Enter the app"].tap()
+        let emailField = launchAndOpenLogin(app)
 
-        let emailField = app.textFields["Email"]
-        XCTAssertTrue(emailField.waitForExistence(timeout: 5))
         emailField.tap()
         emailField.typeText("unknown@reguerta.app")
 
@@ -48,11 +46,7 @@ final class ReguertaUITests: XCTestCase {
     @MainActor
     func testPreAuthorizedAdminEntersHomeWithModulesEnabled() throws {
         let app = configuredApp()
-        app.launch()
-        app.buttons["Enter the app"].tap()
-
-        let emailField = app.textFields["Email"]
-        XCTAssertTrue(emailField.waitForExistence(timeout: 5), "Email field not found")
+        let emailField = launchAndOpenLogin(app)
         emailField.tap()
         emailField.typeText("ana.admin@reguerta.app")
 
@@ -92,5 +86,19 @@ final class ReguertaUITests: XCTestCase {
         let app = XCUIApplication()
         app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US", "-skipSplash"]
         return app
+    }
+
+    @MainActor
+    private func launchAndOpenLogin(_ app: XCUIApplication) -> XCUIElement {
+        app.launch()
+
+        let enterButton = app.buttons["Enter the app"]
+        if enterButton.waitForExistence(timeout: 8) {
+            enterButton.tap()
+        }
+
+        let emailField = app.textFields["Email"]
+        XCTAssertTrue(emailField.waitForExistence(timeout: 12), "Email field not found")
+        return emailField
     }
 }


### PR DESCRIPTION
## Summary
- implement Core Components v1 with Android+iOS parity for auth/onboarding
- add reusable `ReguertaCard`, `ReguertaButton`, `ReguertaInputField`, and `ReguertaInlineFeedback` on both platforms
- wire splash/welcome/login/register/recover auth shell routes to use these primitives as reference flow
- add helper/error state support in input components and keep semantic token usage
- update design-system docs and migration backlog in EN/ES with v1 matrix and usage references
- stabilize iOS UI tests for login route discovery and custom input accessibility labels

## Validation
- Android: `./gradlew app:testDebugUnitTest app:lintDebug`
- Android: `./gradlew app:connectedDebugAndroidTest`
- iOS: `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' -parallel-testing-enabled NO test`

Closes #39
