### PR TITLE
HU-023: session lifecycle refresh and expiry recovery UX

### DIFF
--- a/android/Reguerta/app/src/main/java/com/reguerta/user/data/access/FirebaseAuthSessionProvider.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/data/access/FirebaseAuthSessionProvider.kt
@@ -9,6 +9,7 @@ import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException
 import com.google.firebase.auth.FirebaseAuthInvalidUserException
 import com.reguerta.user.domain.access.AuthPrincipal
 import com.reguerta.user.domain.access.AuthPasswordResetResult
+import com.reguerta.user.domain.access.AuthSessionRefreshResult
 import com.reguerta.user.domain.access.AuthSessionProvider
 import com.reguerta.user.domain.access.AuthSignInFailureReason
 import com.reguerta.user.domain.access.AuthSignInResult
@@ -61,6 +62,45 @@ class FirebaseAuthSessionProvider(
             AuthPasswordResetResult.Success
         } catch (exception: Exception) {
             AuthPasswordResetResult.Failure(exception.toFailureReason())
+        }
+    }
+
+    override suspend fun refreshCurrentSession(): AuthSessionRefreshResult = withContext(Dispatchers.IO) {
+        val user = auth.currentUser ?: return@withContext AuthSessionRefreshResult.NoSession
+        val fallbackPrincipal = AuthPrincipal(
+            uid = user.uid,
+            email = (user.email ?: "").trim().lowercase(),
+        )
+
+        return@withContext try {
+            Tasks.await(user.reload())
+            val refreshedUser = auth.currentUser ?: return@withContext AuthSessionRefreshResult.Expired
+            Tasks.await(refreshedUser.getIdToken(false))
+
+            AuthSessionRefreshResult.Active(
+                principal = AuthPrincipal(
+                    uid = refreshedUser.uid,
+                    email = (refreshedUser.email ?: fallbackPrincipal.email).trim().lowercase(),
+                ),
+            )
+        } catch (exception: Exception) {
+            when (exception.toFailureReason()) {
+                AuthSignInFailureReason.USER_DISABLED,
+                AuthSignInFailureReason.USER_NOT_FOUND,
+                AuthSignInFailureReason.INVALID_CREDENTIALS,
+                    -> {
+                        auth.signOut()
+                        AuthSessionRefreshResult.Expired
+                    }
+
+                AuthSignInFailureReason.NETWORK,
+                AuthSignInFailureReason.TOO_MANY_REQUESTS,
+                AuthSignInFailureReason.UNKNOWN,
+                AuthSignInFailureReason.INVALID_EMAIL,
+                AuthSignInFailureReason.EMAIL_ALREADY_IN_USE,
+                AuthSignInFailureReason.WEAK_PASSWORD,
+                    -> AuthSessionRefreshResult.Active(fallbackPrincipal)
+            }
         }
     }
 

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/domain/access/AuthSessionProvider.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/domain/access/AuthSessionProvider.kt
@@ -24,12 +24,22 @@ sealed interface AuthPasswordResetResult {
     data class Failure(val reason: AuthSignInFailureReason) : AuthPasswordResetResult
 }
 
+sealed interface AuthSessionRefreshResult {
+    data object NoSession : AuthSessionRefreshResult
+
+    data class Active(val principal: AuthPrincipal) : AuthSessionRefreshResult
+
+    data object Expired : AuthSessionRefreshResult
+}
+
 interface AuthSessionProvider {
     suspend fun signIn(email: String, password: String): AuthSignInResult
 
     suspend fun signUp(email: String, password: String): AuthSignInResult
 
     suspend fun sendPasswordReset(email: String): AuthPasswordResetResult
+
+    suspend fun refreshCurrentSession(): AuthSessionRefreshResult
 
     fun signOut()
 }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/domain/access/SessionRefreshPolicy.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/domain/access/SessionRefreshPolicy.kt
@@ -1,0 +1,29 @@
+package com.reguerta.user.domain.access
+
+enum class SessionRefreshTrigger {
+    STARTUP,
+    FOREGROUND,
+}
+
+class SessionRefreshPolicy(
+    private val minimumForegroundIntervalMillis: Long = 15_000L,
+) {
+    fun shouldRefresh(
+        trigger: SessionRefreshTrigger,
+        lastRefreshAtMillis: Long?,
+        nowMillis: Long,
+        isRefreshInFlight: Boolean,
+    ): Boolean {
+        if (isRefreshInFlight) {
+            return false
+        }
+
+        return when (trigger) {
+            SessionRefreshTrigger.STARTUP -> lastRefreshAtMillis == null
+            SessionRefreshTrigger.FOREGROUND -> {
+                lastRefreshAtMillis == null ||
+                    nowMillis - lastRefreshAtMillis >= minimumForegroundIntervalMillis
+            }
+        }
+    }
+}

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/AuthShellRouting.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/AuthShellRouting.kt
@@ -24,6 +24,8 @@ sealed interface AuthShellAction {
 
     data object ContinueFromWelcome : AuthShellAction
 
+    data object Reauthenticate : AuthShellAction
+
     data object OpenRegisterFromWelcome : AuthShellAction
 
     data object OpenRegisterFromLogin : AuthShellAction
@@ -47,6 +49,7 @@ fun reduceAuthShell(
         }
 
         AuthShellAction.ContinueFromWelcome -> state.push(AuthShellRoute.LOGIN)
+        AuthShellAction.Reauthenticate -> state.resetTo(listOf(AuthShellRoute.WELCOME, AuthShellRoute.LOGIN))
         AuthShellAction.OpenRegisterFromWelcome -> state.push(AuthShellRoute.REGISTER)
         AuthShellAction.OpenRegisterFromLogin -> state.push(AuthShellRoute.REGISTER)
         AuthShellAction.OpenRecoverFromLogin -> state.push(AuthShellRoute.RECOVER_PASSWORD)
@@ -62,6 +65,9 @@ private fun AuthShellState.push(route: AuthShellRoute): AuthShellState {
 
 private fun AuthShellState.resetTo(route: AuthShellRoute): AuthShellState =
     copy(backStack = listOf(route))
+
+private fun AuthShellState.resetTo(routes: List<AuthShellRoute>): AuthShellState =
+    copy(backStack = routes)
 
 private fun AuthShellState.popOrStay(): AuthShellState {
     if (!canGoBack) return this

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRoot.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRoot.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -59,6 +60,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
@@ -74,6 +78,7 @@ import com.reguerta.user.domain.access.Member
 import com.reguerta.user.domain.access.MemberRole
 import com.reguerta.user.domain.freshness.ResolveCriticalDataFreshnessUseCase
 import com.reguerta.user.domain.access.ResolveAuthorizedSessionUseCase
+import com.reguerta.user.domain.access.SessionRefreshTrigger
 import com.reguerta.user.domain.access.UnauthorizedReason
 import com.reguerta.user.domain.access.UpsertMemberByAdminUseCase
 import com.reguerta.user.domain.startup.ResolveStartupVersionGateUseCase
@@ -135,6 +140,7 @@ fun ReguertaRoot(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
     val spacing = ReguertaThemeTokens.spacing
     val installedVersion = remember(context) {
         resolveInstalledVersionName(context)
@@ -173,6 +179,10 @@ fun ReguertaRoot(
     }
 
     LaunchedEffect(viewModel) {
+        viewModel.refreshSession(SessionRefreshTrigger.STARTUP)
+    }
+
+    LaunchedEffect(viewModel) {
         viewModel.uiEvents.collect { event ->
             if (event is SessionUiEvent.ShowMessage) {
                 snackbarHostState.showSnackbar(context.getString(event.messageRes))
@@ -180,12 +190,29 @@ fun ReguertaRoot(
         }
     }
 
-    LaunchedEffect(isAuthenticatedSession) {
+    LaunchedEffect(state.mode) {
         if (isAuthenticatedSession && shellState.currentRoute != AuthShellRoute.SPLASH) {
             shellState = reduceAuthShell(
                 state = shellState,
                 action = AuthShellAction.SessionAuthenticated,
             )
+        } else if (state.mode is SessionMode.SignedOut && shellState.currentRoute == AuthShellRoute.HOME) {
+            shellState = reduceAuthShell(
+                state = shellState,
+                action = AuthShellAction.SignedOut,
+            )
+        }
+    }
+
+    DisposableEffect(lifecycleOwner, viewModel) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_START) {
+                viewModel.refreshSession(SessionRefreshTrigger.FOREGROUND)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
 
@@ -221,6 +248,14 @@ fun ReguertaRoot(
             AuthShellRoute.HOME,
                 -> Unit
         }
+    }
+    val routeToReauthentication = {
+        viewModel.dismissSessionExpiredDialog()
+        viewModel.clearLoginForm()
+        shellState = reduceAuthShell(
+            state = shellState,
+            action = AuthShellAction.Reauthenticate,
+        )
     }
 
     BackHandler(enabled = shellState.canGoBack) {
@@ -356,6 +391,19 @@ fun ReguertaRoot(
                         onDismissOptional = {
                             startupGateState = StartupGateUiState.OptionalDismissed
                         },
+                    )
+                }
+
+                if (state.showSessionExpiredDialog) {
+                    ReguertaDialog(
+                        type = ReguertaDialogType.ERROR,
+                        title = stringResource(R.string.session_expired_dialog_title),
+                        message = stringResource(R.string.session_expired_dialog_message),
+                        primaryAction = ReguertaDialogAction(
+                            label = stringResource(R.string.session_expired_dialog_action),
+                            onClick = routeToReauthentication,
+                        ),
+                        onDismissRequest = routeToReauthentication,
                     )
                 }
             }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionViewModel.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionViewModel.kt
@@ -7,6 +7,7 @@ import com.reguerta.user.R
 import com.reguerta.user.domain.access.AccessResolutionResult
 import com.reguerta.user.domain.access.AuthPasswordResetResult
 import com.reguerta.user.domain.access.AuthPrincipal
+import com.reguerta.user.domain.access.AuthSessionRefreshResult
 import com.reguerta.user.domain.access.AuthSessionProvider
 import com.reguerta.user.domain.access.AuthSignInResult
 import com.reguerta.user.domain.access.Member
@@ -14,6 +15,8 @@ import com.reguerta.user.domain.access.MemberManagementException
 import com.reguerta.user.domain.access.MemberRepository
 import com.reguerta.user.domain.access.MemberRole
 import com.reguerta.user.domain.access.ResolveAuthorizedSessionUseCase
+import com.reguerta.user.domain.access.SessionRefreshPolicy
+import com.reguerta.user.domain.access.SessionRefreshTrigger
 import com.reguerta.user.domain.access.UnauthorizedReason
 import com.reguerta.user.domain.access.UpsertMemberByAdminUseCase
 import com.reguerta.user.domain.freshness.CriticalDataFreshnessLocalRepository
@@ -28,6 +31,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.atomic.AtomicBoolean
 
 data class MemberDraft(
     val displayName: String = "",
@@ -70,6 +74,7 @@ data class SessionUiState(
     @param:StringRes val recoverEmailErrorRes: Int? = null,
     val isRecoveringPassword: Boolean = false,
     val showRecoverSuccessDialog: Boolean = false,
+    val showSessionExpiredDialog: Boolean = false,
     val mode: SessionMode = SessionMode.SignedOut,
     val memberDraft: MemberDraft = MemberDraft(),
     val myOrderFreshnessState: MyOrderFreshnessUiState = MyOrderFreshnessUiState.Idle,
@@ -98,12 +103,16 @@ class SessionViewModel(
     private val upsertMemberByAdmin: UpsertMemberByAdminUseCase,
     private val resolveCriticalDataFreshness: ResolveCriticalDataFreshnessUseCase,
     private val criticalDataFreshnessLocalRepository: CriticalDataFreshnessLocalRepository,
+    private val sessionRefreshPolicy: SessionRefreshPolicy = SessionRefreshPolicy(),
+    private val nowMillisProvider: () -> Long = { System.currentTimeMillis() },
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(SessionUiState())
     val uiState: StateFlow<SessionUiState> = _uiState.asStateFlow()
 
     private val _uiEvents = MutableSharedFlow<SessionUiEvent>(replay = 0)
     val uiEvents: SharedFlow<SessionUiEvent> = _uiEvents.asSharedFlow()
+    private val isSessionRefreshInFlight = AtomicBoolean(false)
+    private var lastSessionRefreshAtMillis: Long? = null
 
     fun onEmailChanged(value: String) {
         _uiState.update {
@@ -201,6 +210,10 @@ class SessionViewModel(
 
     fun dismissRecoverSuccessDialog() {
         _uiState.update { it.copy(showRecoverSuccessDialog = false) }
+    }
+
+    fun dismissSessionExpiredDialog() {
+        _uiState.update { it.copy(showSessionExpiredDialog = false) }
     }
 
     fun signIn() {
@@ -444,6 +457,7 @@ class SessionViewModel(
 
     fun signOut() {
         authSessionProvider.signOut()
+        clearSessionRefreshTracking()
         viewModelScope.launch {
             criticalDataFreshnessLocalRepository.clear()
         }
@@ -465,9 +479,54 @@ class SessionViewModel(
                 recoverEmailErrorRes = null,
                 isRecoveringPassword = false,
                 showRecoverSuccessDialog = false,
+                showSessionExpiredDialog = false,
                 memberDraft = MemberDraft(),
                 myOrderFreshnessState = MyOrderFreshnessUiState.Idle,
             )
+        }
+    }
+
+    fun refreshSession(trigger: SessionRefreshTrigger) {
+        val nowMillis = nowMillisProvider()
+        if (!sessionRefreshPolicy.shouldRefresh(
+                trigger = trigger,
+                lastRefreshAtMillis = lastSessionRefreshAtMillis,
+                nowMillis = nowMillis,
+                isRefreshInFlight = isSessionRefreshInFlight.get(),
+            )
+        ) {
+            return
+        }
+        if (!isSessionRefreshInFlight.compareAndSet(false, true)) {
+            return
+        }
+
+        viewModelScope.launch {
+            val hadAuthenticatedSession = _uiState.value.mode.isAuthenticatedSession()
+            try {
+                when (val result = authSessionProvider.refreshCurrentSession()) {
+                    AuthSessionRefreshResult.NoSession -> {
+                        if (hadAuthenticatedSession) {
+                            handleExpiredSession()
+                        }
+                    }
+
+                    is AuthSessionRefreshResult.Active -> {
+                        val shouldRefreshCriticalData = !hadAuthenticatedSession || shouldRefreshCriticalDataFor(result.principal)
+                        applyAuthorizedSession(
+                            principal = result.principal,
+                            shouldRefreshCriticalData = shouldRefreshCriticalData,
+                        )
+                    }
+
+                    AuthSessionRefreshResult.Expired -> {
+                        handleExpiredSession()
+                    }
+                }
+            } finally {
+                lastSessionRefreshAtMillis = nowMillisProvider()
+                isSessionRefreshInFlight.set(false)
+            }
         }
     }
 
@@ -623,6 +682,90 @@ class SessionViewModel(
         }
     }
 
+    private suspend fun applyAuthorizedSession(
+        principal: AuthPrincipal,
+        shouldRefreshCriticalData: Boolean,
+    ) {
+        when (val result = resolveAuthorizedSession(principal)) {
+            is AccessResolutionResult.Authorized -> {
+                val members = repository.getAllMembers()
+                _uiState.update {
+                    it.copy(
+                        mode = SessionMode.Authorized(
+                            principal = principal,
+                            member = result.member,
+                            members = members,
+                        ),
+                        showSessionExpiredDialog = false,
+                        myOrderFreshnessState = if (shouldRefreshCriticalData) {
+                            MyOrderFreshnessUiState.Checking
+                        } else {
+                            it.myOrderFreshnessState
+                        },
+                    )
+                }
+                if (shouldRefreshCriticalData) {
+                    refreshMyOrderFreshness()
+                }
+            }
+
+            is AccessResolutionResult.Unauthorized -> {
+                _uiState.update {
+                    it.copy(
+                        mode = SessionMode.Unauthorized(
+                            email = principal.email,
+                            reason = result.reason,
+                        ),
+                        showSessionExpiredDialog = false,
+                        myOrderFreshnessState = MyOrderFreshnessUiState.Idle,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun shouldRefreshCriticalDataFor(principal: AuthPrincipal): Boolean {
+        val currentMode = _uiState.value.mode
+        return when (currentMode) {
+            SessionMode.SignedOut -> true
+            is SessionMode.Unauthorized -> currentMode.email != principal.email
+            is SessionMode.Authorized -> currentMode.principal.uid != principal.uid
+        }
+    }
+
+    private suspend fun handleExpiredSession() {
+        clearSessionRefreshTracking()
+        criticalDataFreshnessLocalRepository.clear()
+        _uiState.update {
+            it.copy(
+                mode = SessionMode.SignedOut,
+                passwordInput = "",
+                emailErrorRes = null,
+                passwordErrorRes = null,
+                isAuthenticating = false,
+                registerEmailInput = "",
+                registerPasswordInput = "",
+                registerRepeatPasswordInput = "",
+                registerEmailErrorRes = null,
+                registerPasswordErrorRes = null,
+                registerRepeatPasswordErrorRes = null,
+                isRegistering = false,
+                recoverEmailInput = "",
+                recoverEmailErrorRes = null,
+                isRecoveringPassword = false,
+                showRecoverSuccessDialog = false,
+                showSessionExpiredDialog = true,
+                memberDraft = MemberDraft(),
+                myOrderFreshnessState = MyOrderFreshnessUiState.Idle,
+            )
+        }
+    }
+
+    private fun clearSessionRefreshTracking() {
+        lastSessionRefreshAtMillis = null
+        isSessionRefreshInFlight.set(false)
+    }
+
     private fun buildRoles(draft: MemberDraft): Set<MemberRole> {
         val roles = mutableSetOf<MemberRole>()
         if (draft.isMember) roles.add(MemberRole.MEMBER)
@@ -643,3 +786,6 @@ private const val PasswordMinLength = 6
 private const val PasswordMaxLength = 16
 
 private fun String.isValidPassword(): Boolean = length in PasswordMinLength..PasswordMaxLength
+
+private fun SessionMode.isAuthenticatedSession(): Boolean =
+    this is SessionMode.Authorized || this is SessionMode.Unauthorized

--- a/android/Reguerta/app/src/main/res/values-es/strings.xml
+++ b/android/Reguerta/app/src/main/res/values-es/strings.xml
@@ -38,6 +38,9 @@
     <string name="recover_action_sending">Enviando email…</string>
     <string name="recover_success_dialog_title">Recuperar contraseña</string>
     <string name="recover_success_dialog_message">Se ha enviado el correo de restablecimiento de la contraseña con éxito. Revisa tu correo.</string>
+    <string name="session_expired_dialog_title">Sesión caducada</string>
+    <string name="session_expired_dialog_message">Tu sesión ya no es válida. Vuelve a iniciar sesión para continuar de forma segura.</string>
+    <string name="session_expired_dialog_action">Iniciar sesión otra vez</string>
     <string name="common_action_back">Volver</string>
     <string name="common_action_accept">Aceptar</string>
     <string name="common_action_clear">Borrar</string>

--- a/android/Reguerta/app/src/main/res/values/strings.xml
+++ b/android/Reguerta/app/src/main/res/values/strings.xml
@@ -38,6 +38,9 @@
     <string name="recover_action_sending">Sending email…</string>
     <string name="recover_success_dialog_title">Recover password</string>
     <string name="recover_success_dialog_message">The password reset email was sent successfully. Check your inbox.</string>
+    <string name="session_expired_dialog_title">Session expired</string>
+    <string name="session_expired_dialog_message">Your session is no longer valid. Sign in again to continue safely.</string>
+    <string name="session_expired_dialog_action">Sign in again</string>
     <string name="common_action_back">Back</string>
     <string name="common_action_accept">Accept</string>
     <string name="common_action_clear">Clear</string>

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/domain/access/SessionRefreshPolicyTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/domain/access/SessionRefreshPolicyTest.kt
@@ -1,0 +1,60 @@
+package com.reguerta.user.domain.access
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SessionRefreshPolicyTest {
+    private val policy = SessionRefreshPolicy(minimumForegroundIntervalMillis = 15_000L)
+
+    @Test
+    fun `startup refresh only runs once per cold session`() {
+        assertTrue(
+            policy.shouldRefresh(
+                trigger = SessionRefreshTrigger.STARTUP,
+                lastRefreshAtMillis = null,
+                nowMillis = 1_000L,
+                isRefreshInFlight = false,
+            ),
+        )
+
+        assertFalse(
+            policy.shouldRefresh(
+                trigger = SessionRefreshTrigger.STARTUP,
+                lastRefreshAtMillis = 1_000L,
+                nowMillis = 2_000L,
+                isRefreshInFlight = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `foreground refresh is debounced and blocked while in flight`() {
+        assertFalse(
+            policy.shouldRefresh(
+                trigger = SessionRefreshTrigger.FOREGROUND,
+                lastRefreshAtMillis = 10_000L,
+                nowMillis = 20_000L,
+                isRefreshInFlight = true,
+            ),
+        )
+
+        assertFalse(
+            policy.shouldRefresh(
+                trigger = SessionRefreshTrigger.FOREGROUND,
+                lastRefreshAtMillis = 10_000L,
+                nowMillis = 20_000L,
+                isRefreshInFlight = false,
+            ),
+        )
+
+        assertTrue(
+            policy.shouldRefresh(
+                trigger = SessionRefreshTrigger.FOREGROUND,
+                lastRefreshAtMillis = 10_000L,
+                nowMillis = 25_000L,
+                isRefreshInFlight = false,
+            ),
+        )
+    }
+}

--- a/ios/Reguerta/Reguerta/ContentView.swift
+++ b/ios/Reguerta/Reguerta/ContentView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ContentView: View {
     @Environment(\.openURL) private var openURL
     @Environment(\.reguertaTokens) private var tokens
+    @Environment(\.scenePhase) private var scenePhase
     @State private var viewModel = SessionViewModel()
     @State private var shellState = AuthShellState()
     @State private var splashScale: CGFloat = SplashAnimationContract.initialScale
@@ -75,17 +76,36 @@ struct ContentView: View {
                     onDismiss: handleRecoverSuccessDialogDismiss
                 )
             }
+            if viewModel.showSessionExpiredDialog {
+                ReguertaDialog(
+                    type: .error,
+                    title: l10n(AccessL10nKey.sessionExpiredTitle),
+                    message: l10n(AccessL10nKey.sessionExpiredMessage),
+                    primaryAction: ReguertaDialogAction(
+                        title: l10n(AccessL10nKey.sessionExpiredAction),
+                        action: handleSessionExpiredDialogAction
+                    ),
+                    onDismiss: handleSessionExpiredDialogAction
+                )
+            }
         }
         .task(id: shellState.currentRoute) {
             await handleSplashIfNeeded()
         }
         .task {
+            viewModel.refreshSession(trigger: .startup)
             await evaluateStartupGateIfNeeded()
         }
         .onChange(of: viewModel.mode) { _, mode in
             if mode.isAuthenticatedSession, shellState.currentRoute != .splash {
                 dispatchShell(.sessionAuthenticated)
+            } else if mode == .signedOut, shellState.currentRoute == .home {
+                dispatchShell(.signedOut)
             }
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            guard newPhase == .active else { return }
+            viewModel.refreshSession(trigger: .foreground)
         }
         .onChange(of: startupGateState) { _, _ in
             continueFromSplashIfAllowed()
@@ -719,6 +739,12 @@ struct ContentView: View {
 
     private func dispatchShell(_ action: AuthShellAction) {
         shellState = reduceAuthShell(state: shellState, action: action)
+    }
+
+    private func handleSessionExpiredDialogAction() {
+        viewModel.dismissSessionExpiredDialog()
+        viewModel.resetSignInDraft()
+        dispatchShell(.reauthenticate)
     }
 
     private func handleSplashIfNeeded() async {

--- a/ios/Reguerta/Reguerta/Data/Access/FirebaseAuthSessionProvider.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/FirebaseAuthSessionProvider.swift
@@ -1,6 +1,8 @@
 import FirebaseAuth
 import Foundation
 
+extension User: @retroactive @unchecked Sendable {}
+
 struct FirebaseAuthSessionProvider: AuthSessionProvider {
     private let auth: Auth
 
@@ -49,11 +51,45 @@ struct FirebaseAuthSessionProvider: AuthSessionProvider {
         }
     }
 
+    func refreshCurrentSession() async -> AuthSessionRefreshResult {
+        guard let user = auth.currentUser else {
+            return .noSession
+        }
+
+        let fallbackPrincipal = AuthPrincipal(
+            uid: user.uid,
+            email: (user.email ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        )
+
+        do {
+            try await user.reload()
+            guard let refreshedUser = auth.currentUser else {
+                return .expired
+            }
+            _ = try await refreshedUser.getIDTokenResult(forcingRefresh: false)
+
+            let principal = AuthPrincipal(
+                uid: refreshedUser.uid,
+                email: (refreshedUser.email ?? fallbackPrincipal.email)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .lowercased()
+            )
+            return .active(principal)
+        } catch {
+            if isExpiredSessionError(error) {
+                try? auth.signOut()
+                return .expired
+            }
+            return .active(fallbackPrincipal)
+        }
+    }
+
     func signOut() {
         try? auth.signOut()
     }
 }
 
+@MainActor
 func mapFirebaseAuthError(_ error: Error) -> AuthSignInFailureReason {
     let nsError = error as NSError
     guard let code = AuthErrorCode(rawValue: nsError.code) else {
@@ -79,5 +115,20 @@ func mapFirebaseAuthError(_ error: Error) -> AuthSignInFailureReason {
         return .network
     default:
         return .unknown
+    }
+}
+
+@MainActor
+private func isExpiredSessionError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    guard let code = AuthErrorCode(rawValue: nsError.code) else {
+        return false
+    }
+
+    switch code {
+    case .userDisabled, .userNotFound, .invalidCredential, .userTokenExpired, .invalidUserToken:
+        return true
+    default:
+        return false
     }
 }

--- a/ios/Reguerta/Reguerta/Data/Access/MockAuthSessionProvider.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/MockAuthSessionProvider.swift
@@ -1,22 +1,21 @@
 import Foundation
 
-struct MockAuthSessionProvider: AuthSessionProvider {
+@MainActor
+final class MockAuthSessionProvider: AuthSessionProvider {
+    private var currentPrincipal: AuthPrincipal?
+
     func signIn(email: String, password: String) async -> AuthSignInResult {
         guard password == "test1234" else {
             return .failure(.invalidCredentials)
         }
 
-        let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        let uidSuffix = normalizedEmail
-            .replacingOccurrences(of: "[^a-z0-9]+", with: "_", options: .regularExpression)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "_"))
-        let uid = "mock_\(uidSuffix.isEmpty ? "user" : uidSuffix)"
-
-        return .success(AuthPrincipal(uid: uid, email: normalizedEmail))
+        let principal = buildPrincipal(from: email)
+        currentPrincipal = principal
+        return .success(principal)
     }
 
     func signUp(email: String, password: String) async -> AuthSignInResult {
-        if !password.isValidMockPassword {
+        if !(6...16).contains(password.count) {
             return .failure(.weakPassword)
         }
 
@@ -24,12 +23,10 @@ struct MockAuthSessionProvider: AuthSessionProvider {
         if normalizedEmail.contains("exists") {
             return .failure(.emailAlreadyInUse)
         }
-        let uidSuffix = normalizedEmail
-            .replacingOccurrences(of: "[^a-z0-9]+", with: "_", options: .regularExpression)
-            .trimmingCharacters(in: CharacterSet(charactersIn: "_"))
-        let uid = "mock_\(uidSuffix.isEmpty ? "user" : uidSuffix)"
 
-        return .success(AuthPrincipal(uid: uid, email: normalizedEmail))
+        let principal = buildPrincipal(from: email)
+        currentPrincipal = principal
+        return .success(principal)
     }
 
     func sendPasswordReset(email: String) async -> AuthPasswordResetResult {
@@ -40,12 +37,23 @@ struct MockAuthSessionProvider: AuthSessionProvider {
         return .success
     }
 
-    func signOut() {
+    func refreshCurrentSession() async -> AuthSessionRefreshResult {
+        guard let currentPrincipal else {
+            return .noSession
+        }
+        return .active(currentPrincipal)
     }
-}
 
-private extension String {
-    var isValidMockPassword: Bool {
-        (6...16).contains(count)
+    func signOut() {
+        currentPrincipal = nil
+    }
+
+    private func buildPrincipal(from email: String) -> AuthPrincipal {
+        let normalizedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let uidSuffix = normalizedEmail
+            .replacingOccurrences(of: "[^a-z0-9]+", with: "_", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+        let uid = "mock_\(uidSuffix.isEmpty ? "user" : uidSuffix)"
+        return AuthPrincipal(uid: uid, email: normalizedEmail)
     }
 }

--- a/ios/Reguerta/Reguerta/Domain/Access/AuthSessionProvider.swift
+++ b/ios/Reguerta/Reguerta/Domain/Access/AuthSessionProvider.swift
@@ -22,9 +22,17 @@ enum AuthPasswordResetResult: Equatable, Sendable {
     case failure(AuthSignInFailureReason)
 }
 
-protocol AuthSessionProvider: Sendable {
+enum AuthSessionRefreshResult: Equatable, Sendable {
+    case noSession
+    case active(AuthPrincipal)
+    case expired
+}
+
+@MainActor
+protocol AuthSessionProvider {
     func signIn(email: String, password: String) async -> AuthSignInResult
     func signUp(email: String, password: String) async -> AuthSignInResult
     func sendPasswordReset(email: String) async -> AuthPasswordResetResult
+    func refreshCurrentSession() async -> AuthSessionRefreshResult
     func signOut()
 }

--- a/ios/Reguerta/Reguerta/Domain/Access/SessionRefreshPolicy.swift
+++ b/ios/Reguerta/Reguerta/Domain/Access/SessionRefreshPolicy.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum SessionRefreshTrigger: Sendable {
+    case startup
+    case foreground
+}
+
+struct SessionRefreshPolicy: Sendable {
+    let minimumForegroundIntervalMillis: Int64
+
+    init(minimumForegroundIntervalMillis: Int64 = 15_000) {
+        self.minimumForegroundIntervalMillis = minimumForegroundIntervalMillis
+    }
+
+    func shouldRefresh(
+        trigger: SessionRefreshTrigger,
+        lastRefreshAtMillis: Int64?,
+        nowMillis: Int64,
+        isRefreshInFlight: Bool
+    ) -> Bool {
+        if isRefreshInFlight {
+            return false
+        }
+
+        switch trigger {
+        case .startup:
+            return lastRefreshAtMillis == nil
+        case .foreground:
+            guard let lastRefreshAtMillis else { return true }
+            return nowMillis - lastRefreshAtMillis >= minimumForegroundIntervalMillis
+        }
+    }
+}

--- a/ios/Reguerta/Reguerta/Presentation/Access/AccessLocalization.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/AccessLocalization.swift
@@ -48,6 +48,9 @@ enum AccessL10nKey {
     static let recoverSubtitle = "recover.subtitle"
     static let recoverActionSendEmail = "recover.action.send_email"
     static let recoverActionSending = "recover.action.sending"
+    static let sessionExpiredTitle = "session.expired.title"
+    static let sessionExpiredMessage = "session.expired.message"
+    static let sessionExpiredAction = "session.expired.action"
 
     static let homeTitle = "home.title"
     static let homeWelcome = "home.welcome"

--- a/ios/Reguerta/Reguerta/Presentation/Access/AuthShellRouting.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/AuthShellRouting.swift
@@ -24,6 +24,7 @@ struct AuthShellState: Equatable, Sendable {
 enum AuthShellAction: Equatable, Sendable {
     case splashCompleted(isAuthenticated: Bool)
     case continueFromWelcome
+    case reauthenticate
     case openRegisterFromWelcome
     case openRegisterFromLogin
     case openRecoverFromLogin
@@ -38,6 +39,8 @@ func reduceAuthShell(state: AuthShellState, action: AuthShellAction) -> AuthShel
         return state.resetTo(isAuthenticated ? .home : .welcome)
     case .continueFromWelcome:
         return state.push(.login)
+    case .reauthenticate:
+        return state.resetTo([.welcome, .login])
     case .openRegisterFromWelcome:
         return state.push(.register)
     case .openRegisterFromLogin:
@@ -61,6 +64,10 @@ private extension AuthShellState {
 
     func resetTo(_ route: AuthShellRoute) -> AuthShellState {
         AuthShellState(backStack: [route])
+    }
+
+    func resetTo(_ routes: [AuthShellRoute]) -> AuthShellState {
+        AuthShellState(backStack: routes)
     }
 
     func popOrStay() -> AuthShellState {

--- a/ios/Reguerta/Reguerta/Presentation/Access/SessionViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/SessionViewModel.swift
@@ -83,6 +83,7 @@ final class SessionViewModel {
     var isAuthenticating = false
     var isRegistering = false
     var isRecoveringPassword = false
+    var showSessionExpiredDialog = false
     var mode: SessionMode = .signedOut
     var memberDraft = MemberDraft()
     var feedbackMessageKey: String?
@@ -94,6 +95,10 @@ final class SessionViewModel {
     private let upsertMemberByAdmin: UpsertMemberByAdminUseCase
     private let resolveCriticalDataFreshness: ResolveCriticalDataFreshnessUseCase
     private let criticalDataFreshnessLocalRepository: any CriticalDataFreshnessLocalRepository
+    private let sessionRefreshPolicy: SessionRefreshPolicy
+    private let nowMillisProvider: @Sendable () -> Int64
+    private var lastSessionRefreshAtMillis: Int64?
+    private var isSessionRefreshInFlight = false
 
     var canSubmitSignIn: Bool {
         !isAuthenticating &&
@@ -127,7 +132,9 @@ final class SessionViewModel {
         repository: (any MemberRepository)? = nil,
         authSessionProvider: (any AuthSessionProvider)? = nil,
         resolveAuthorizedSession: ResolveAuthorizedSessionUseCase? = nil,
-        upsertMemberByAdmin: UpsertMemberByAdminUseCase? = nil
+        upsertMemberByAdmin: UpsertMemberByAdminUseCase? = nil,
+        sessionRefreshPolicy: SessionRefreshPolicy = SessionRefreshPolicy(),
+        nowMillisProvider: @escaping @Sendable () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1_000) }
     ) {
         let selectedRepository = repository ?? ChainedMemberRepository(
             primary: FirestoreMemberRepository(),
@@ -162,6 +169,8 @@ final class SessionViewModel {
             localRepository: freshnessLocalRepository
         )
         self.criticalDataFreshnessLocalRepository = freshnessLocalRepository
+        self.sessionRefreshPolicy = sessionRefreshPolicy
+        self.nowMillisProvider = nowMillisProvider
     }
 
     func signIn() {
@@ -223,6 +232,7 @@ final class SessionViewModel {
 
     func signOut() {
         authSessionProvider.signOut()
+        clearSessionRefreshTracking()
         emailInput = ""
         passwordInput = ""
         registerEmailInput = ""
@@ -238,12 +248,55 @@ final class SessionViewModel {
         isAuthenticating = false
         isRegistering = false
         isRecoveringPassword = false
+        showSessionExpiredDialog = false
         feedbackMessageKey = nil
         mode = .signedOut
         memberDraft = MemberDraft()
         myOrderFreshnessState = .idle
         Task {
             await criticalDataFreshnessLocalRepository.clear()
+        }
+    }
+
+    func dismissSessionExpiredDialog() {
+        showSessionExpiredDialog = false
+    }
+
+    func refreshSession(trigger: SessionRefreshTrigger) {
+        let nowMillis = nowMillisProvider()
+        guard sessionRefreshPolicy.shouldRefresh(
+            trigger: trigger,
+            lastRefreshAtMillis: lastSessionRefreshAtMillis,
+            nowMillis: nowMillis,
+            isRefreshInFlight: isSessionRefreshInFlight
+        ) else {
+            return
+        }
+
+        isSessionRefreshInFlight = true
+        let hadAuthenticatedSession = mode.isAuthenticatedSession
+
+        Task { @MainActor in
+            defer {
+                lastSessionRefreshAtMillis = nowMillisProvider()
+                isSessionRefreshInFlight = false
+            }
+
+            let result = await authSessionProvider.refreshCurrentSession()
+            switch result {
+            case .noSession:
+                if hadAuthenticatedSession {
+                    await handleExpiredSession()
+                }
+            case .active(let principal):
+                let shouldRefreshCriticalData = !hadAuthenticatedSession || shouldRefreshCriticalData(for: principal)
+                await applyAuthorizedSession(
+                    principal: principal,
+                    shouldRefreshCriticalData: shouldRefreshCriticalData
+                )
+            case .expired:
+                await handleExpiredSession()
+            }
         }
     }
 
@@ -519,7 +572,10 @@ final class SessionViewModel {
         feedbackMessageKey = mapped.globalMessageKey
     }
 
-    private func applyAuthorizedSession(principal: AuthPrincipal) async {
+    private func applyAuthorizedSession(
+        principal: AuthPrincipal,
+        shouldRefreshCriticalData: Bool = true
+    ) async {
         let result = await resolveAuthorizedSession.execute(authPrincipal: principal)
         switch result {
         case .authorized(let member):
@@ -531,12 +587,57 @@ final class SessionViewModel {
                     members: members
                 )
             )
-            myOrderFreshnessState = .checking
-            refreshMyOrderFreshness()
+            showSessionExpiredDialog = false
+            if shouldRefreshCriticalData {
+                myOrderFreshnessState = .checking
+                refreshMyOrderFreshness()
+            }
         case .unauthorized(let reason):
             mode = .unauthorized(email: principal.email, reason: reason)
+            showSessionExpiredDialog = false
             myOrderFreshnessState = .idle
         }
+    }
+
+    private func shouldRefreshCriticalData(for principal: AuthPrincipal) -> Bool {
+        switch mode {
+        case .signedOut:
+            return true
+        case .unauthorized(let email, _):
+            return email != principal.email
+        case .authorized(let session):
+            return session.principal.uid != principal.uid
+        }
+    }
+
+    private func handleExpiredSession() async {
+        clearSessionRefreshTracking()
+        emailInput = ""
+        passwordInput = ""
+        registerEmailInput = ""
+        registerPasswordInput = ""
+        registerRepeatPasswordInput = ""
+        recoverEmailInput = ""
+        emailErrorKey = nil
+        passwordErrorKey = nil
+        registerEmailErrorKey = nil
+        registerPasswordErrorKey = nil
+        registerRepeatPasswordErrorKey = nil
+        recoverEmailErrorKey = nil
+        isAuthenticating = false
+        isRegistering = false
+        isRecoveringPassword = false
+        feedbackMessageKey = nil
+        mode = .signedOut
+        memberDraft = MemberDraft()
+        myOrderFreshnessState = .idle
+        showSessionExpiredDialog = true
+        await criticalDataFreshnessLocalRepository.clear()
+    }
+
+    private func clearSessionRefreshTracking() {
+        lastSessionRefreshAtMillis = nil
+        isSessionRefreshInFlight = false
     }
 
     private func persistMember(target: Member, session: AuthorizedSession) async {

--- a/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
+++ b/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
@@ -1535,6 +1535,57 @@
         }
       }
     },
+    "session.expired.action" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in again"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar sesión otra vez"
+          }
+        }
+      }
+    },
+    "session.expired.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your session is no longer valid. Sign in again to continue safely."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tu sesión ya no es válida. Vuelve a iniciar sesión para continuar de forma segura."
+          }
+        }
+      }
+    },
+    "session.expired.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session expired"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sesión caducada"
+          }
+        }
+      }
+    },
     "startup.update.action.later" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/ios/Reguerta/ReguertaTests/ReguertaTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaTests.swift
@@ -354,6 +354,87 @@ struct ReguertaTests {
 
         #expect(evaluation == .accepted(metadataToPersist: nil))
     }
+
+    @Test
+    func sessionRefreshPolicyDebouncesForegroundTransitions() {
+        let policy = SessionRefreshPolicy(minimumForegroundIntervalMillis: 15_000)
+
+        #expect(policy.shouldRefresh(
+            trigger: .startup,
+            lastRefreshAtMillis: nil,
+            nowMillis: 1_000,
+            isRefreshInFlight: false
+        ))
+        #expect(!policy.shouldRefresh(
+            trigger: .startup,
+            lastRefreshAtMillis: 1_000,
+            nowMillis: 2_000,
+            isRefreshInFlight: false
+        ))
+        #expect(!policy.shouldRefresh(
+            trigger: .foreground,
+            lastRefreshAtMillis: 10_000,
+            nowMillis: 20_000,
+            isRefreshInFlight: false
+        ))
+        #expect(policy.shouldRefresh(
+            trigger: .foreground,
+            lastRefreshAtMillis: 10_000,
+            nowMillis: 25_000,
+            isRefreshInFlight: false
+        ))
+    }
+
+    @Test
+    func startupRefreshRestoresAuthorizedSession() async {
+        let provider = TestAuthSessionProvider(
+            refreshResult: .active(AuthPrincipal(uid: "uid_admin_restore", email: "ana.admin@reguerta.app"))
+        )
+        let viewModel = SessionViewModel(
+            repository: InMemoryMemberRepository(),
+            authSessionProvider: provider,
+            sessionRefreshPolicy: SessionRefreshPolicy(minimumForegroundIntervalMillis: 15_000),
+            nowMillisProvider: { 1_000 }
+        )
+
+        viewModel.refreshSession(trigger: .startup)
+        await waitForCondition { viewModel.mode.isAuthenticatedSession }
+
+        guard case .authorized(let session) = viewModel.mode else {
+            Issue.record("Expected restored authorized session")
+            return
+        }
+
+        #expect(session.principal.uid == "uid_admin_restore")
+        #expect(viewModel.showSessionExpiredDialog == false)
+    }
+
+    @Test
+    func expiredRefreshSignsOutAndShowsRecoveryDialog() async {
+        let provider = TestAuthSessionProvider(
+            signInResult: .success(AuthPrincipal(uid: "uid_admin_expired", email: "ana.admin@reguerta.app")),
+            refreshResult: .expired
+        )
+        let viewModel = SessionViewModel(
+            repository: InMemoryMemberRepository(),
+            authSessionProvider: provider,
+            sessionRefreshPolicy: SessionRefreshPolicy(minimumForegroundIntervalMillis: 15_000),
+            nowMillisProvider: { 1_000 }
+        )
+
+        viewModel.emailInput = "ana.admin@reguerta.app"
+        viewModel.passwordInput = "test1234"
+        viewModel.signIn()
+        await waitForCondition { viewModel.mode.isAuthenticatedSession }
+
+        #expect(viewModel.mode.isAuthenticatedSession)
+
+        viewModel.refreshSession(trigger: .foreground)
+        await waitForCondition { viewModel.mode == .signedOut && viewModel.showSessionExpiredDialog }
+
+        #expect(viewModel.mode == .signedOut)
+        #expect(viewModel.showSessionExpiredDialog)
+    }
 }
 
 private struct FixedStartupVersionPolicyRepository: StartupVersionPolicyRepository {
@@ -385,5 +466,53 @@ private actor InMemoryCriticalDataFreshnessLocalRepository: CriticalDataFreshnes
 
     func clear() async {
         metadata = nil
+    }
+}
+
+@MainActor
+private final class TestAuthSessionProvider: AuthSessionProvider {
+    private let signInResult: AuthSignInResult
+    private let refreshResult: AuthSessionRefreshResult
+
+    init(
+        signInResult: AuthSignInResult = .failure(.invalidCredentials),
+        refreshResult: AuthSessionRefreshResult = .noSession
+    ) {
+        self.signInResult = signInResult
+        self.refreshResult = refreshResult
+    }
+
+    func signIn(email: String, password: String) async -> AuthSignInResult {
+        signInResult
+    }
+
+    func signUp(email: String, password: String) async -> AuthSignInResult {
+        signInResult
+    }
+
+    func sendPasswordReset(email: String) async -> AuthPasswordResetResult {
+        .success
+    }
+
+    func refreshCurrentSession() async -> AuthSessionRefreshResult {
+        refreshResult
+    }
+
+    func signOut() {
+    }
+}
+
+@MainActor
+private func waitForCondition(
+    timeoutNanoseconds: UInt64 = 500_000_000,
+    pollNanoseconds: UInt64 = 10_000_000,
+    condition: @escaping @MainActor () -> Bool
+) async {
+    let start = ContinuousClock.now
+    while !condition() {
+        if ContinuousClock.now - start >= .nanoseconds(Int(timeoutNanoseconds)) {
+            return
+        }
+        try? await Task.sleep(nanoseconds: pollNanoseconds)
     }
 }

--- a/spec/app/hu-023-session-lifecycle-refresh-and-expiry-ux/spec.md
+++ b/spec/app/hu-023-session-lifecycle-refresh-and-expiry-ux/spec.md
@@ -4,7 +4,7 @@
 - issue_id: #23
 - priority: P1
 - platform: both
-- status: ready
+- status: in_progress
 
 ## Context and problem
 
@@ -45,8 +45,19 @@ As a member I want session refresh on lifecycle events and explicit expiry feedb
 
 ## Definition of Done (DoD)
 
-- [ ] Story acceptance criteria validated.
-- [ ] Android/iOS parity reviewed or temporary gap documented.
-- [ ] Tests executed.
-- [ ] Documentation updated.
+- [x] Story acceptance criteria implemented in code.
+- [x] Android/iOS parity reviewed.
+- [x] Automated tests executed.
+- [x] Documentation updated.
+- [ ] Story acceptance criteria validated manually in develop.
 - [ ] Issue and PR linked.
+
+## Implementation notes
+
+- Lifecycle trigger policy:
+  - `startup` refresh runs once per cold app session.
+  - `foreground` refresh is debounced with a 15-second minimum interval.
+- Refresh outcomes:
+  - Active session restores or keeps access without forcing a sign-out.
+  - Missing or expired session while the app was authenticated signs the member out, clears critical-data freshness metadata, and shows an explicit re-auth dialog.
+  - Transient Firebase failures keep the current session active to avoid noisy false-expiry UX.

--- a/spec/app/hu-023-session-lifecycle-refresh-and-expiry-ux/tasks.md
+++ b/spec/app/hu-023-session-lifecycle-refresh-and-expiry-ux/tasks.md
@@ -1,27 +1,27 @@
 # Tasks - HU-023 (Session lifecycle refresh and expiry UX)
 
 ## 1. Preparation
-- [ ] Define lifecycle trigger matrix.
-- [ ] Define expiry UX and recovery behavior.
+- [x] Define lifecycle trigger matrix.
+- [x] Define expiry UX and recovery behavior.
 
 ## 2. Android implementation
-- [ ] Add refresh on startup and foreground.
-- [ ] Implement explicit expiry UX and recovery navigation.
+- [x] Add refresh on startup and foreground.
+- [x] Implement explicit expiry UX and recovery navigation.
 
 ## 3. iOS implementation
-- [ ] Add refresh on startup and foreground.
-- [ ] Implement explicit expiry UX and recovery navigation.
+- [x] Add refresh on startup and foreground.
+- [x] Implement explicit expiry UX and recovery navigation.
 
 ## 4. Backend / Firestore
-- [ ] Validate no backend schema changes are required.
+- [x] Validate no backend schema changes are required.
 
 ## 5. Testing
-- [ ] Unit tests for refresh trigger/debounce logic.
-- [ ] Integration tests for expired session flow.
+- [x] Unit tests for refresh trigger/debounce logic.
+- [x] Integration tests for expired session flow.
 - [ ] Manual tests for user-facing recovery path.
 
 ## 6. Documentation
-- [ ] Document lifecycle trigger policy.
+- [x] Document lifecycle trigger policy.
 - [ ] Update issue evidence.
 
 ## 7. Closure


### PR DESCRIPTION
## Summary
- implement session refresh on startup and foreground for Android and iOS
- add explicit expired-session recovery UX with direct reauthentication routing
- keep HU-023 scoped to lifecycle/expiry behavior and update spec tracking

## What changed
- Android: refresh policy, auth provider refresh result handling, lifecycle hooks, expiry dialog, reauth shell action, and unit coverage
- iOS: matching refresh policy, auth refresh flow, scene lifecycle hooks, expiry dialog, reauth shell action, and test coverage
- Spec: update `HU-023` notes and tasks to reflect implementation progress

## Validation
- `cd android/Reguerta && ./gradlew app:testDebugUnitTest`
- `cd android/Reguerta && ./gradlew --no-daemon app:lintDebug`
- `cd ios/Reguerta && xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:ReguertaTests test`

## Notes
- No backend/schema changes were required for this HU
- Manual validation in `develop` is still pending for the real recovery path
- Closes #23
