### PR TITLE
HU-033: Input V2 + shared auth error mapping

### DIFF
--- a/android/Reguerta/app/build.gradle.kts
+++ b/android/Reguerta/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.kotlinx.serialization.json)

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/AuthErrorMapping.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/AuthErrorMapping.kt
@@ -1,0 +1,81 @@
+package com.reguerta.user.presentation.access
+
+import androidx.annotation.StringRes
+import com.reguerta.user.R
+import com.reguerta.user.domain.access.AuthSignInFailureReason
+
+enum class AuthErrorFlow {
+    SIGN_IN,
+    SIGN_UP,
+    PASSWORD_RESET,
+}
+
+data class AuthErrorUiMapping(
+    @param:StringRes val emailErrorRes: Int? = null,
+    @param:StringRes val passwordErrorRes: Int? = null,
+    @param:StringRes val globalMessageRes: Int? = null,
+)
+
+fun mapAuthFailure(reason: AuthSignInFailureReason, flow: AuthErrorFlow): AuthErrorUiMapping =
+    when (flow) {
+        AuthErrorFlow.SIGN_IN -> when (reason) {
+            AuthSignInFailureReason.INVALID_EMAIL ->
+                AuthErrorUiMapping(emailErrorRes = R.string.feedback_email_invalid)
+            AuthSignInFailureReason.INVALID_CREDENTIALS ->
+                AuthErrorUiMapping(passwordErrorRes = R.string.auth_error_invalid_credentials)
+            AuthSignInFailureReason.EMAIL_ALREADY_IN_USE ->
+                AuthErrorUiMapping(emailErrorRes = R.string.auth_error_email_already_in_use)
+            AuthSignInFailureReason.WEAK_PASSWORD ->
+                AuthErrorUiMapping(passwordErrorRes = R.string.auth_error_weak_password)
+            AuthSignInFailureReason.USER_NOT_FOUND ->
+                AuthErrorUiMapping(emailErrorRes = R.string.auth_error_user_not_found)
+            AuthSignInFailureReason.USER_DISABLED ->
+                AuthErrorUiMapping(emailErrorRes = R.string.auth_error_user_disabled)
+            AuthSignInFailureReason.TOO_MANY_REQUESTS ->
+                AuthErrorUiMapping(globalMessageRes = R.string.auth_error_too_many_requests)
+            AuthSignInFailureReason.NETWORK ->
+                AuthErrorUiMapping(globalMessageRes = R.string.auth_error_network)
+            AuthSignInFailureReason.UNKNOWN ->
+                AuthErrorUiMapping(globalMessageRes = R.string.auth_error_unknown)
+        }
+
+        AuthErrorFlow.SIGN_UP -> when (reason) {
+            AuthSignInFailureReason.INVALID_EMAIL ->
+                AuthErrorUiMapping(emailErrorRes = R.string.feedback_email_invalid)
+            AuthSignInFailureReason.INVALID_CREDENTIALS ->
+                AuthErrorUiMapping(passwordErrorRes = R.string.auth_error_invalid_credentials)
+            AuthSignInFailureReason.EMAIL_ALREADY_IN_USE ->
+                AuthErrorUiMapping(emailErrorRes = R.string.auth_error_email_already_in_use)
+            AuthSignInFailureReason.WEAK_PASSWORD ->
+                AuthErrorUiMapping(passwordErrorRes = R.string.auth_error_weak_password)
+            AuthSignInFailureReason.USER_NOT_FOUND ->
+                AuthErrorUiMapping(emailErrorRes = R.string.auth_error_user_not_found)
+            AuthSignInFailureReason.USER_DISABLED ->
+                AuthErrorUiMapping(emailErrorRes = R.string.auth_error_user_disabled)
+            AuthSignInFailureReason.TOO_MANY_REQUESTS ->
+                AuthErrorUiMapping(globalMessageRes = R.string.auth_error_too_many_requests)
+            AuthSignInFailureReason.NETWORK ->
+                AuthErrorUiMapping(globalMessageRes = R.string.auth_error_network)
+            AuthSignInFailureReason.UNKNOWN ->
+                AuthErrorUiMapping(globalMessageRes = R.string.auth_error_unknown)
+        }
+
+        AuthErrorFlow.PASSWORD_RESET -> when (reason) {
+            AuthSignInFailureReason.INVALID_EMAIL ->
+                AuthErrorUiMapping(emailErrorRes = R.string.feedback_email_invalid)
+            AuthSignInFailureReason.USER_NOT_FOUND ->
+                AuthErrorUiMapping(emailErrorRes = R.string.auth_error_user_not_found)
+            AuthSignInFailureReason.USER_DISABLED ->
+                AuthErrorUiMapping(emailErrorRes = R.string.auth_error_user_disabled)
+            AuthSignInFailureReason.TOO_MANY_REQUESTS ->
+                AuthErrorUiMapping(globalMessageRes = R.string.auth_error_too_many_requests)
+            AuthSignInFailureReason.NETWORK ->
+                AuthErrorUiMapping(globalMessageRes = R.string.auth_error_network)
+            AuthSignInFailureReason.UNKNOWN,
+            AuthSignInFailureReason.INVALID_CREDENTIALS,
+            AuthSignInFailureReason.EMAIL_ALREADY_IN_USE,
+            AuthSignInFailureReason.WEAK_PASSWORD,
+            ->
+                AuthErrorUiMapping(globalMessageRes = R.string.auth_error_unknown)
+        }
+    }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRoot.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRoot.kt
@@ -506,6 +506,7 @@ private fun RecoverPasswordCard(
                 helperMessage = stringResource(R.string.recover_subtitle),
                 keyboardType = androidx.compose.ui.text.input.KeyboardType.Email,
                 errorMessage = state.recoverEmailErrorRes?.let { stringResource(it) },
+                showClearAction = true,
             )
             ReguertaButton(
                 label = stringResource(
@@ -604,6 +605,7 @@ private fun SignInCard(
                 helperMessage = stringResource(R.string.access_signed_out_hint),
                 keyboardType = androidx.compose.ui.text.input.KeyboardType.Email,
                 errorMessage = state.emailErrorRes?.let { stringResource(it) },
+                showClearAction = true,
             )
             ReguertaInputField(
                 label = stringResource(R.string.common_input_password_label),
@@ -613,6 +615,7 @@ private fun SignInCard(
                 },
                 keyboardType = androidx.compose.ui.text.input.KeyboardType.Password,
                 isPassword = true,
+                showPasswordToggle = true,
                 errorMessage = state.passwordErrorRes?.let { stringResource(it) },
             )
             ReguertaButton(
@@ -662,6 +665,7 @@ private fun SignUpCard(
                 onValueChange = onEmailChanged,
                 keyboardType = androidx.compose.ui.text.input.KeyboardType.Email,
                 errorMessage = state.registerEmailErrorRes?.let { stringResource(it) },
+                showClearAction = true,
             )
             ReguertaInputField(
                 label = stringResource(R.string.common_input_password_label),
@@ -669,6 +673,7 @@ private fun SignUpCard(
                 onValueChange = onPasswordChanged,
                 keyboardType = androidx.compose.ui.text.input.KeyboardType.Password,
                 isPassword = true,
+                showPasswordToggle = true,
                 errorMessage = state.registerPasswordErrorRes?.let { stringResource(it) },
             )
             ReguertaInputField(
@@ -677,6 +682,7 @@ private fun SignUpCard(
                 onValueChange = onRepeatPasswordChanged,
                 keyboardType = androidx.compose.ui.text.input.KeyboardType.Password,
                 isPassword = true,
+                showPasswordToggle = true,
                 errorMessage = state.registerRepeatPasswordErrorRes?.let { stringResource(it) },
             )
             ReguertaButton(

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionViewModel.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionViewModel.kt
@@ -8,7 +8,6 @@ import com.reguerta.user.domain.access.AccessResolutionResult
 import com.reguerta.user.domain.access.AuthPasswordResetResult
 import com.reguerta.user.domain.access.AuthPrincipal
 import com.reguerta.user.domain.access.AuthSessionProvider
-import com.reguerta.user.domain.access.AuthSignInFailureReason
 import com.reguerta.user.domain.access.AuthSignInResult
 import com.reguerta.user.domain.access.Member
 import com.reguerta.user.domain.access.MemberManagementException
@@ -172,15 +171,19 @@ class SessionViewModel(
                 }
 
                 is AuthSignInResult.Failure -> {
+                    val mappedError = mapAuthFailure(
+                        reason = authResult.reason,
+                        flow = AuthErrorFlow.SIGN_IN,
+                    )
                     _uiState.update {
                         it.copy(
                             isAuthenticating = false,
-                            emailErrorRes = authResult.reason.emailErrorRes(),
-                            passwordErrorRes = authResult.reason.passwordErrorRes(),
+                            emailErrorRes = mappedError.emailErrorRes,
+                            passwordErrorRes = mappedError.passwordErrorRes,
                         )
                     }
 
-                    authResult.reason.globalMessageResOrNull()?.let(::emitMessage)
+                    mappedError.globalMessageRes?.let(::emitMessage)
                 }
             }
         }
@@ -263,15 +266,19 @@ class SessionViewModel(
                 }
 
                 is AuthSignInResult.Failure -> {
+                    val mappedError = mapAuthFailure(
+                        reason = authResult.reason,
+                        flow = AuthErrorFlow.SIGN_UP,
+                    )
                     _uiState.update {
                         it.copy(
                             isRegistering = false,
-                            registerEmailErrorRes = authResult.reason.registerEmailErrorRes(),
-                            registerPasswordErrorRes = authResult.reason.registerPasswordErrorRes(),
+                            registerEmailErrorRes = mappedError.emailErrorRes,
+                            registerPasswordErrorRes = mappedError.passwordErrorRes,
                         )
                     }
 
-                    authResult.reason.globalMessageResOrNull()?.let(::emitMessage)
+                    mappedError.globalMessageRes?.let(::emitMessage)
                 }
             }
         }
@@ -306,13 +313,17 @@ class SessionViewModel(
                 }
 
                 is AuthPasswordResetResult.Failure -> {
+                    val mappedError = mapAuthFailure(
+                        reason = result.reason,
+                        flow = AuthErrorFlow.PASSWORD_RESET,
+                    )
                     _uiState.update {
                         it.copy(
                             isRecoveringPassword = false,
-                            recoverEmailErrorRes = result.reason.recoverEmailErrorRes(),
+                            recoverEmailErrorRes = mappedError.emailErrorRes,
                         )
                     }
-                    result.reason.globalMessageResOrNull()?.let(::emitMessage)
+                    mappedError.globalMessageRes?.let(::emitMessage)
                 }
             }
         }
@@ -484,53 +495,3 @@ class SessionViewModel(
 }
 
 private val EmailPatternRegex = "^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$".toRegex(setOf(RegexOption.IGNORE_CASE))
-
-@StringRes
-private fun AuthSignInFailureReason.emailErrorRes(): Int? =
-    when (this) {
-        AuthSignInFailureReason.INVALID_EMAIL -> R.string.feedback_email_invalid
-        AuthSignInFailureReason.USER_NOT_FOUND -> R.string.auth_error_user_not_found
-        AuthSignInFailureReason.USER_DISABLED -> R.string.auth_error_user_disabled
-        else -> null
-    }
-
-@StringRes
-private fun AuthSignInFailureReason.passwordErrorRes(): Int? =
-    when (this) {
-        AuthSignInFailureReason.INVALID_CREDENTIALS -> R.string.auth_error_invalid_credentials
-        else -> null
-    }
-
-@StringRes
-private fun AuthSignInFailureReason.registerEmailErrorRes(): Int? =
-    when (this) {
-        AuthSignInFailureReason.INVALID_EMAIL -> R.string.feedback_email_invalid
-        AuthSignInFailureReason.EMAIL_ALREADY_IN_USE -> R.string.auth_error_email_already_in_use
-        AuthSignInFailureReason.USER_DISABLED -> R.string.auth_error_user_disabled
-        else -> null
-    }
-
-@StringRes
-private fun AuthSignInFailureReason.registerPasswordErrorRes(): Int? =
-    when (this) {
-        AuthSignInFailureReason.WEAK_PASSWORD -> R.string.auth_error_weak_password
-        else -> null
-    }
-
-@StringRes
-private fun AuthSignInFailureReason.recoverEmailErrorRes(): Int? =
-    when (this) {
-        AuthSignInFailureReason.INVALID_EMAIL -> R.string.feedback_email_invalid
-        AuthSignInFailureReason.USER_NOT_FOUND -> R.string.auth_error_user_not_found
-        AuthSignInFailureReason.USER_DISABLED -> R.string.auth_error_user_disabled
-        else -> null
-    }
-
-@StringRes
-private fun AuthSignInFailureReason.globalMessageResOrNull(): Int? =
-    when (this) {
-        AuthSignInFailureReason.TOO_MANY_REQUESTS -> R.string.auth_error_too_many_requests
-        AuthSignInFailureReason.NETWORK -> R.string.auth_error_network
-        AuthSignInFailureReason.UNKNOWN -> R.string.auth_error_unknown
-        else -> null
-    }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaInputField.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaInputField.kt
@@ -5,6 +5,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
@@ -19,6 +25,8 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.res.stringResource
+import com.reguerta.user.R
 import com.reguerta.user.ui.theme.ReguertaThemeTokens
 
 enum class ReguertaInputState {
@@ -40,9 +48,12 @@ fun ReguertaInputField(
     keyboardType: KeyboardType = KeyboardType.Text,
     errorMessage: String? = null,
     isPassword: Boolean = false,
+    showClearAction: Boolean = false,
+    showPasswordToggle: Boolean = isPassword,
     trailing: (@Composable () -> Unit)? = null,
 ) {
     var focused by remember { mutableStateOf(false) }
+    var passwordVisible by remember { mutableStateOf(false) }
     val spacing = ReguertaThemeTokens.spacing
     val hasError = !errorMessage.isNullOrBlank()
     val state = when {
@@ -69,8 +80,41 @@ fun ReguertaInputField(
             },
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-            visualTransformation = if (isPassword) PasswordVisualTransformation() else VisualTransformation.None,
-            trailingIcon = trailing,
+            visualTransformation = if (isPassword && !passwordVisible) {
+                PasswordVisualTransformation()
+            } else {
+                VisualTransformation.None
+            },
+            trailingIcon = {
+                when {
+                    isPassword && showPasswordToggle -> {
+                        IconButton(
+                            onClick = { passwordVisible = !passwordVisible },
+                            enabled = enabled,
+                        ) {
+                            Icon(
+                                imageVector = if (passwordVisible) Icons.Filled.VisibilityOff else Icons.Filled.Visibility,
+                                contentDescription = if (passwordVisible) {
+                                    stringResource(R.string.common_action_hide_password)
+                                } else {
+                                    stringResource(R.string.common_action_show_password)
+                                },
+                            )
+                        }
+                    }
+
+                    showClearAction && enabled && value.isNotEmpty() -> {
+                        IconButton(onClick = { onValueChange("") }) {
+                            Icon(
+                                imageVector = Icons.Filled.Clear,
+                                contentDescription = stringResource(R.string.common_action_clear),
+                            )
+                        }
+                    }
+
+                    trailing != null -> trailing()
+                }
+            },
             colors = OutlinedTextFieldDefaults.colors(
                 focusedBorderColor = stateBorderColor(ReguertaInputState.FOCUSED),
                 unfocusedBorderColor = stateBorderColor(ReguertaInputState.DEFAULT),

--- a/android/Reguerta/app/src/main/res/values-es/strings.xml
+++ b/android/Reguerta/app/src/main/res/values-es/strings.xml
@@ -31,6 +31,9 @@
     <string name="recover_action_send_email">Enviar email de recuperación</string>
     <string name="recover_action_sending">Enviando email...</string>
     <string name="common_action_back">Volver</string>
+    <string name="common_action_clear">Borrar</string>
+    <string name="common_action_show_password">Mostrar contraseña</string>
+    <string name="common_action_hide_password">Ocultar contraseña</string>
 
     <string name="auth_error_member_unauthorized">Usuario no autorizado</string>
     <string name="access_signed_in_email_format">Email de sesión: %1$s</string>

--- a/android/Reguerta/app/src/main/res/values/strings.xml
+++ b/android/Reguerta/app/src/main/res/values/strings.xml
@@ -31,6 +31,9 @@
     <string name="recover_action_send_email">Send reset email</string>
     <string name="recover_action_sending">Sending email...</string>
     <string name="common_action_back">Back</string>
+    <string name="common_action_clear">Clear</string>
+    <string name="common_action_show_password">Show password</string>
+    <string name="common_action_hide_password">Hide password</string>
 
     <string name="auth_error_member_unauthorized">Unauthorized user</string>
     <string name="access_signed_in_email_format">Signed in email: %1$s</string>

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/access/AuthErrorMappingTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/access/AuthErrorMappingTest.kt
@@ -1,0 +1,48 @@
+package com.reguerta.user.presentation.access
+
+import com.reguerta.user.R
+import com.reguerta.user.domain.access.AuthSignInFailureReason
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AuthErrorMappingTest {
+    @Test
+    fun `maps sign in errors to field or global messages`() {
+        val invalidCredentials = mapAuthFailure(
+            reason = AuthSignInFailureReason.INVALID_CREDENTIALS,
+            flow = AuthErrorFlow.SIGN_IN,
+        )
+        assertEquals(R.string.auth_error_invalid_credentials, invalidCredentials.passwordErrorRes)
+        assertEquals(null, invalidCredentials.emailErrorRes)
+
+        val network = mapAuthFailure(
+            reason = AuthSignInFailureReason.NETWORK,
+            flow = AuthErrorFlow.SIGN_IN,
+        )
+        assertEquals(R.string.auth_error_network, network.globalMessageRes)
+    }
+
+    @Test
+    fun `maps sign up errors to register fields`() {
+        val alreadyInUse = mapAuthFailure(
+            reason = AuthSignInFailureReason.EMAIL_ALREADY_IN_USE,
+            flow = AuthErrorFlow.SIGN_UP,
+        )
+        assertEquals(R.string.auth_error_email_already_in_use, alreadyInUse.emailErrorRes)
+
+        val weakPassword = mapAuthFailure(
+            reason = AuthSignInFailureReason.WEAK_PASSWORD,
+            flow = AuthErrorFlow.SIGN_UP,
+        )
+        assertEquals(R.string.auth_error_weak_password, weakPassword.passwordErrorRes)
+    }
+
+    @Test
+    fun `maps password reset unsupported reasons to unknown global message`() {
+        val unsupported = mapAuthFailure(
+            reason = AuthSignInFailureReason.INVALID_CREDENTIALS,
+            flow = AuthErrorFlow.PASSWORD_RESET,
+        )
+        assertEquals(R.string.auth_error_unknown, unsupported.globalMessageRes)
+    }
+}

--- a/android/Reguerta/gradle/libs.versions.toml
+++ b/android/Reguerta/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 # androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "navigation3" }
 androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "navigation3" }

--- a/docs-es/design-system/components.md
+++ b/docs-es/design-system/components.md
@@ -26,20 +26,37 @@ Flujo de referencia implementado de extremo a extremo con los componentes V1:
   - Splash usa `ReguertaCard`.
   - Welcome usa `ReguertaCard` + `ReguertaButton`.
   - Login usa `ReguertaCard`, `ReguertaInputField`, `ReguertaInlineFeedback`, `ReguertaButton`.
-  - Placeholders de registro/recuperar usan `ReguertaCard` + `ReguertaButton`.
+  - Registro usa `ReguertaCard`, `ReguertaInputField`, `ReguertaButton`.
+  - Recuperar usa `ReguertaCard`, `ReguertaInputField`, `ReguertaButton`.
 - iOS: `ContentView.swift`
   - Splash usa `ReguertaCard`.
   - Welcome usa `ReguertaCard` + `ReguertaButton`.
   - Login usa `ReguertaCard`, `ReguertaInputField`, `ReguertaInlineFeedback`, `ReguertaButton`.
-  - Placeholders de registro/recuperar usan `ReguertaCard` + `ReguertaButton`.
+  - Registro usa `ReguertaCard`, `ReguertaInputField`, `ReguertaButton`.
+  - Recuperar usa `ReguertaCard`, `ReguertaInputField`, `ReguertaButton`.
 
-## 4. Reglas de contrato
+## 4. Contrato Input V2 (HU-033)
+
+- Estados canónicos: `default`, `focused`, `error`, `disabled`.
+- Icono opcional para borrar valor cuando el campo está editable y no vacío.
+- Toggle opcional de visibilidad para campos de contraseña.
+- El slot de error inline tiene prioridad sobre el helper.
+- Ninguna pantalla debe mostrar texto raw del backend/provider directamente en errores de input.
+
+Referencias actuales:
+
+- Android input: `ui/components/auth/ReguertaInputField.kt`
+- iOS input: `DesignSystem/Components/ReguertaInputField.swift`
+- Android mapeo auth: `presentation/access/AuthErrorMapping.kt`
+- iOS mapeo auth: `Presentation/Access/AuthErrorMapping.swift`
+
+## 5. Reglas de contrato
 
 - Definir APIs por comportamiento y estados explícitos, no por contexto de una pantalla concreta.
 - Mantener `enabled`, `disabled`, `loading`, `focus` y `error` visibles en el contrato del componente.
 - Consumir solo theme/tokens semánticos. Evitar colores y medidas hardcodeadas en vistas de feature.
 
-## 5. Exclusiones legacy explícitas
+## 6. Exclusiones legacy explícitas
 
 - Android `NavigationDrawerInfo` (deprecated).
 - Android params legacy en `InverseReguertaButton` (`borderSize`, `cornerSize`).

--- a/docs/design-system/components.md
+++ b/docs/design-system/components.md
@@ -26,20 +26,37 @@ Implemented reference flow (end-to-end) using the V1 components:
   - Splash route uses `ReguertaCard`.
   - Welcome route uses `ReguertaCard` + `ReguertaButton`.
   - Login route uses `ReguertaCard`, `ReguertaInputField`, `ReguertaInlineFeedback`, `ReguertaButton`.
-  - Register/recover placeholders use `ReguertaCard` + `ReguertaButton`.
+  - Register route uses `ReguertaCard`, `ReguertaInputField`, `ReguertaButton`.
+  - Recover route uses `ReguertaCard`, `ReguertaInputField`, `ReguertaButton`.
 - iOS: `ContentView.swift`
   - Splash route uses `ReguertaCard`.
   - Welcome route uses `ReguertaCard` + `ReguertaButton`.
   - Login route uses `ReguertaCard`, `ReguertaInputField`, `ReguertaInlineFeedback`, `ReguertaButton`.
-  - Register/recover placeholders use `ReguertaCard` + `ReguertaButton`.
+  - Register route uses `ReguertaCard`, `ReguertaInputField`, `ReguertaButton`.
+  - Recover route uses `ReguertaCard`, `ReguertaInputField`, `ReguertaButton`.
 
-## 4. Contract Rules
+## 4. Input V2 Contract (HU-033)
+
+- Canonical states: `default`, `focused`, `error`, `disabled`.
+- Optional clear action icon for editable non-empty values.
+- Optional password visibility toggle for secure fields.
+- Inline error slot has priority over helper slot.
+- No screen should render raw backend/provider auth text directly in input errors.
+
+Current references:
+
+- Android input component: `ui/components/auth/ReguertaInputField.kt`
+- iOS input component: `DesignSystem/Components/ReguertaInputField.swift`
+- Android auth error mapping: `presentation/access/AuthErrorMapping.kt`
+- iOS auth error mapping: `Presentation/Access/AuthErrorMapping.swift`
+
+## 5. Contract Rules
 
 - Define component APIs by behavior and explicit state, not by a single screen context.
 - Keep `enabled`, `disabled`, `loading`, `focus`, and `error` visible in the component contract.
 - Consume semantic theme/tokens only. Avoid raw colors and ad-hoc dimensions in feature views.
 
-## 5. Explicit Legacy Exclusions
+## 6. Explicit Legacy Exclusions
 
 - Android `NavigationDrawerInfo` (deprecated).
 - Android legacy params in `InverseReguertaButton` (`borderSize`, `cornerSize`).

--- a/ios/Reguerta/Reguerta.xcodeproj/project.pbxproj
+++ b/ios/Reguerta/Reguerta.xcodeproj/project.pbxproj
@@ -213,11 +213,11 @@
 			buildConfigurationList = E03FA03D2F353C1A0038B8EB /* Build configuration list for PBXProject "Reguerta" */;
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
-				knownRegions = (
-					en,
-					es,
-					Base,
-				);
+			knownRegions = (
+				en,
+				es,
+				Base,
+			);
 			mainGroup = E03FA0392F353C1A0038B8EB;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (

--- a/ios/Reguerta/Reguerta/ContentView.swift
+++ b/ios/Reguerta/Reguerta/ContentView.swift
@@ -262,6 +262,7 @@ struct ContentView: View {
                     helperMessage: localizedKey(AccessL10nKey.signedOutHint),
                     errorMessage: viewModel.emailErrorKey.map(localizedKey),
                     isEnabled: !viewModel.isAuthenticating,
+                    showsClearAction: true,
                     keyboardType: .emailAddress
                 )
 
@@ -272,6 +273,7 @@ struct ContentView: View {
                     errorMessage: viewModel.passwordErrorKey.map(localizedKey),
                     isEnabled: !viewModel.isAuthenticating,
                     isSecure: true,
+                    showsPasswordToggle: true,
                     keyboardType: .default
                 )
 
@@ -299,6 +301,7 @@ struct ContentView: View {
                     helperMessage: localizedKey(AccessL10nKey.signedOutHint),
                     errorMessage: viewModel.registerEmailErrorKey.map(localizedKey),
                     isEnabled: !viewModel.isRegistering,
+                    showsClearAction: true,
                     keyboardType: .emailAddress
                 )
 
@@ -309,6 +312,7 @@ struct ContentView: View {
                     errorMessage: viewModel.registerPasswordErrorKey.map(localizedKey),
                     isEnabled: !viewModel.isRegistering,
                     isSecure: true,
+                    showsPasswordToggle: true,
                     keyboardType: .default
                 )
 
@@ -319,6 +323,7 @@ struct ContentView: View {
                     errorMessage: viewModel.registerRepeatPasswordErrorKey.map(localizedKey),
                     isEnabled: !viewModel.isRegistering,
                     isSecure: true,
+                    showsPasswordToggle: true,
                     keyboardType: .default
                 )
 
@@ -346,6 +351,7 @@ struct ContentView: View {
                     helperMessage: localizedKey(AccessL10nKey.recoverSubtitle),
                     errorMessage: viewModel.recoverEmailErrorKey.map(localizedKey),
                     isEnabled: !viewModel.isRecoveringPassword,
+                    showsClearAction: true,
                     keyboardType: .emailAddress
                 )
 

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaInputField.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaInputField.swift
@@ -10,6 +10,7 @@ enum ReguertaInputState {
 struct ReguertaInputField: View {
     @Environment(\.reguertaTokens) private var tokens
     @FocusState private var isFocused: Bool
+    @State private var isPasswordVisible = false
 
     let label: LocalizedStringKey
     @Binding var text: String
@@ -18,6 +19,8 @@ struct ReguertaInputField: View {
     let errorMessage: LocalizedStringKey?
     let isEnabled: Bool
     let isSecure: Bool
+    let showsClearAction: Bool
+    let showsPasswordToggle: Bool
     let keyboardType: UIKeyboardType
     let trailingIcon: Image?
     let onTrailingTap: (() -> Void)?
@@ -30,6 +33,8 @@ struct ReguertaInputField: View {
         errorMessage: LocalizedStringKey? = nil,
         isEnabled: Bool = true,
         isSecure: Bool = false,
+        showsClearAction: Bool = false,
+        showsPasswordToggle: Bool = true,
         keyboardType: UIKeyboardType = .default,
         trailingIcon: Image? = nil,
         onTrailingTap: (() -> Void)? = nil
@@ -41,6 +46,8 @@ struct ReguertaInputField: View {
         self.errorMessage = errorMessage
         self.isEnabled = isEnabled
         self.isSecure = isSecure
+        self.showsClearAction = showsClearAction
+        self.showsPasswordToggle = showsPasswordToggle
         self.keyboardType = keyboardType
         self.trailingIcon = trailingIcon
         self.onTrailingTap = onTrailingTap
@@ -67,7 +74,7 @@ struct ReguertaInputField: View {
                             .foregroundStyle(tokens.colors.textSecondary.opacity(0.65))
                             .opacity(text.isEmpty ? 1 : 0)
                     }
-                    if isSecure {
+                    if isSecure && !isPasswordVisible {
                         SecureField("", text: $text)
                             .font(tokens.typography.body)
                             .disabled(!isEnabled)
@@ -84,6 +91,29 @@ struct ReguertaInputField: View {
                             .keyboardType(keyboardType)
                             .accessibilityLabel(Text(label))
                     }
+                }
+
+                if isSecure && showsPasswordToggle {
+                    Button {
+                        isPasswordVisible.toggle()
+                    } label: {
+                        Image(systemName: isPasswordVisible ? "eye.slash.fill" : "eye.fill")
+                            .foregroundStyle(tokens.colors.textSecondary)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!isEnabled)
+                    .accessibilityLabel(Text(isPasswordVisible ? "common.action.hide_password" : "common.action.show_password"))
+                }
+
+                if showsClearAction && isEnabled && !text.isEmpty {
+                    Button {
+                        text = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(tokens.colors.textSecondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(Text("common.action.clear"))
                 }
 
                 if let trailingIcon {

--- a/ios/Reguerta/Reguerta/Presentation/Access/AccessLocalization.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/AccessLocalization.swift
@@ -15,6 +15,9 @@ enum AccessL10nKey {
     static let dismissMessage = "access.action.dismiss_message"
     static let splashLoading = "auth_shell.splash.loading"
     static let commonBack = "common.action.back"
+    static let commonClear = "common.action.clear"
+    static let commonShowPassword = "common.action.show_password"
+    static let commonHidePassword = "common.action.hide_password"
 
     static let unauthorized = "auth_error.member.unauthorized"
     static let signedInEmail = "access.signed_in_email"

--- a/ios/Reguerta/Reguerta/Presentation/Access/AuthErrorMapping.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/AuthErrorMapping.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+enum AuthErrorFlow: Sendable {
+    case signIn
+    case signUp
+    case passwordReset
+}
+
+struct AuthErrorPresentation: Sendable {
+    let emailErrorKey: String?
+    let passwordErrorKey: String?
+    let globalMessageKey: String?
+
+    init(
+        emailErrorKey: String? = nil,
+        passwordErrorKey: String? = nil,
+        globalMessageKey: String? = nil
+    ) {
+        self.emailErrorKey = emailErrorKey
+        self.passwordErrorKey = passwordErrorKey
+        self.globalMessageKey = globalMessageKey
+    }
+}
+
+func mapAuthFailure(_ reason: AuthSignInFailureReason, flow: AuthErrorFlow) -> AuthErrorPresentation {
+    switch flow {
+    case .signIn:
+        switch reason {
+        case .invalidEmail:
+            AuthErrorPresentation(emailErrorKey: AccessL10nKey.feedbackEmailInvalid)
+        case .invalidCredentials:
+            AuthErrorPresentation(passwordErrorKey: AccessL10nKey.authErrorInvalidCredentials)
+        case .emailAlreadyInUse:
+            AuthErrorPresentation(emailErrorKey: AccessL10nKey.authErrorEmailAlreadyInUse)
+        case .weakPassword:
+            AuthErrorPresentation(passwordErrorKey: AccessL10nKey.authErrorWeakPassword)
+        case .userNotFound:
+            AuthErrorPresentation(emailErrorKey: AccessL10nKey.authErrorUserNotFound)
+        case .userDisabled:
+            AuthErrorPresentation(emailErrorKey: AccessL10nKey.authErrorUserDisabled)
+        case .tooManyRequests:
+            AuthErrorPresentation(globalMessageKey: AccessL10nKey.authErrorTooManyRequests)
+        case .network:
+            AuthErrorPresentation(globalMessageKey: AccessL10nKey.authErrorNetwork)
+        case .unknown:
+            AuthErrorPresentation(globalMessageKey: AccessL10nKey.authErrorUnknown)
+        }
+
+    case .signUp:
+        switch reason {
+        case .invalidEmail:
+            AuthErrorPresentation(emailErrorKey: AccessL10nKey.feedbackEmailInvalid)
+        case .invalidCredentials:
+            AuthErrorPresentation(passwordErrorKey: AccessL10nKey.authErrorInvalidCredentials)
+        case .emailAlreadyInUse:
+            AuthErrorPresentation(emailErrorKey: AccessL10nKey.authErrorEmailAlreadyInUse)
+        case .weakPassword:
+            AuthErrorPresentation(passwordErrorKey: AccessL10nKey.authErrorWeakPassword)
+        case .userNotFound:
+            AuthErrorPresentation(emailErrorKey: AccessL10nKey.authErrorUserNotFound)
+        case .userDisabled:
+            AuthErrorPresentation(emailErrorKey: AccessL10nKey.authErrorUserDisabled)
+        case .tooManyRequests:
+            AuthErrorPresentation(globalMessageKey: AccessL10nKey.authErrorTooManyRequests)
+        case .network:
+            AuthErrorPresentation(globalMessageKey: AccessL10nKey.authErrorNetwork)
+        case .unknown:
+            AuthErrorPresentation(globalMessageKey: AccessL10nKey.authErrorUnknown)
+        }
+
+    case .passwordReset:
+        switch reason {
+        case .invalidEmail:
+            AuthErrorPresentation(emailErrorKey: AccessL10nKey.feedbackEmailInvalid)
+        case .userNotFound:
+            AuthErrorPresentation(emailErrorKey: AccessL10nKey.authErrorUserNotFound)
+        case .userDisabled:
+            AuthErrorPresentation(emailErrorKey: AccessL10nKey.authErrorUserDisabled)
+        case .tooManyRequests:
+            AuthErrorPresentation(globalMessageKey: AccessL10nKey.authErrorTooManyRequests)
+        case .network:
+            AuthErrorPresentation(globalMessageKey: AccessL10nKey.authErrorNetwork)
+        case .unknown, .invalidCredentials, .emailAlreadyInUse, .weakPassword:
+            AuthErrorPresentation(globalMessageKey: AccessL10nKey.authErrorUnknown)
+        }
+    }
+}

--- a/ios/Reguerta/Reguerta/Presentation/Access/SessionViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/SessionViewModel.swift
@@ -394,72 +394,23 @@ final class SessionViewModel {
     }
 
     private func applySignInFailure(_ reason: AuthSignInFailureReason) {
-        switch reason {
-        case .invalidEmail:
-            emailErrorKey = AccessL10nKey.feedbackEmailInvalid
-        case .invalidCredentials:
-            passwordErrorKey = AccessL10nKey.authErrorInvalidCredentials
-        case .emailAlreadyInUse:
-            emailErrorKey = AccessL10nKey.authErrorEmailAlreadyInUse
-        case .weakPassword:
-            passwordErrorKey = AccessL10nKey.authErrorWeakPassword
-        case .userNotFound:
-            emailErrorKey = AccessL10nKey.authErrorUserNotFound
-        case .userDisabled:
-            emailErrorKey = AccessL10nKey.authErrorUserDisabled
-        case .tooManyRequests:
-            feedbackMessageKey = AccessL10nKey.authErrorTooManyRequests
-        case .network:
-            feedbackMessageKey = AccessL10nKey.authErrorNetwork
-        case .unknown:
-            feedbackMessageKey = AccessL10nKey.authErrorUnknown
-        }
+        let mapped = mapAuthFailure(reason, flow: .signIn)
+        emailErrorKey = mapped.emailErrorKey
+        passwordErrorKey = mapped.passwordErrorKey
+        feedbackMessageKey = mapped.globalMessageKey
     }
 
     private func applySignUpFailure(_ reason: AuthSignInFailureReason) {
-        switch reason {
-        case .invalidEmail:
-            registerEmailErrorKey = AccessL10nKey.feedbackEmailInvalid
-        case .invalidCredentials:
-            registerPasswordErrorKey = AccessL10nKey.authErrorInvalidCredentials
-        case .emailAlreadyInUse:
-            registerEmailErrorKey = AccessL10nKey.authErrorEmailAlreadyInUse
-        case .weakPassword:
-            registerPasswordErrorKey = AccessL10nKey.authErrorWeakPassword
-        case .userNotFound:
-            registerEmailErrorKey = AccessL10nKey.authErrorUserNotFound
-        case .userDisabled:
-            registerEmailErrorKey = AccessL10nKey.authErrorUserDisabled
-        case .tooManyRequests:
-            feedbackMessageKey = AccessL10nKey.authErrorTooManyRequests
-        case .network:
-            feedbackMessageKey = AccessL10nKey.authErrorNetwork
-        case .unknown:
-            feedbackMessageKey = AccessL10nKey.authErrorUnknown
-        }
+        let mapped = mapAuthFailure(reason, flow: .signUp)
+        registerEmailErrorKey = mapped.emailErrorKey
+        registerPasswordErrorKey = mapped.passwordErrorKey
+        feedbackMessageKey = mapped.globalMessageKey
     }
 
     private func applyPasswordResetFailure(_ reason: AuthSignInFailureReason) {
-        switch reason {
-        case .invalidEmail:
-            recoverEmailErrorKey = AccessL10nKey.feedbackEmailInvalid
-        case .userNotFound:
-            recoverEmailErrorKey = AccessL10nKey.authErrorUserNotFound
-        case .userDisabled:
-            recoverEmailErrorKey = AccessL10nKey.authErrorUserDisabled
-        case .tooManyRequests:
-            feedbackMessageKey = AccessL10nKey.authErrorTooManyRequests
-        case .network:
-            feedbackMessageKey = AccessL10nKey.authErrorNetwork
-        case .unknown:
-            feedbackMessageKey = AccessL10nKey.authErrorUnknown
-        case .invalidCredentials:
-            feedbackMessageKey = AccessL10nKey.authErrorUnknown
-        case .emailAlreadyInUse:
-            feedbackMessageKey = AccessL10nKey.authErrorUnknown
-        case .weakPassword:
-            feedbackMessageKey = AccessL10nKey.authErrorUnknown
-        }
+        let mapped = mapAuthFailure(reason, flow: .passwordReset)
+        recoverEmailErrorKey = mapped.emailErrorKey
+        feedbackMessageKey = mapped.globalMessageKey
     }
 
     private func applyAuthorizedSession(principal: AuthPrincipal) async {

--- a/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
+++ b/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
@@ -1121,6 +1121,54 @@
         }
       }
     },
+    "common.action.clear": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Borrar"
+          }
+        }
+      }
+    },
+    "common.action.show_password": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show password"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar contraseña"
+          }
+        }
+      }
+    },
+    "common.action.hide_password": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide password"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar contraseña"
+          }
+        }
+      }
+    },
     "welcome.title.prefix": {
       "localizations": {
         "en": {

--- a/ios/Reguerta/ReguertaTests/ReguertaTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaTests.swift
@@ -171,4 +171,17 @@ struct ReguertaTests {
         #expect(mapFirebaseAuthError(tooMany) == .tooManyRequests)
         #expect(mapFirebaseAuthError(network) == .network)
     }
+
+    @Test
+    func authErrorPresentationMappingByFlow() {
+        let signIn = mapAuthFailure(.invalidCredentials, flow: .signIn)
+        #expect(signIn.passwordErrorKey == AccessL10nKey.authErrorInvalidCredentials)
+        #expect(signIn.emailErrorKey == nil)
+
+        let signUp = mapAuthFailure(.emailAlreadyInUse, flow: .signUp)
+        #expect(signUp.emailErrorKey == AccessL10nKey.authErrorEmailAlreadyInUse)
+
+        let passwordReset = mapAuthFailure(.invalidCredentials, flow: .passwordReset)
+        #expect(passwordReset.globalMessageKey == AccessL10nKey.authErrorUnknown)
+    }
 }


### PR DESCRIPTION
## Summary
- implement Input V2 contract on both platforms (clear action, password visibility toggle, inline error slot support)
- add a shared auth error mapping layer by flow (sign-in/sign-up/password reset) on Android and iOS
- refactor auth view models to consume the new mapper and keep field vs global errors consistent
- add/update localization keys for new input actions in EN/ES
- update design-system component docs (EN/ES) with Input V2 contract and current auth routes

## Progress checklist (HU-033)
- [x] Shared auth error mapping (Android)
- [x] Shared auth error mapping (iOS)
- [x] Input V2 actions (clear/toggle) on Android
- [x] Input V2 actions (clear/toggle) on iOS
- [x] Auth screens wired to Input V2 contract
- [x] Mapper tests added/updated on Android
- [x] Mapper tests added/updated on iOS
- [x] EN/ES localization keys added
- [x] Design-system docs updated (EN/ES)

## Validation
- [x] `cd ios/Reguerta && xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test`
- [x] `cd android/Reguerta && ./gradlew app:testDebugUnitTest app:lintDebug app:connectedDebugAndroidTest`

Closes #33
