### PR TITLE
[HU-032] Password reset flow

### DIFF
--- a/android/Reguerta/app/src/main/java/com/reguerta/user/data/access/FirebaseAuthSessionProvider.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/data/access/FirebaseAuthSessionProvider.kt
@@ -8,6 +8,7 @@ import com.google.firebase.auth.FirebaseAuthException
 import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
 import com.google.firebase.auth.FirebaseAuthInvalidUserException
 import com.reguerta.user.domain.access.AuthPrincipal
+import com.reguerta.user.domain.access.AuthPasswordResetResult
 import com.reguerta.user.domain.access.AuthSessionProvider
 import com.reguerta.user.domain.access.AuthSignInFailureReason
 import com.reguerta.user.domain.access.AuthSignInResult
@@ -50,6 +51,16 @@ class FirebaseAuthSessionProvider(
             )
         } catch (exception: Exception) {
             AuthSignInResult.Failure(exception.toFailureReason())
+        }
+    }
+
+    override suspend fun sendPasswordReset(email: String): AuthPasswordResetResult = withContext(Dispatchers.IO) {
+        val trimmedEmail = email.trim()
+        return@withContext try {
+            Tasks.await(auth.sendPasswordResetEmail(trimmedEmail))
+            AuthPasswordResetResult.Success
+        } catch (exception: Exception) {
+            AuthPasswordResetResult.Failure(exception.toFailureReason())
         }
     }
 

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/domain/access/AuthSessionProvider.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/domain/access/AuthSessionProvider.kt
@@ -18,10 +18,18 @@ sealed interface AuthSignInResult {
     data class Failure(val reason: AuthSignInFailureReason) : AuthSignInResult
 }
 
+sealed interface AuthPasswordResetResult {
+    data object Success : AuthPasswordResetResult
+
+    data class Failure(val reason: AuthSignInFailureReason) : AuthPasswordResetResult
+}
+
 interface AuthSessionProvider {
     suspend fun signIn(email: String, password: String): AuthSignInResult
 
     suspend fun signUp(email: String, password: String): AuthSignInResult
+
+    suspend fun sendPasswordReset(email: String): AuthPasswordResetResult
 
     fun signOut()
 }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRoot.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRoot.kt
@@ -191,11 +191,11 @@ fun ReguertaRoot(
                     },
                 )
 
-                AuthShellRoute.RECOVER_PASSWORD -> PlaceholderAuthRoute(
-                    titleRes = R.string.recover_title,
-                    subtitleRes = R.string.recover_subtitle,
-                    actionLabelRes = R.string.common_action_back,
-                    onAction = {
+                AuthShellRoute.RECOVER_PASSWORD -> RecoverPasswordRoute(
+                    state = state,
+                    onEmailChanged = viewModel::onRecoverEmailChanged,
+                    onSendReset = viewModel::sendPasswordReset,
+                    onBack = {
                         shellState = reduceAuthShell(
                             state = shellState,
                             action = AuthShellAction.Back,
@@ -439,32 +439,85 @@ private fun RegisterRoute(
 }
 
 @Composable
-private fun PlaceholderAuthRoute(
-    titleRes: Int,
-    subtitleRes: Int,
-    actionLabelRes: Int,
-    onAction: () -> Unit,
+private fun RecoverPasswordRoute(
+    state: SessionUiState,
+    onEmailChanged: (String) -> Unit,
+    onSendReset: () -> Unit,
+    onBack: () -> Unit,
 ) {
     val spacing = ReguertaThemeTokens.spacing
     ReguertaCard {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(spacing.xl),
+                .padding(spacing.lg),
             verticalArrangement = Arrangement.spacedBy(spacing.md),
         ) {
             Text(
-                text = stringResource(titleRes),
-                style = MaterialTheme.typography.titleLarge,
+                text = stringResource(R.string.recover_title),
+                style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
             )
             Text(
-                text = stringResource(subtitleRes),
+                text = stringResource(R.string.recover_subtitle),
                 style = MaterialTheme.typography.bodyMedium,
             )
+        }
+    }
+
+    RecoverPasswordCard(
+        state = state,
+        onEmailChanged = onEmailChanged,
+        onSendReset = onSendReset,
+    )
+
+    Row(horizontalArrangement = Arrangement.spacedBy(spacing.sm)) {
+        ReguertaButton(
+            label = stringResource(R.string.common_action_back),
+            onClick = onBack,
+            variant = ReguertaButtonVariant.TEXT,
+            fullWidth = false,
+        )
+    }
+}
+
+@Composable
+private fun RecoverPasswordCard(
+    state: SessionUiState,
+    onEmailChanged: (String) -> Unit,
+    onSendReset: () -> Unit,
+) {
+    val spacing = ReguertaThemeTokens.spacing
+    val canSubmit = !state.isRecoveringPassword &&
+        state.recoverEmailInput.trim().matches(LoginEmailPatternRegex)
+
+    ReguertaCard {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(spacing.lg),
+            verticalArrangement = Arrangement.spacedBy(spacing.md),
+        ) {
+            Text(stringResource(R.string.access_card_authentication))
+            ReguertaInputField(
+                label = stringResource(R.string.common_input_email_label),
+                value = state.recoverEmailInput,
+                onValueChange = onEmailChanged,
+                helperMessage = stringResource(R.string.recover_subtitle),
+                keyboardType = androidx.compose.ui.text.input.KeyboardType.Email,
+                errorMessage = state.recoverEmailErrorRes?.let { stringResource(it) },
+            )
             ReguertaButton(
-                label = stringResource(actionLabelRes),
-                onClick = onAction,
+                label = stringResource(
+                    if (state.isRecoveringPassword) {
+                        R.string.recover_action_sending
+                    } else {
+                        R.string.recover_action_send_email
+                    },
+                ),
+                onClick = onSendReset,
+                enabled = canSubmit,
+                loading = state.isRecoveringPassword,
             )
         }
     }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionViewModel.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.reguerta.user.R
 import com.reguerta.user.domain.access.AccessResolutionResult
+import com.reguerta.user.domain.access.AuthPasswordResetResult
 import com.reguerta.user.domain.access.AuthPrincipal
 import com.reguerta.user.domain.access.AuthSessionProvider
 import com.reguerta.user.domain.access.AuthSignInFailureReason
@@ -62,6 +63,9 @@ data class SessionUiState(
     @param:StringRes val registerPasswordErrorRes: Int? = null,
     @param:StringRes val registerRepeatPasswordErrorRes: Int? = null,
     val isRegistering: Boolean = false,
+    val recoverEmailInput: String = "",
+    @param:StringRes val recoverEmailErrorRes: Int? = null,
+    val isRecoveringPassword: Boolean = false,
     val mode: SessionMode = SessionMode.SignedOut,
     val memberDraft: MemberDraft = MemberDraft(),
 )
@@ -105,6 +109,10 @@ class SessionViewModel(
                 registerRepeatPasswordErrorRes = null,
             )
         }
+    }
+
+    fun onRecoverEmailChanged(value: String) {
+        _uiState.update { it.copy(recoverEmailInput = value, recoverEmailErrorRes = null) }
     }
 
     fun signIn() {
@@ -269,6 +277,47 @@ class SessionViewModel(
         }
     }
 
+    fun sendPasswordReset() {
+        val currentState = _uiState.value
+        val email = currentState.recoverEmailInput.trim()
+        val emailErrorRes = when {
+            email.isBlank() -> R.string.feedback_email_required
+            !email.matches(EmailPatternRegex) -> R.string.feedback_email_invalid
+            else -> null
+        }
+
+        if (emailErrorRes != null) {
+            _uiState.update { it.copy(recoverEmailErrorRes = emailErrorRes) }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isRecoveringPassword = true, recoverEmailErrorRes = null) }
+
+            when (val result = authSessionProvider.sendPasswordReset(email = email)) {
+                AuthPasswordResetResult.Success -> {
+                    _uiState.update {
+                        it.copy(
+                            isRecoveringPassword = false,
+                            recoverEmailInput = "",
+                        )
+                    }
+                    emitMessage(R.string.auth_info_password_reset_sent)
+                }
+
+                is AuthPasswordResetResult.Failure -> {
+                    _uiState.update {
+                        it.copy(
+                            isRecoveringPassword = false,
+                            recoverEmailErrorRes = result.reason.recoverEmailErrorRes(),
+                        )
+                    }
+                    result.reason.globalMessageResOrNull()?.let(::emitMessage)
+                }
+            }
+        }
+    }
+
     fun signOut() {
         authSessionProvider.signOut()
         _uiState.update {
@@ -285,6 +334,9 @@ class SessionViewModel(
                 registerPasswordErrorRes = null,
                 registerRepeatPasswordErrorRes = null,
                 isRegistering = false,
+                recoverEmailInput = "",
+                recoverEmailErrorRes = null,
+                isRecoveringPassword = false,
                 memberDraft = MemberDraft(),
             )
         }
@@ -462,6 +514,15 @@ private fun AuthSignInFailureReason.registerEmailErrorRes(): Int? =
 private fun AuthSignInFailureReason.registerPasswordErrorRes(): Int? =
     when (this) {
         AuthSignInFailureReason.WEAK_PASSWORD -> R.string.auth_error_weak_password
+        else -> null
+    }
+
+@StringRes
+private fun AuthSignInFailureReason.recoverEmailErrorRes(): Int? =
+    when (this) {
+        AuthSignInFailureReason.INVALID_EMAIL -> R.string.feedback_email_invalid
+        AuthSignInFailureReason.USER_NOT_FOUND -> R.string.auth_error_user_not_found
+        AuthSignInFailureReason.USER_DISABLED -> R.string.auth_error_user_disabled
         else -> null
     }
 

--- a/android/Reguerta/app/src/main/res/values-es/strings.xml
+++ b/android/Reguerta/app/src/main/res/values-es/strings.xml
@@ -27,7 +27,9 @@
     <string name="register_action_create_account">Crear cuenta</string>
     <string name="register_action_creating">Creando cuenta...</string>
     <string name="recover_title">Recuperar contraseña</string>
-    <string name="recover_subtitle">La pantalla de recuperación ya está integrada en navegación y se completará en HU-032.</string>
+    <string name="recover_subtitle">Introduce tu email y te enviaremos instrucciones para restablecerla</string>
+    <string name="recover_action_send_email">Enviar email de recuperación</string>
+    <string name="recover_action_sending">Enviando email...</string>
     <string name="common_action_back">Volver</string>
 
     <string name="auth_error_member_unauthorized">Usuario no autorizado</string>
@@ -74,6 +76,7 @@
     <string name="auth_error_too_many_requests">Demasiados intentos. Inténtalo más tarde</string>
     <string name="auth_error_network">Revisa tu conexión e inténtalo de nuevo</string>
     <string name="auth_error_unknown">No se pudo iniciar sesión ahora mismo</string>
+    <string name="auth_info_password_reset_sent">Si existe una cuenta para este email, hemos enviado instrucciones de recuperación</string>
     <string name="auth_error_email_already_in_use">Este email ya está en uso</string>
     <string name="auth_error_weak_password">Usa una contraseña más segura (mínimo 6 caracteres)</string>
     <string name="feedback_password_repeat_required">Debes repetir la contraseña</string>

--- a/android/Reguerta/app/src/main/res/values/strings.xml
+++ b/android/Reguerta/app/src/main/res/values/strings.xml
@@ -27,7 +27,9 @@
     <string name="register_action_create_account">Create account</string>
     <string name="register_action_creating">Creating account...</string>
     <string name="recover_title">Recover password</string>
-    <string name="recover_subtitle">Recover screen is wired into navigation and will be completed in HU-032.</string>
+    <string name="recover_subtitle">Enter your email and we will send reset instructions</string>
+    <string name="recover_action_send_email">Send reset email</string>
+    <string name="recover_action_sending">Sending email...</string>
     <string name="common_action_back">Back</string>
 
     <string name="auth_error_member_unauthorized">Unauthorized user</string>
@@ -74,6 +76,7 @@
     <string name="auth_error_too_many_requests">Too many attempts. Try again later</string>
     <string name="auth_error_network">Check your connection and try again</string>
     <string name="auth_error_unknown">Unable to sign in right now</string>
+    <string name="auth_info_password_reset_sent">If an account exists for this email, reset instructions were sent</string>
     <string name="auth_error_email_already_in_use">This email is already in use</string>
     <string name="auth_error_weak_password">Use a stronger password (at least 6 characters)</string>
     <string name="feedback_password_repeat_required">Repeat password is required</string>

--- a/ios/Reguerta/Reguerta/ContentView.swift
+++ b/ios/Reguerta/Reguerta/ContentView.swift
@@ -27,10 +27,7 @@ struct ContentView: View {
                     case .register:
                         registerRoute
                     case .recoverPassword:
-                        placeholderRoute(
-                            titleKey: AccessL10nKey.recoverTitle,
-                            subtitleKey: AccessL10nKey.recoverSubtitle
-                        )
+                        recoverRoute
                     case .home:
                         homeRoute
                     }
@@ -195,6 +192,33 @@ struct ContentView: View {
         }
     }
 
+    private var recoverRoute: some View {
+        VStack(alignment: .leading, spacing: tokens.spacing.md) {
+            ReguertaCard {
+                VStack(alignment: .leading, spacing: tokens.spacing.md) {
+                    Text(localizedKey(AccessL10nKey.recoverTitle))
+                        .font(tokens.typography.titleCard)
+                        .foregroundStyle(tokens.colors.textPrimary)
+                    Text(localizedKey(AccessL10nKey.recoverSubtitle))
+                        .font(tokens.typography.bodySecondary)
+                        .foregroundStyle(tokens.colors.textSecondary)
+                }
+            }
+
+            recoverPasswordCard
+
+            HStack {
+                ReguertaButton(
+                    localizedKey(AccessL10nKey.commonBack),
+                    variant: .text,
+                    fullWidth: false
+                ) {
+                    dispatchShell(.back)
+                }
+            }
+        }
+    }
+
     private var homeRoute: some View {
         VStack(alignment: .leading, spacing: tokens.spacing.lg) {
             cardContainer {
@@ -304,6 +328,33 @@ struct ContentView: View {
                     isLoading: viewModel.isRegistering
                 ) {
                     viewModel.signUp()
+                }
+            }
+        }
+    }
+
+    private var recoverPasswordCard: some View {
+        ReguertaCard {
+            VStack(alignment: .leading, spacing: tokens.spacing.md) {
+                Text(localizedKey(AccessL10nKey.authenticationCardTitle))
+                    .font(tokens.typography.titleCard)
+
+                ReguertaInputField(
+                    localizedKey(AccessL10nKey.emailLabel),
+                    text: binding(\.recoverEmailInput),
+                    placeholder: localizedKey(AccessL10nKey.emailLabel),
+                    helperMessage: localizedKey(AccessL10nKey.recoverSubtitle),
+                    errorMessage: viewModel.recoverEmailErrorKey.map(localizedKey),
+                    isEnabled: !viewModel.isRecoveringPassword,
+                    keyboardType: .emailAddress
+                )
+
+                ReguertaButton(
+                    localizedKey(viewModel.isRecoveringPassword ? AccessL10nKey.recoverActionSending : AccessL10nKey.recoverActionSendEmail),
+                    isEnabled: viewModel.canSubmitPasswordReset,
+                    isLoading: viewModel.isRecoveringPassword
+                ) {
+                    viewModel.sendPasswordReset()
                 }
             }
         }

--- a/ios/Reguerta/Reguerta/Data/Access/FirebaseAuthSessionProvider.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/FirebaseAuthSessionProvider.swift
@@ -38,6 +38,17 @@ struct FirebaseAuthSessionProvider: AuthSessionProvider {
         }
     }
 
+    func sendPasswordReset(email: String) async -> AuthPasswordResetResult {
+        let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        do {
+            try await auth.sendPasswordReset(withEmail: trimmedEmail)
+            return .success
+        } catch {
+            return .failure(mapFirebaseAuthError(error))
+        }
+    }
+
     func signOut() {
         try? auth.signOut()
     }

--- a/ios/Reguerta/Reguerta/Data/Access/MockAuthSessionProvider.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/MockAuthSessionProvider.swift
@@ -21,6 +21,10 @@ struct MockAuthSessionProvider: AuthSessionProvider {
         return .success(AuthPrincipal(uid: uid, email: normalizedEmail))
     }
 
+    func sendPasswordReset(email: String) async -> AuthPasswordResetResult {
+        .success
+    }
+
     func signOut() {
     }
 }

--- a/ios/Reguerta/Reguerta/Domain/Access/AuthSessionProvider.swift
+++ b/ios/Reguerta/Reguerta/Domain/Access/AuthSessionProvider.swift
@@ -17,8 +17,14 @@ enum AuthSignInResult: Equatable, Sendable {
     case failure(AuthSignInFailureReason)
 }
 
+enum AuthPasswordResetResult: Equatable, Sendable {
+    case success
+    case failure(AuthSignInFailureReason)
+}
+
 protocol AuthSessionProvider: Sendable {
     func signIn(email: String, password: String) async -> AuthSignInResult
     func signUp(email: String, password: String) async -> AuthSignInResult
+    func sendPasswordReset(email: String) async -> AuthPasswordResetResult
     func signOut()
 }

--- a/ios/Reguerta/Reguerta/Presentation/Access/AccessLocalization.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/AccessLocalization.swift
@@ -37,6 +37,8 @@ enum AccessL10nKey {
     static let registerActionCreating = "register.action.creating"
     static let recoverTitle = "recover.title"
     static let recoverSubtitle = "recover.subtitle"
+    static let recoverActionSendEmail = "recover.action.send_email"
+    static let recoverActionSending = "recover.action.sending"
 
     static let homeTitle = "home.title"
     static let homeWelcome = "home.welcome"
@@ -79,6 +81,7 @@ enum AccessL10nKey {
     static let authErrorTooManyRequests = "auth_error.too_many_requests"
     static let authErrorNetwork = "auth_error.network"
     static let authErrorUnknown = "auth_error.unknown"
+    static let authInfoPasswordResetSent = "auth_info.password_reset_sent"
     static let feedbackPasswordRepeatRequired = "feedback.password_repeat_required"
     static let feedbackPasswordMismatch = "feedback.password_mismatch"
     static let feedbackOnlyAdminCreate = "feedback.only_admin_create"

--- a/ios/Reguerta/Reguerta/Presentation/Access/SessionViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/SessionViewModel.swift
@@ -60,13 +60,22 @@ final class SessionViewModel {
             }
         }
     }
+    var recoverEmailInput = "" {
+        didSet {
+            if oldValue != recoverEmailInput {
+                recoverEmailErrorKey = nil
+            }
+        }
+    }
     var emailErrorKey: String?
     var passwordErrorKey: String?
     var registerEmailErrorKey: String?
     var registerPasswordErrorKey: String?
     var registerRepeatPasswordErrorKey: String?
+    var recoverEmailErrorKey: String?
     var isAuthenticating = false
     var isRegistering = false
+    var isRecoveringPassword = false
     var mode: SessionMode = .signedOut
     var memberDraft = MemberDraft()
     var feedbackMessageKey: String?
@@ -90,6 +99,12 @@ final class SessionViewModel {
             !registerPasswordInput.isEmpty &&
             !registerRepeatPasswordInput.isEmpty &&
             registerPasswordInput == registerRepeatPasswordInput
+    }
+
+    var canSubmitPasswordReset: Bool {
+        !isRecoveringPassword &&
+            !normalizeEmail(recoverEmailInput).isEmpty &&
+            normalizeEmail(recoverEmailInput).isValidEmail
     }
 
     init(
@@ -178,16 +193,47 @@ final class SessionViewModel {
         registerEmailInput = ""
         registerPasswordInput = ""
         registerRepeatPasswordInput = ""
+        recoverEmailInput = ""
         emailErrorKey = nil
         passwordErrorKey = nil
         registerEmailErrorKey = nil
         registerPasswordErrorKey = nil
         registerRepeatPasswordErrorKey = nil
+        recoverEmailErrorKey = nil
         isAuthenticating = false
         isRegistering = false
+        isRecoveringPassword = false
         feedbackMessageKey = nil
         mode = .signedOut
         memberDraft = MemberDraft()
+    }
+
+    func sendPasswordReset() {
+        let email = normalizeEmail(recoverEmailInput)
+        feedbackMessageKey = nil
+        recoverEmailErrorKey = nil
+
+        if email.isEmpty {
+            recoverEmailErrorKey = AccessL10nKey.feedbackEmailRequired
+            return
+        }
+        if !email.isValidEmail {
+            recoverEmailErrorKey = AccessL10nKey.feedbackEmailInvalid
+            return
+        }
+
+        isRecoveringPassword = true
+        Task {
+            let result = await authSessionProvider.sendPasswordReset(email: email)
+            switch result {
+            case .success:
+                recoverEmailInput = ""
+                feedbackMessageKey = AccessL10nKey.authInfoPasswordResetSent
+            case .failure(let reason):
+                applyPasswordResetFailure(reason)
+            }
+            isRecoveringPassword = false
+        }
     }
 
     func createAuthorizedMember() {
@@ -389,6 +435,29 @@ final class SessionViewModel {
         case .network:
             feedbackMessageKey = AccessL10nKey.authErrorNetwork
         case .unknown:
+            feedbackMessageKey = AccessL10nKey.authErrorUnknown
+        }
+    }
+
+    private func applyPasswordResetFailure(_ reason: AuthSignInFailureReason) {
+        switch reason {
+        case .invalidEmail:
+            recoverEmailErrorKey = AccessL10nKey.feedbackEmailInvalid
+        case .userNotFound:
+            recoverEmailErrorKey = AccessL10nKey.authErrorUserNotFound
+        case .userDisabled:
+            recoverEmailErrorKey = AccessL10nKey.authErrorUserDisabled
+        case .tooManyRequests:
+            feedbackMessageKey = AccessL10nKey.authErrorTooManyRequests
+        case .network:
+            feedbackMessageKey = AccessL10nKey.authErrorNetwork
+        case .unknown:
+            feedbackMessageKey = AccessL10nKey.authErrorUnknown
+        case .invalidCredentials:
+            feedbackMessageKey = AccessL10nKey.authErrorUnknown
+        case .emailAlreadyInUse:
+            feedbackMessageKey = AccessL10nKey.authErrorUnknown
+        case .weakPassword:
             feedbackMessageKey = AccessL10nKey.authErrorUnknown
         }
     }

--- a/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
+++ b/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
@@ -449,6 +449,22 @@
         }
       }
     },
+    "auth_info.password_reset_sent": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If an account exists for this email, reset instructions were sent"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si existe una cuenta para este email, hemos enviado instrucciones de recuperación"
+          }
+        }
+      }
+    },
     "common.brand.reguerta": {
       "localizations": {
         "en": {
@@ -1350,13 +1366,45 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Recover screen is wired into navigation and will be completed in HU-032."
+            "value": "Enter your email and we will send reset instructions"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "La pantalla de recuperación ya está integrada en navegación y se completará en HU-032."
+            "value": "Introduce tu email y te enviaremos instrucciones para restablecerla"
+          }
+        }
+      }
+    },
+    "recover.action.send_email": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send reset email"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviar email de recuperación"
+          }
+        }
+      }
+    },
+    "recover.action.sending": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sending email..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enviando email..."
           }
         }
       }

--- a/ios/Reguerta/ReguertaTests/ReguertaTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaTests.swift
@@ -155,6 +155,8 @@ struct ReguertaTests {
     func firebaseAuthErrorMappingCoversKnownCodes() {
         let invalidEmail = NSError(domain: AuthErrorDomain, code: AuthErrorCode.invalidEmail.rawValue)
         let wrongPassword = NSError(domain: AuthErrorDomain, code: AuthErrorCode.wrongPassword.rawValue)
+        let emailAlreadyInUse = NSError(domain: AuthErrorDomain, code: AuthErrorCode.emailAlreadyInUse.rawValue)
+        let weakPassword = NSError(domain: AuthErrorDomain, code: AuthErrorCode.weakPassword.rawValue)
         let notFound = NSError(domain: AuthErrorDomain, code: AuthErrorCode.userNotFound.rawValue)
         let disabled = NSError(domain: AuthErrorDomain, code: AuthErrorCode.userDisabled.rawValue)
         let tooMany = NSError(domain: AuthErrorDomain, code: AuthErrorCode.tooManyRequests.rawValue)
@@ -162,6 +164,8 @@ struct ReguertaTests {
 
         #expect(mapFirebaseAuthError(invalidEmail) == .invalidEmail)
         #expect(mapFirebaseAuthError(wrongPassword) == .invalidCredentials)
+        #expect(mapFirebaseAuthError(emailAlreadyInUse) == .emailAlreadyInUse)
+        #expect(mapFirebaseAuthError(weakPassword) == .weakPassword)
         #expect(mapFirebaseAuthError(notFound) == .userNotFound)
         #expect(mapFirebaseAuthError(disabled) == .userDisabled)
         #expect(mapFirebaseAuthError(tooMany) == .tooManyRequests)


### PR DESCRIPTION
## Summary
- Implement password reset contract in auth providers for Android and iOS (`sendPasswordReset`).
- Replace recover-password placeholders with real screens in both platforms.
- Add recover flow state to ViewModels (email input, validation, loading, mapped errors).
- Send Firebase password reset email and surface success/info feedback and friendly failure messages.
- Externalize all new copy in EN/ES localization resources.

## Validation
- Android: `./gradlew app:testDebugUnitTest`
- Android: `./gradlew app:lintDebug`
- Android: `./gradlew app:connectedDebugAndroidTest`
- iOS: `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test`

## Notes
- Tests were run on `iPhone 17 Pro` simulator.

Closes #32
