### PR TITLE
[HU-042] Reflect delivery day exceptions across app texts and Google Sheets

### DIFF
--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRoot.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRoot.kt
@@ -1260,6 +1260,7 @@ private fun HomeRoute(
                     NextShiftsCard(
                         nextDeliveryShift = nextDeliveryShift,
                         nextMarketShift = nextMarketShift,
+                        deliveryCalendarOverrides = deliveryCalendarOverrides,
                         isLoading = isLoadingShifts,
                         members = (mode as? SessionMode.Authorized)?.members.orEmpty(),
                         onViewAll = {
@@ -1388,6 +1389,7 @@ private fun HomeRoute(
                     dismissedShiftSwapRequestIds = dismissedShiftSwapRequestIds,
                     nextDeliveryShift = nextDeliveryShift,
                     nextMarketShift = nextMarketShift,
+                    deliveryCalendarOverrides = deliveryCalendarOverrides,
                     currentMember = member,
                     members = (mode as? SessionMode.Authorized)?.members.orEmpty(),
                     isLoading = isLoadingShifts,
@@ -1407,6 +1409,7 @@ private fun HomeRoute(
                 HomeDestination.SHIFT_SWAP_REQUEST -> ShiftSwapRequestRoute(
                     draft = shiftSwapDraft,
                     shifts = shiftsFeed,
+                    deliveryCalendarOverrides = deliveryCalendarOverrides,
                     members = (mode as? SessionMode.Authorized)?.members.orEmpty(),
                     isSaving = isSavingShiftSwapRequest,
                     onDraftChanged = onShiftSwapDraftChanged,
@@ -1736,6 +1739,7 @@ private fun HomeDrawerItem(
 private fun NextShiftsCard(
     nextDeliveryShift: ShiftAssignment?,
     nextMarketShift: ShiftAssignment?,
+    deliveryCalendarOverrides: List<DeliveryCalendarOverride>,
     isLoading: Boolean,
     members: List<Member>,
     onViewAll: () -> Unit,
@@ -1767,11 +1771,13 @@ private fun NextShiftsCard(
                 ShiftSummaryRow(
                     label = stringResource(R.string.shifts_next_delivery),
                     shift = nextDeliveryShift,
+                    overrides = deliveryCalendarOverrides,
                     members = members,
                 )
                 ShiftSummaryRow(
                     label = stringResource(R.string.shifts_next_market),
                     shift = nextMarketShift,
+                    overrides = deliveryCalendarOverrides,
                     members = members,
                 )
             }
@@ -1786,6 +1792,7 @@ private fun NextShiftsCard(
 private fun ShiftSummaryRow(
     label: String,
     shift: ShiftAssignment?,
+    overrides: List<DeliveryCalendarOverride>,
     members: List<Member>,
 ) {
     Column(
@@ -1798,7 +1805,7 @@ private fun ShiftSummaryRow(
             color = MaterialTheme.colorScheme.primary,
         )
         Text(
-            text = shift?.toSummaryLine(members).orEmpty().ifBlank {
+            text = shift?.toSummaryLine(members, overrides).orEmpty().ifBlank {
                 stringResource(R.string.shifts_next_pending)
             },
             style = MaterialTheme.typography.bodyMedium,
@@ -1813,6 +1820,7 @@ private fun ShiftsRoute(
     dismissedShiftSwapRequestIds: Set<String>,
     nextDeliveryShift: ShiftAssignment?,
     nextMarketShift: ShiftAssignment?,
+    deliveryCalendarOverrides: List<DeliveryCalendarOverride>,
     currentMember: Member?,
     members: List<Member>,
     isLoading: Boolean,
@@ -1862,6 +1870,7 @@ private fun ShiftsRoute(
         NextShiftsCard(
             nextDeliveryShift = nextDeliveryShift,
             nextMarketShift = nextMarketShift,
+            deliveryCalendarOverrides = deliveryCalendarOverrides,
             isLoading = isLoading,
             members = members,
             onViewAll = onRefresh,
@@ -1871,6 +1880,7 @@ private fun ShiftsRoute(
             requests = shiftSwapRequests,
             dismissedRequestIds = dismissedShiftSwapRequestIds,
             shifts = shifts,
+            deliveryCalendarOverrides = deliveryCalendarOverrides,
             members = members,
             currentMemberId = currentMember?.id,
             selectedSegment = selectedSegment,
@@ -1918,6 +1928,7 @@ private fun ShiftsRoute(
                 boardShifts.forEach { shift ->
                     ShiftBoardCard(
                         shift = shift,
+                        deliveryCalendarOverrides = deliveryCalendarOverrides,
                         members = members,
                         currentMemberId = currentMember?.id,
                         onRequestShiftSwap = onRequestShiftSwap,
@@ -1973,15 +1984,16 @@ private fun ShiftBoardSegmentSelector(
 @Composable
 private fun ShiftBoardCard(
     shift: ShiftAssignment,
+    deliveryCalendarOverrides: List<DeliveryCalendarOverride>,
     members: List<Member>,
     currentMemberId: String?,
     onRequestShiftSwap: (String) -> Unit,
 ) {
     val primaryNames = shift.primaryBoardNames(members)
-    val leftLines = shift.leftBoardLines()
+    val leftLines = shift.leftBoardLines(deliveryCalendarOverrides)
     val leftAlignment = if (shift.type == ShiftType.MARKET) Alignment.CenterHorizontally else Alignment.Start
-    val canRequestShiftSwap = remember(shift, currentMemberId) {
-        currentMemberId != null && shift.canBeRequestedBy(currentMemberId)
+    val canRequestShiftSwap = remember(shift, currentMemberId, deliveryCalendarOverrides) {
+        currentMemberId != null && shift.canBeRequestedBy(currentMemberId, deliveryCalendarOverrides)
     }
     val highlightedIndex = remember(shift, currentMemberId) {
         currentMemberId?.let { shift.highlightedBoardNameIndex(it) }
@@ -2074,6 +2086,7 @@ private fun ShiftSwapRequestsCard(
     requests: List<ShiftSwapRequest>,
     dismissedRequestIds: Set<String>,
     shifts: List<ShiftAssignment>,
+    deliveryCalendarOverrides: List<DeliveryCalendarOverride>,
     members: List<Member>,
     currentMemberId: String?,
     selectedSegment: ShiftBoardSegment,
@@ -2145,6 +2158,7 @@ private fun ShiftSwapRequestsCard(
                     title = stringResource(R.string.shift_swap_requests_incoming),
                     pendingCandidates = incoming,
                     shifts = shifts,
+                    deliveryCalendarOverrides = deliveryCalendarOverrides,
                     members = members,
                     isUpdating = isUpdating,
                     onAccept = onAccept,
@@ -2157,6 +2171,7 @@ private fun ShiftSwapRequestsCard(
                     title = stringResource(R.string.shift_swap_requests_responses),
                     responseOptions = availableResponses,
                     shifts = shifts,
+                    deliveryCalendarOverrides = deliveryCalendarOverrides,
                     members = members,
                     isUpdating = isUpdating,
                     onConfirm = onConfirm,
@@ -2168,6 +2183,7 @@ private fun ShiftSwapRequestsCard(
                     title = stringResource(R.string.shift_swap_requests_outgoing),
                     requests = waiting,
                     shifts = shifts,
+                    deliveryCalendarOverrides = deliveryCalendarOverrides,
                     members = members,
                     onCancel = onCancel,
                 )
@@ -2178,6 +2194,7 @@ private fun ShiftSwapRequestsCard(
                     title = stringResource(R.string.shift_swap_requests_history),
                     requests = history,
                     shifts = shifts,
+                    deliveryCalendarOverrides = deliveryCalendarOverrides,
                     members = members,
                     onDismissRequest = onDismissRequest,
                 )
@@ -2191,6 +2208,7 @@ private fun IncomingShiftSwapSection(
     title: String,
     pendingCandidates: List<Pair<ShiftSwapRequest, com.reguerta.user.domain.shifts.ShiftSwapCandidate>>,
     shifts: List<ShiftAssignment>,
+    deliveryCalendarOverrides: List<DeliveryCalendarOverride>,
     members: List<Member>,
     isUpdating: Boolean,
     onAccept: (String, String) -> Unit,
@@ -2224,14 +2242,14 @@ private fun IncomingShiftSwapSection(
                     Text(
                         text = stringResource(
                             R.string.shift_swap_request_shift_format,
-                            requestedShift?.toShiftSwapDisplayLabel(request.requesterUserId).orEmpty().ifBlank { request.requestedShiftId },
+                            requestedShift?.toShiftSwapDisplayLabel(request.requesterUserId, deliveryCalendarOverrides).orEmpty().ifBlank { request.requestedShiftId },
                         ),
                         style = MaterialTheme.typography.bodySmall,
                     )
                     Text(
                         text = stringResource(
                             R.string.shift_swap_request_offer_shift_format,
-                            candidateShift?.toShiftSwapDisplayLabel(candidate.userId).orEmpty().ifBlank { candidate.shiftId },
+                            candidateShift?.toShiftSwapDisplayLabel(candidate.userId, deliveryCalendarOverrides).orEmpty().ifBlank { candidate.shiftId },
                         ),
                         style = MaterialTheme.typography.bodySmall,
                     )
@@ -2269,6 +2287,7 @@ private fun RequesterResponsesSection(
     title: String,
     responseOptions: List<Triple<ShiftSwapRequest, com.reguerta.user.domain.shifts.ShiftSwapCandidate, com.reguerta.user.domain.shifts.ShiftSwapResponse>>,
     shifts: List<ShiftAssignment>,
+    deliveryCalendarOverrides: List<DeliveryCalendarOverride>,
     members: List<Member>,
     isUpdating: Boolean,
     onConfirm: (String, String) -> Unit,
@@ -2298,8 +2317,8 @@ private fun RequesterResponsesSection(
                     Text(
                         text = stringResource(
                             R.string.shift_swap_request_confirm_before_after_format,
-                            requestedShift?.toShiftSwapDisplayLabel(request.requesterUserId).orEmpty().ifBlank { request.requestedShiftId },
-                            candidateShift?.toShiftSwapDisplayLabel(candidate.userId).orEmpty().ifBlank { candidate.shiftId },
+                            requestedShift?.toShiftSwapDisplayLabel(request.requesterUserId, deliveryCalendarOverrides).orEmpty().ifBlank { request.requestedShiftId },
+                            candidateShift?.toShiftSwapDisplayLabel(candidate.userId, deliveryCalendarOverrides).orEmpty().ifBlank { candidate.shiftId },
                         ),
                         style = MaterialTheme.typography.bodySmall,
                     )
@@ -2321,6 +2340,7 @@ private fun WaitingShiftSwapSection(
     title: String,
     requests: List<ShiftSwapRequest>,
     shifts: List<ShiftAssignment>,
+    deliveryCalendarOverrides: List<DeliveryCalendarOverride>,
     members: List<Member>,
     onCancel: (String) -> Unit,
 ) {
@@ -2341,7 +2361,7 @@ private fun WaitingShiftSwapSection(
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     Text(
-                        text = requestedShift?.toShiftSwapDisplayLabel(request.requesterUserId) ?: request.requestedShiftId,
+                        text = requestedShift?.toShiftSwapDisplayLabel(request.requesterUserId, deliveryCalendarOverrides) ?: request.requestedShiftId,
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.SemiBold,
                     )
@@ -2367,6 +2387,7 @@ private fun HistoryShiftSwapSection(
     title: String,
     requests: List<ShiftSwapRequest>,
     shifts: List<ShiftAssignment>,
+    deliveryCalendarOverrides: List<DeliveryCalendarOverride>,
     members: List<Member>,
     onDismissRequest: (String) -> Unit,
 ) {
@@ -2381,6 +2402,7 @@ private fun HistoryShiftSwapSection(
             ShiftSwapRequestHistoryItem(
                 request = request,
                 shift = shifts.firstOrNull { it.id == request.requestedShiftId },
+                deliveryCalendarOverrides = deliveryCalendarOverrides,
                 members = members,
                 onDismiss = onDismissRequest,
             )
@@ -2392,6 +2414,7 @@ private fun HistoryShiftSwapSection(
 private fun ShiftSwapRequestHistoryItem(
     request: ShiftSwapRequest,
     shift: ShiftAssignment?,
+    deliveryCalendarOverrides: List<DeliveryCalendarOverride>,
     members: List<Member>,
     onDismiss: (String) -> Unit,
 ) {
@@ -2403,7 +2426,7 @@ private fun ShiftSwapRequestHistoryItem(
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Text(
-                text = shift?.toShiftSwapDisplayLabel(request.requesterUserId) ?: request.requestedShiftId,
+                text = shift?.toShiftSwapDisplayLabel(request.requesterUserId, deliveryCalendarOverrides) ?: request.requestedShiftId,
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.SemiBold,
             )
@@ -2452,6 +2475,7 @@ private fun ShiftSwapRequestHistoryItem(
 private fun ShiftSwapRequestRoute(
     draft: ShiftSwapDraft,
     shifts: List<ShiftAssignment>,
+    deliveryCalendarOverrides: List<DeliveryCalendarOverride>,
     members: List<Member>,
     isSaving: Boolean,
     onDraftChanged: (ShiftSwapDraft) -> Unit,
@@ -2480,9 +2504,12 @@ private fun ShiftSwapRequestRoute(
             Text(
                 text = stringResource(
                     R.string.shift_swap_request_shift_format,
-                    shift?.toShiftSwapDisplayLabel(
-                        shift.assignedUserIds.firstOrNull() ?: shift.helperUserId,
-                    ).orEmpty().ifBlank { draft.shiftId },
+                    shift?.let {
+                        it.toShiftSwapDisplayLabel(
+                            it.assignedUserIds.firstOrNull() ?: it.helperUserId,
+                            deliveryCalendarOverrides,
+                        )
+                    }.orEmpty().ifBlank { draft.shiftId },
                 ),
                 style = MaterialTheme.typography.bodyMedium,
             )
@@ -3123,9 +3150,9 @@ private fun AdminDeliveryCalendarSection(
     onSaveOverride: (String, DeliveryWeekday, String, onSuccess: () -> Unit) -> Unit,
     onDeleteOverride: (String, onSuccess: () -> Unit) -> Unit,
 ) {
-    val futureWeeks = remember(shifts) {
-        shifts.filter { it.type == ShiftType.DELIVERY && it.dateMillis > System.currentTimeMillis() }
-            .sortedBy { it.dateMillis }
+    val futureWeeks = remember(shifts, overrides) {
+        shifts.filter { it.type == ShiftType.DELIVERY && it.effectiveDateMillis(overrides) > System.currentTimeMillis() }
+            .sortedBy { it.effectiveDateMillis(overrides) }
             .distinctBy { it.dateMillis.toWeekKey() }
     }
     var isPickerVisible by rememberSaveable { mutableStateOf(false) }
@@ -3171,6 +3198,7 @@ private fun AdminDeliveryCalendarSection(
         if (isPickerVisible) {
             DeliveryCalendarWeekPickerDialog(
                 futureWeeks = futureWeeks,
+                overrides = overrides,
                 onDismiss = { isPickerVisible = false },
                 onSelectWeek = { weekKey ->
                     selectedWeekKey = weekKey
@@ -3267,6 +3295,7 @@ private fun AdminShiftPlanningSection(
 @Composable
 private fun DeliveryCalendarWeekPickerDialog(
     futureWeeks: List<ShiftAssignment>,
+    overrides: List<DeliveryCalendarOverride>,
     onDismiss: () -> Unit,
     onSelectWeek: (String) -> Unit,
 ) {
@@ -3301,7 +3330,7 @@ private fun DeliveryCalendarWeekPickerDialog(
             ) {
                 OutlinedTextField(
                     value = selectedShift?.let {
-                        "${it.dateMillis.toWeekKey()} · ${it.dateMillis.toLocalizedDateOnly()}"
+                        "${it.dateMillis.toWeekKey()} · ${it.effectiveDateMillis(overrides).toLocalizedDateOnly()}"
                     }.orEmpty(),
                     onValueChange = {},
                     readOnly = true,
@@ -3321,7 +3350,7 @@ private fun DeliveryCalendarWeekPickerDialog(
                         val weekKey = shift.dateMillis.toWeekKey()
                         DropdownMenuItem(
                             text = {
-                                Text("${weekKey} · ${shift.dateMillis.toLocalizedDateOnly()}")
+                                Text("${weekKey} · ${shift.effectiveDateMillis(overrides).toLocalizedDateOnly()}")
                             },
                             onClick = {
                                 selectedWeekKey = weekKey
@@ -3345,7 +3374,7 @@ private fun DeliveryCalendarWeekPickerDialog(
                             fontWeight = FontWeight.SemiBold,
                         )
                         Text(
-                            text = shift.dateMillis.toLocalizedDateOnly(),
+                            text = shift.effectiveDateMillis(overrides).toLocalizedDateOnly(),
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
@@ -3403,7 +3432,7 @@ private fun DeliveryCalendarOverrideDialog(
                     fontWeight = FontWeight.SemiBold,
                 )
                 Text(
-                    text = selectedShift.dateMillis.toLocalizedDateOnly(),
+                    text = (override?.deliveryDateMillis ?: selectedShift.dateMillis).toLocalizedDateOnly(),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -3868,16 +3897,25 @@ private fun ShiftStatus.labelRes(): Int = when (this) {
     ShiftStatus.CONFIRMED -> R.string.shifts_status_confirmed
 }
 
-private fun ShiftAssignment.toSummaryLine(members: List<Member>): String =
-    "${dateMillis.toLocalizedDateTime()} · ${assignedUserIds.toMemberNames(members)}"
+private fun ShiftAssignment.effectiveDateMillis(overrides: List<DeliveryCalendarOverride>): Long =
+    if (type == ShiftType.DELIVERY) {
+        overrides.firstOrNull { it.weekKey == dateMillis.toWeekKey() }?.deliveryDateMillis ?: dateMillis
+    } else {
+        dateMillis
+    }
+
+private fun ShiftAssignment.toSummaryLine(
+    members: List<Member>,
+    overrides: List<DeliveryCalendarOverride>,
+): String = "${effectiveDateMillis(overrides).toLocalizedDateTime()} · ${assignedUserIds.toMemberNames(members)}"
 
 @Composable
-private fun ShiftAssignment.leftBoardLines(): List<ShiftBoardLine> = when (type) {
+private fun ShiftAssignment.leftBoardLines(overrides: List<DeliveryCalendarOverride>): List<ShiftBoardLine> = when (type) {
     ShiftType.DELIVERY -> {
-        val localDate = dateMillis.toLocalDate()
+        val localDate = effectiveDateMillis(overrides).toLocalDate()
         listOf(
             ShiftBoardLine(
-                text = dateMillis.toWeekKey(),
+                text = effectiveDateMillis(overrides).toWeekKey(),
                 style = MaterialTheme.typography.bodySmall,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
@@ -3889,7 +3927,7 @@ private fun ShiftAssignment.leftBoardLines(): List<ShiftBoardLine> = when (type)
         )
     }
     ShiftType.MARKET -> {
-        val localDate = dateMillis.toLocalDate()
+        val localDate = effectiveDateMillis(overrides).toLocalDate()
         listOf(
             ShiftBoardLine(
                 text = localDate.toSpanishMonthLabel(),
@@ -3927,10 +3965,13 @@ private fun ShiftAssignment.primaryBoardNames(members: List<Member>): List<Strin
         }
 }
 
-private fun ShiftAssignment.canBeRequestedBy(currentMemberId: String): Boolean = when (type) {
-    ShiftType.DELIVERY -> dateMillis > System.currentTimeMillis() &&
+private fun ShiftAssignment.canBeRequestedBy(
+    currentMemberId: String,
+    overrides: List<DeliveryCalendarOverride>,
+): Boolean = when (type) {
+    ShiftType.DELIVERY -> effectiveDateMillis(overrides) > System.currentTimeMillis() &&
         assignedUserIds.firstOrNull() == currentMemberId
-    ShiftType.MARKET -> dateMillis > System.currentTimeMillis() &&
+    ShiftType.MARKET -> effectiveDateMillis(overrides) > System.currentTimeMillis() &&
         assignedUserIds.contains(currentMemberId)
 }
 
@@ -4574,9 +4615,10 @@ private fun Long.toLocalizedDateTime(): String =
 private fun Long.toLocalizedDateOnly(): String =
     java.text.SimpleDateFormat("d MMM yyyy", Locale.forLanguageTag("es-ES")).format(java.util.Date(this))
 
-private fun ShiftAssignment.toShiftSwapDisplayLabel(memberId: String?): String {
-    return dateMillis.toLocalizedDateOnly()
-}
+private fun ShiftAssignment.toShiftSwapDisplayLabel(
+    memberId: String?,
+    overrides: List<DeliveryCalendarOverride>,
+): String = effectiveDateMillis(overrides).toLocalizedDateOnly()
 
 private fun Long.toDeliveryWeekday(): DeliveryWeekday =
     when (toLocalDate().dayOfWeek) {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1897,6 +1897,52 @@ const dispatchShiftUpdatedNotification = async (
   });
 };
 
+const formatNotificationDate = (
+  timestamp: admin.firestore.Timestamp,
+): string => {
+  const formatter = new Intl.DateTimeFormat("es-ES", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: SHEET_TIME_ZONE,
+  });
+  return formatter.format(timestamp.toDate());
+};
+
+const createDeliveryCalendarNotification = async (
+  env: string,
+  weekKey: string,
+  updatedByUserId: string | null,
+  nextDate: admin.firestore.Timestamp | null,
+  previousDate: admin.firestore.Timestamp | null,
+): Promise<void> => {
+  if (!nextDate && !previousDate) {
+    return;
+  }
+
+  const title = "Cambio en el dia de reparto";
+  const body = nextDate ?
+    (
+      previousDate ?
+        `El reparto de la semana ${weekKey} pasa del ` +
+          `${formatNotificationDate(previousDate)} al ` +
+          `${formatNotificationDate(nextDate)}.` :
+        `El reparto de la semana ${weekKey} pasa al ` +
+          `${formatNotificationDate(nextDate)}.`
+    ) :
+    `El reparto de la semana ${weekKey} vuelve a su dia por defecto.`;
+
+  await firestore.collection(`${env}/plus-collections/notificationEvents`).add({
+    title,
+    body,
+    type: "delivery_calendar_updated",
+    target: "all",
+    targetPayload: {},
+    createdBy: updatedByUserId || "system",
+    sentAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+};
+
 const hasRelevantShiftChange = (
   before: FirestoreShiftRecord | null,
   after: FirestoreShiftRecord,
@@ -2381,6 +2427,19 @@ export const onDeliveryCalendarOverrideWritten = onDocumentWritten(
   async (event) => {
     const env = event.params.env;
     const weekKey = event.params.weekKey;
+    const beforeSnapshot = event.data?.before;
+    const afterSnapshot = event.data?.after;
+    const previousDate = beforeSnapshot?.exists &&
+      beforeSnapshot.get("deliveryDate") instanceof admin.firestore.Timestamp ?
+      beforeSnapshot.get("deliveryDate") as admin.firestore.Timestamp :
+      null;
+    const nextDate = afterSnapshot?.exists &&
+      afterSnapshot.get("deliveryDate") instanceof admin.firestore.Timestamp ?
+      afterSnapshot.get("deliveryDate") as admin.firestore.Timestamp :
+      null;
+    const updatedByUserId = parseString(
+      afterSnapshot?.get("updatedBy") ?? beforeSnapshot?.get("updatedBy"),
+    );
 
     try {
       const sheetConfig = getSheetConfig(env);
@@ -2426,6 +2485,16 @@ export const onDeliveryCalendarOverrideWritten = onDocumentWritten(
         weekKey,
         updatedCount,
       });
+
+      if (updatedCount > 0) {
+        await createDeliveryCalendarNotification(
+          env,
+          weekKey,
+          updatedByUserId,
+          nextDate,
+          previousDate,
+        );
+      }
     } catch (error) {
       logger.error(
         "❌ Failed to reflect delivery calendar override in Google Sheets",

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -82,6 +82,9 @@ const usersCollection = (env: string) =>
 const plusUsersCollection = (env: string) =>
   firestore.collection(`${env}/plus-collections/users`);
 
+const deliveryCalendarCollection = (env: string) =>
+  firestore.collection(`${env}/plus-collections/deliveryCalendar`);
+
 const globalConfigDocRefs = (env: string) => [
   firestore.collection(`${env}/collections/config`).doc("global"),
   firestore.collection(`${env}/plus-collections/config`).doc("global"),
@@ -144,6 +147,8 @@ type VersionPolicy = {
   forceUpdate: boolean;
   storeUrl: string;
 };
+
+type DeliveryCalendarOverrideMap = Map<string, admin.firestore.Timestamp>;
 
 const VERSION_STRING_REGEX = /^\d+(?:\.\d+)*$/;
 const DEFAULT_VERSION_POLICY_ENVS = ["local", "develop", "production"];
@@ -1125,9 +1130,53 @@ const isoWeekNumber = (
   );
 };
 
+const timestampToIsoWeekKey = (
+  timestamp: admin.firestore.Timestamp,
+): string => {
+  const date = timestamp.toDate();
+  const utcDate = new Date(Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+  ));
+  const day = utcDate.getUTCDay() || 7;
+  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - day);
+  const year = utcDate.getUTCFullYear();
+  const yearStart = new Date(Date.UTC(year, 0, 1));
+  const week = Math.ceil(
+    (((utcDate.getTime() - yearStart.getTime()) / 86400000) + 1) / 7
+  );
+  return `${year}-W${String(week).padStart(2, "0")}`;
+};
+
+const resolveEffectiveDeliveryDate = (
+  shift: FirestoreShiftRecord,
+  overrides: DeliveryCalendarOverrideMap,
+): admin.firestore.Timestamp => {
+  if (shift.type !== "delivery") {
+    return shift.date;
+  }
+  return overrides.get(timestampToIsoWeekKey(shift.date)) || shift.date;
+};
+
+const readDeliveryCalendarOverrideMap = async (
+  env: string,
+): Promise<DeliveryCalendarOverrideMap> => {
+  const snapshot = await deliveryCalendarCollection(env).get();
+  const overrides = new Map<string, admin.firestore.Timestamp>();
+  snapshot.docs.forEach((doc) => {
+    const deliveryDate = doc.get("deliveryDate");
+    if (deliveryDate instanceof admin.firestore.Timestamp) {
+      overrides.set(doc.id, deliveryDate);
+    }
+  });
+  return overrides;
+};
+
 const toDeliveryHumanRow = (
   shift: FirestoreShiftRecord,
   membersById: Map<string, MemberSheetRef>,
+  effectiveDate: admin.firestore.Timestamp,
   existingRow: string[] = [],
 ): string[] => {
   const responsible = shift.assignedUserIds
@@ -1135,12 +1184,12 @@ const toDeliveryHumanRow = (
     .find((value): value is MemberSheetRef => Boolean(value));
 
   return [
-    formatHumanShortDate(shift.date),
+    formatHumanShortDate(effectiveDate),
     responsible?.displayName || existingRow[1] || "",
     responsible?.phone || existingRow[2] || "",
     existingRow[3] || "",
     existingRow[4] || "",
-    `${isoWeekNumber(shift.date)}`,
+    `${isoWeekNumber(effectiveDate)}`,
   ];
 };
 
@@ -1183,6 +1232,7 @@ const upsertShiftRowInSheet = async (
   range: string,
   shift: FirestoreShiftRecord,
   membersById: Map<string, MemberSheetRef>,
+  deliveryOverrides: DeliveryCalendarOverrideMap,
 ): Promise<"updated" | "appended"> => {
   const valuesResponse = await sheets.spreadsheets.values.get({
     spreadsheetId,
@@ -1190,14 +1240,16 @@ const upsertShiftRowInSheet = async (
   });
   const rows = valuesResponse.data.values || [];
   const normalizedRows = rows.map((row) => row.map((cell) => `${cell}`));
+  const effectiveDate = resolveEffectiveDeliveryDate(shift, deliveryOverrides);
 
   if (shift.type === "delivery") {
+    const targetWeekKey = timestampToIsoWeekKey(effectiveDate);
     for (let rowOffset = 0; rowOffset < normalizedRows.length; rowOffset += 1) {
       const row = normalizedRows[rowOffset];
       const rowDate = parseDateInput(row[0]);
       if (
         rowDate &&
-        timestampToSheetDate(rowDate) === timestampToSheetDate(shift.date)
+        timestampToIsoWeekKey(rowDate) === targetWeekKey
       ) {
         const rowNumber = rowOffset + 1;
         await sheets.spreadsheets.values.update({
@@ -1205,7 +1257,9 @@ const upsertShiftRowInSheet = async (
           range: `${parseSheetName(range)}!A${rowNumber}:F${rowNumber}`,
           valueInputOption: "RAW",
           requestBody: {
-            values: [toDeliveryHumanRow(shift, membersById, row)],
+            values: [
+              toDeliveryHumanRow(shift, membersById, effectiveDate, row),
+            ],
           },
         });
         return "updated";
@@ -1219,8 +1273,8 @@ const upsertShiftRowInSheet = async (
       insertDataOption: "INSERT_ROWS",
       requestBody: {
         values: [
-          [formatHumanMonthHeading(shift.date)],
-          toDeliveryHumanRow(shift, membersById),
+          [formatHumanMonthHeading(effectiveDate)],
+          toDeliveryHumanRow(shift, membersById, effectiveDate),
         ],
       },
     });
@@ -1705,16 +1759,21 @@ const buildDeliverySheetValues = (
   shifts: FirestoreShiftRecord[],
   seasonLabel: string,
   membersById: Map<string, MemberSheetRef>,
+  deliveryOverrides: DeliveryCalendarOverrideMap,
 ): string[][] => {
   const rows: string[][] = [[`TURNOS REPARTO ${seasonLabel}`], []];
   let currentMonthHeading = "";
   shifts.forEach((shift) => {
-    const monthHeading = formatHumanMonthHeading(shift.date);
+    const effectiveDate = resolveEffectiveDeliveryDate(
+      shift,
+      deliveryOverrides,
+    );
+    const monthHeading = formatHumanMonthHeading(effectiveDate);
     if (monthHeading !== currentMonthHeading) {
       rows.push([monthHeading]);
       currentMonthHeading = monthHeading;
     }
-    rows.push(toDeliveryHumanRow(shift, membersById));
+    rows.push(toDeliveryHumanRow(shift, membersById, effectiveDate));
   });
   return rows;
 };
@@ -1863,10 +1922,11 @@ const exportAllShiftsToGoogleSheets = async (
     );
   }
 
-  const [sheets, membersById, shifts] = await Promise.all([
+  const [sheets, membersById, shifts, deliveryOverrides] = await Promise.all([
     getSheetsClient(),
     loadMembersById(env),
     readAllShifts(env),
+    readDeliveryCalendarOverrideMap(env),
   ]);
   let deliveryCount = 0;
   let marketCount = 0;
@@ -1880,6 +1940,7 @@ const exportAllShiftsToGoogleSheets = async (
         sheetConfig.deliveryRange,
       shift,
       membersById,
+      deliveryOverrides,
     );
     if (shift.type === "market") {
       marketCount += 1;
@@ -2109,16 +2170,22 @@ const processShiftPlanningRequest = async (
     throw new Error("Missing sheets configuration for shift planning.");
   }
 
-  const [sheets, membersById] = await Promise.all([
+  const [sheets, membersById, deliveryOverrides] = await Promise.all([
     getSheetsClient(),
     loadMembersById(env),
+    readDeliveryCalendarOverrideMap(env),
   ]);
 
   const sheetName = request.type === "delivery" ?
     buildDeliverySheetName(seasonLabel) :
     buildMarketSheetName(seasonLabel);
   const sheetValues = request.type === "delivery" ?
-    buildDeliverySheetValues(plannedShifts, seasonLabel, membersById) :
+    buildDeliverySheetValues(
+      plannedShifts,
+      seasonLabel,
+      membersById,
+      deliveryOverrides,
+    ) :
     buildMarketSheetValues(plannedShifts, seasonLabel, membersById);
 
   await updateWholeSheet(
@@ -2251,9 +2318,10 @@ export const onShiftWritten = onDocumentWritten(
           sheetConfig.deliveryRange
       );
 
-    const [sheets, membersById] = await Promise.all([
+    const [sheets, membersById, deliveryOverrides] = await Promise.all([
       getSheetsClient(),
       loadMembersById(env),
+      readDeliveryCalendarOverrideMap(env),
     ]);
 
     const result = await upsertShiftRowInSheet(
@@ -2262,6 +2330,7 @@ export const onShiftWritten = onDocumentWritten(
       targetRange,
       after,
       membersById,
+      deliveryOverrides,
     );
 
     await afterSnapshot.ref.set({
@@ -2281,6 +2350,32 @@ export const onShiftWritten = onDocumentWritten(
       exportMode: result,
       targetRange,
     });
+  }
+);
+
+export const onDeliveryCalendarOverrideWritten = onDocumentWritten(
+  "{env}/plus-collections/deliveryCalendar/{weekKey}",
+  async (event) => {
+    const env = event.params.env;
+    const weekKey = event.params.weekKey;
+
+    try {
+      const summary = await exportAllShiftsToGoogleSheets(env);
+      logger.info("✅ Delivery calendar override reflected in Google Sheets", {
+        env,
+        weekKey,
+        ...summary,
+      });
+    } catch (error) {
+      logger.error(
+        "❌ Failed to reflect delivery calendar override in Google Sheets",
+        {
+          env,
+          weekKey,
+          error,
+        },
+      );
+    }
   }
 );
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2383,11 +2383,48 @@ export const onDeliveryCalendarOverrideWritten = onDocumentWritten(
     const weekKey = event.params.weekKey;
 
     try {
-      const summary = await exportAllShiftsToGoogleSheets(env);
+      const sheetConfig = getSheetConfig(env);
+      if (!sheetConfig) {
+        throw new Error(
+          `Missing sheets configuration for env=${env}. ` +
+          "Expected sheets.spreadsheet_id and ranges."
+        );
+      }
+
+      const [
+        sheets,
+        membersById,
+        shifts,
+        deliveryOverrides,
+      ] = await Promise.all([
+        getSheetsClient(),
+        loadMembersById(env),
+        readAllShifts(env),
+        readDeliveryCalendarOverrideMap(env),
+      ]);
+
+      const matchingDeliveryShifts = shifts.filter((shift) =>
+        shift.type === "delivery" &&
+        timestampToIsoWeekKey(shift.date) === weekKey
+      );
+
+      let updatedCount = 0;
+      for (const shift of matchingDeliveryShifts) {
+        await upsertShiftRowInSheet(
+          sheets,
+          sheetConfig.spreadsheetId,
+          sheetConfig.deliveryRange,
+          shift,
+          membersById,
+          deliveryOverrides,
+        );
+        updatedCount += 1;
+      }
+
       logger.info("✅ Delivery calendar override reflected in Google Sheets", {
         env,
         weekKey,
-        ...summary,
+        updatedCount,
       });
     } catch (error) {
       logger.error(

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -655,11 +655,6 @@ const parseDateInput = (value: unknown): admin.firestore.Timestamp | null => {
     return admin.firestore.Timestamp.fromMillis(millis);
   }
 
-  const isoMillis = Date.parse(text);
-  if (!Number.isNaN(isoMillis)) {
-    return admin.firestore.Timestamp.fromMillis(isoMillis);
-  }
-
   const normalizedText = text
     .trim()
     .toLowerCase()

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -603,8 +603,33 @@ const isShiftType = (value: string): value is ShiftType =>
 const isShiftStatus = (value: string): value is ShiftStatus =>
   value === "planned" || value === "swap_pending" || value === "confirmed";
 
-const timestampToSheetDate = (timestamp: admin.firestore.Timestamp): string =>
-  timestamp.toDate().toISOString().slice(0, 10);
+const SHEET_TIME_ZONE = "Europe/Madrid";
+
+const timestampToZonedDateParts = (
+  timestamp: admin.firestore.Timestamp,
+  timeZone: string = SHEET_TIME_ZONE,
+): {year: number; month: number; day: number} => {
+  const parts = new Intl.DateTimeFormat("en-GB", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(timestamp.toDate());
+  const getPart = (type: "year" | "month" | "day") =>
+    Number(parts.find((part) => part.type === type)?.value || "0");
+  return {
+    year: getPart("year"),
+    month: getPart("month"),
+    day: getPart("day"),
+  };
+};
+
+const timestampToSheetDate = (timestamp: admin.firestore.Timestamp): string => {
+  const {year, month, day} = timestampToZonedDateParts(timestamp);
+  const paddedMonth = String(month).padStart(2, "0");
+  const paddedDay = String(day).padStart(2, "0");
+  return `${year}-${paddedMonth}-${paddedDay}`;
+};
 
 const buildShiftId = (
   type: ShiftType,
@@ -1085,9 +1110,8 @@ const toShiftRecord = (
 const formatHumanShortDate = (
   timestamp: admin.firestore.Timestamp,
 ): string => {
-  const date = timestamp.toDate();
-  return `${date.getUTCDate()}/${date.getUTCMonth() + 1}` +
-    `/${date.getUTCFullYear()}`;
+  const {year, month, day} = timestampToZonedDateParts(timestamp);
+  return `${day}/${month}/${year}`;
 };
 
 const formatHumanLongDate = (
@@ -1097,7 +1121,7 @@ const formatHumanLongDate = (
     day: "numeric",
     month: "long",
     year: "numeric",
-    timeZone: "UTC",
+    timeZone: SHEET_TIME_ZONE,
   });
   return formatter.format(timestamp.toDate()).toUpperCase();
 };
@@ -1108,7 +1132,7 @@ const formatHumanMonthHeading = (
   const formatter = new Intl.DateTimeFormat("es-ES", {
     month: "long",
     year: "numeric",
-    timeZone: "UTC",
+    timeZone: SHEET_TIME_ZONE,
   });
   return formatter.format(timestamp.toDate()).toUpperCase();
 };
@@ -1116,14 +1140,14 @@ const formatHumanMonthHeading = (
 const isoWeekNumber = (
   timestamp: admin.firestore.Timestamp,
 ): number => {
-  const date = timestamp.toDate();
+  const {year, month, day: localDay} = timestampToZonedDateParts(timestamp);
   const utcDate = new Date(Date.UTC(
-    date.getUTCFullYear(),
-    date.getUTCMonth(),
-    date.getUTCDate(),
+    year,
+    month - 1,
+    localDay,
   ));
-  const day = utcDate.getUTCDay() || 7;
-  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - day);
+  const isoDay = utcDate.getUTCDay() || 7;
+  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - isoDay);
   const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
   return Math.ceil(
     (((utcDate.getTime() - yearStart.getTime()) / 86400000) + 1) / 7
@@ -1133,14 +1157,18 @@ const isoWeekNumber = (
 const timestampToIsoWeekKey = (
   timestamp: admin.firestore.Timestamp,
 ): string => {
-  const date = timestamp.toDate();
+  const {
+    year: localYear,
+    month,
+    day: localDay,
+  } = timestampToZonedDateParts(timestamp);
   const utcDate = new Date(Date.UTC(
-    date.getUTCFullYear(),
-    date.getUTCMonth(),
-    date.getUTCDate(),
+    localYear,
+    month - 1,
+    localDay,
   ));
-  const day = utcDate.getUTCDay() || 7;
-  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - day);
+  const isoDay = utcDate.getUTCDay() || 7;
+  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - isoDay);
   const year = utcDate.getUTCFullYear();
   const yearStart = new Date(Date.UTC(year, 0, 1));
   const week = Math.ceil(

--- a/ios/Reguerta/Reguerta/ContentView.swift
+++ b/ios/Reguerta/Reguerta/ContentView.swift
@@ -1168,13 +1168,13 @@ struct ContentView: View {
     private func shiftBoardCard(_ shift: ShiftAssignment, currentMemberId: String?) -> some View {
         let leftColumnWidth = shift.type == .market ? 88.resize : 104.resize
         let leftAlignment: HorizontalAlignment = shift.type == .market ? .center : .leading
-        let canRequestSwap = currentMemberId.map { shift.canBeRequested(by: $0) } ?? false
+        let canRequestSwap = currentMemberId.map { canRequestSwapForShift(shift, currentMemberId: $0) } ?? false
         let highlightedIndex = currentMemberId.flatMap { shift.highlightedBoardNameIndex(for: $0) }
         return cardContainer {
             VStack(alignment: .leading, spacing: tokens.spacing.sm) {
                 HStack(alignment: .top, spacing: tokens.spacing.md) {
                     VStack(alignment: leftAlignment, spacing: tokens.spacing.xs) {
-                        ForEach(Array(shift.leftBoardLines(tokens: tokens).enumerated()), id: \.offset) { _, line in
+                        ForEach(Array(shiftLeftBoardLines(shift).enumerated()), id: \.offset) { _, line in
                             Text(line.text)
                                 .font(line.font)
                                 .fontWeight(line.weight)
@@ -2134,8 +2134,8 @@ struct ContentView: View {
     @ViewBuilder
     private func adminDeliveryCalendarSection(session: AuthorizedSession) -> some View {
         let futureWeeks = viewModel.shiftsFeed
-            .filter { $0.type == .delivery && $0.dateMillis > Int64(Date().timeIntervalSince1970 * 1000) }
-            .sorted { $0.dateMillis < $1.dateMillis }
+            .filter { $0.type == .delivery && effectiveDateMillis(for: $0) > Int64(Date().timeIntervalSince1970 * 1000) }
+            .sorted { effectiveDateMillis(for: $0) < effectiveDateMillis(for: $1) }
             .uniqued { $0.weekKey }
         VStack(alignment: .leading, spacing: tokens.spacing.sm) {
             Text("Calendario de reparto")
@@ -2170,6 +2170,7 @@ struct ContentView: View {
         .sheet(isPresented: $isDeliveryCalendarWeekPickerPresented) {
             DeliveryCalendarWeekPickerSheet(
                 futureWeeks: futureWeeks,
+                overrides: viewModel.deliveryCalendarOverrides,
                 onSelectWeek: { weekKey in
                     selectedDeliveryCalendarWeekKey = weekKey
                     isDeliveryCalendarWeekPickerPresented = false
@@ -2289,14 +2290,17 @@ struct ContentView: View {
         @Environment(\.reguertaTokens) private var tokens
         @Environment(\.dismiss) private var dismiss
         let futureWeeks: [ShiftAssignment]
+        let overrides: [DeliveryCalendarOverride]
         let onSelectWeek: (String) -> Void
         @State private var selectedWeekKey: String
 
         init(
             futureWeeks: [ShiftAssignment],
+            overrides: [DeliveryCalendarOverride],
             onSelectWeek: @escaping (String) -> Void
         ) {
             self.futureWeeks = futureWeeks
+            self.overrides = overrides
             self.onSelectWeek = onSelectWeek
             _selectedWeekKey = State(initialValue: futureWeeks.first?.weekKey ?? "")
         }
@@ -2309,7 +2313,7 @@ struct ContentView: View {
                         .foregroundStyle(tokens.colors.textSecondary)
                     Picker("Semana", selection: $selectedWeekKey) {
                         ForEach(futureWeeks, id: \.weekKey) { shift in
-                            Text("\(shift.weekKey) · \(localizedDateOnly(shift.dateMillis))")
+                            Text("\(shift.weekKey) · \(effectiveDateLabel(for: shift))")
                                 .tag(shift.weekKey)
                         }
                     }
@@ -2323,7 +2327,7 @@ struct ContentView: View {
                             Text(selectedShift.weekKey)
                                 .font(tokens.typography.body.weight(.semibold))
                                 .foregroundStyle(tokens.colors.textPrimary)
-                            Text(localizedDateOnly(selectedShift.dateMillis))
+                            Text(effectiveDateLabel(for: selectedShift))
                                 .font(tokens.typography.label)
                                 .foregroundStyle(tokens.colors.textSecondary)
                         }
@@ -2359,6 +2363,11 @@ struct ContentView: View {
             formatter.locale = Locale(identifier: "es_ES")
             formatter.dateFormat = "d MMM yyyy"
             return formatter.string(from: Date(timeIntervalSince1970: TimeInterval(millis) / 1_000))
+        }
+
+        private func effectiveDateLabel(for shift: ShiftAssignment) -> String {
+            let effectiveMillis = overrides.first(where: { $0.weekKey == shift.weekKey })?.deliveryDateMillis ?? shift.dateMillis
+            return localizedDateOnly(effectiveMillis)
         }
     }
 
@@ -2406,7 +2415,7 @@ struct ContentView: View {
                         VStack(spacing: 4) {
                             Text(shift.weekKey)
                                 .font(tokens.typography.body.weight(.semibold))
-                            Text(localizedDateOnly(shift.dateMillis))
+                            Text(localizedDateOnly(overrideEntry?.deliveryDateMillis ?? shift.dateMillis))
                                 .font(tokens.typography.label)
                                 .foregroundStyle(tokens.colors.textSecondary)
                         }
@@ -2592,6 +2601,87 @@ struct ContentView: View {
         session.members.first(where: { $0.id == userId })?.displayName ?? userId
     }
 
+    private func deliveryOverride(for shift: ShiftAssignment) -> DeliveryCalendarOverride? {
+        guard shift.type == .delivery else { return nil }
+        return viewModel.deliveryCalendarOverrides.first(where: { $0.weekKey == shift.weekKey })
+    }
+
+    private func effectiveDateMillis(for shift: ShiftAssignment) -> Int64 {
+        deliveryOverride(for: shift)?.deliveryDateMillis ?? shift.dateMillis
+    }
+
+    private func effectiveDate(for shift: ShiftAssignment) -> Date {
+        Date(timeIntervalSince1970: TimeInterval(effectiveDateMillis(for: shift)) / 1_000)
+    }
+
+    private func localizedEffectiveDateTime(_ shift: ShiftAssignment) -> String {
+        localizedDateTime(effectiveDateMillis(for: shift))
+    }
+
+    private func localizedEffectiveDateOnly(_ shift: ShiftAssignment) -> String {
+        localizedDateOnly(effectiveDateMillis(for: shift))
+    }
+
+    private func shiftLeftBoardLines(_ shift: ShiftAssignment) -> [ShiftBoardLine] {
+        switch shift.type {
+        case .delivery:
+            return [
+                ShiftBoardLine(
+                    text: effectiveDateMillis(for: shift).isoWeekKey,
+                    font: tokens.typography.label,
+                    weight: .semibold,
+                    color: tokens.colors.textPrimary
+                ),
+                ShiftBoardLine(
+                    text: effectiveDate(for: shift).boardDateLabel,
+                    font: tokens.typography.bodySecondary,
+                    weight: .regular,
+                    color: tokens.colors.textSecondary
+                ),
+            ]
+        case .market:
+            let date = effectiveDate(for: shift)
+            let monthFormatter = DateFormatter()
+            monthFormatter.locale = Locale(identifier: "es_ES")
+            monthFormatter.dateFormat = "LLLL"
+            let weekdayFormatter = DateFormatter()
+            weekdayFormatter.locale = Locale(identifier: "es_ES")
+            weekdayFormatter.dateFormat = "EEEE"
+            return [
+                ShiftBoardLine(
+                    text: monthFormatter.string(from: date).capitalized,
+                    font: tokens.typography.bodySecondary,
+                    weight: .semibold,
+                    color: tokens.colors.textPrimary
+                ),
+                ShiftBoardLine(
+                    text: weekdayFormatter.string(from: date).capitalized,
+                    font: tokens.typography.label,
+                    weight: .regular,
+                    color: tokens.colors.textSecondary
+                ),
+                ShiftBoardLine(
+                    text: date.dayNumberLabel,
+                    font: tokens.typography.titleCard,
+                    weight: .semibold,
+                    color: tokens.colors.textPrimary
+                ),
+            ]
+        }
+    }
+
+    private func canRequestSwapForShift(_ shift: ShiftAssignment, currentMemberId: String) -> Bool {
+        let effectiveMillis = effectiveDateMillis(for: shift)
+        switch shift.type {
+        case .delivery:
+            return effectiveMillis > Int64(Date().timeIntervalSince1970 * 1_000) &&
+                shift.assignedUserIds.first == currentMemberId
+        case .market:
+            return effectiveMillis > Int64(Date().timeIntervalSince1970 * 1_000) &&
+                shift.assignedUserIds.contains(currentMemberId)
+        }
+    }
+
     private func memberNames(for userIds: [String]) -> String {
         guard let session = currentHomeSession else {
             return userIds.joined(separator: ", ")
@@ -2601,11 +2691,11 @@ struct ContentView: View {
     }
 
     private func shiftSummary(_ shift: ShiftAssignment) -> String {
-        "\(localizedDateTime(shift.dateMillis)) · \(memberNames(for: shift.assignedUserIds))"
+        "\(localizedEffectiveDateTime(shift)) · \(memberNames(for: shift.assignedUserIds))"
     }
 
     private func shiftSwapDisplayLabel(_ shift: ShiftAssignment, memberId: String?) -> String {
-        localizedDateOnly(shift.dateMillis)
+        localizedEffectiveDateOnly(shift)
     }
 
     private func displayNameForSwap(_ userId: String) -> String {
@@ -3291,6 +3381,14 @@ private extension DeliveryWeekday {
 }
 
 private extension Int64 {
+    var isoWeekKey: String {
+        let calendar = Calendar(identifier: .iso8601)
+        let date = Date(timeIntervalSince1970: TimeInterval(self) / 1_000)
+        let week = calendar.component(.weekOfYear, from: date)
+        let year = calendar.component(.yearForWeekOfYear, from: date)
+        return String(format: "%04d-W%02d", year, week)
+    }
+
     var deliveryWeekday: DeliveryWeekday {
         let weekday = Calendar.current.component(.weekday, from: Date(timeIntervalSince1970: TimeInterval(self) / 1_000))
         switch weekday {
@@ -3302,6 +3400,44 @@ private extension Int64 {
         case 7: return .saturday
         default: return .sunday
         }
+    }
+}
+
+private extension Date {
+    var boardDateLabel: String {
+        let weekdayFormatter = DateFormatter()
+        weekdayFormatter.locale = Locale(identifier: "es_ES")
+        weekdayFormatter.dateFormat = "EEE"
+        let weekday = weekdayFormatter.string(from: self)
+            .replacingOccurrences(of: ".", with: "")
+            .capitalized
+        return "\(weekday) \(dayNumberLabel) \(shortMonthLabel)"
+    }
+
+    var shortMonthLabel: String {
+        let month = Calendar(identifier: .iso8601).component(.month, from: self)
+        switch month {
+        case 1: return "ene"
+        case 2: return "feb"
+        case 3: return "mar"
+        case 4: return "abr"
+        case 5: return "may"
+        case 6: return "jun"
+        case 7: return "jul"
+        case 8: return "ago"
+        case 9: return "sep"
+        case 10: return "oct"
+        case 11: return "nov"
+        case 12: return "dic"
+        default: return ""
+        }
+    }
+
+    var dayNumberLabel: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "es_ES")
+        formatter.dateFormat = "d"
+        return formatter.string(from: self)
     }
 }
 

--- a/spec/admin/hu-042-reflect-delivery-day-exceptions/spec.md
+++ b/spec/admin/hu-042-reflect-delivery-day-exceptions/spec.md
@@ -1,0 +1,52 @@
+# HU-042 - Reflect delivery day exceptions across app texts and Google Sheets
+
+## Metadata
+- issue_id: #68
+- priority: P1
+- platform: both
+- status: implemented
+
+## Context and problem
+
+Weekly delivery exceptions already existed in `deliveryCalendar/{weekKey}`, but the effective date was not propagated consistently through app text surfaces and Google Sheets exports.
+
+## User story
+
+As an admin I want weekly delivery-day exceptions to be reflected everywhere so that members and operations see the same effective delivery date.
+
+## Scope
+
+### In Scope
+- Reflect the effective delivery date in Android/iOS texts and cards that reference weekly delivery shifts.
+- Reflect weekly exceptions in the corresponding Google Sheets rows for delivery shifts.
+- Keep Android/iOS parity.
+
+### Out of Scope
+- Annual planning generation.
+- General redesign/polish of the settings flow.
+
+## Acceptance criteria
+
+- A weekly exception saved from the app updates the effective delivery date shown in app UI for that week.
+- The same exception is reflected in the Google Sheet for that week.
+- Android and iOS behave the same.
+
+## Dependencies
+
+- `HU-011` delivery calendar management.
+- `HU-020` Google Sheets sync for shifts.
+- `HU-041` segmented shifts board.
+
+## Risks
+
+- Delivery exceptions may desync app text and sheet exports if one path still uses the original shift date.
+- Incremental shift exports may miss exception changes if only `shifts` writes are observed.
+
+## Definition of Done (DoD)
+
+- [x] App text surfaces use the effective delivery date for exception weeks.
+- [x] Google Sheets export updates after delivery-calendar changes.
+- [x] Android/iOS parity reviewed or temporary gap documented.
+- [x] Agreed tests executed.
+- [x] Technical/functional documentation updated.
+- [ ] Issue and PR linked.

--- a/spec/admin/hu-042-reflect-delivery-day-exceptions/tasks.md
+++ b/spec/admin/hu-042-reflect-delivery-day-exceptions/tasks.md
@@ -1,0 +1,31 @@
+# Tasks - HU-042 (Reflect delivery day exceptions across app texts and Google Sheets)
+
+## 1. Preparation
+- [x] Review issue #68 and identify affected Android/iOS/backend surfaces.
+- [x] Trace which UI texts still used raw `shift.date`.
+
+## 2. Android implementation
+- [x] Use effective delivery date in next shifts, board cards, swap labels, and calendar admin flow.
+- [x] Keep swap-request eligibility aligned with the effective future date.
+
+## 3. iOS implementation
+- [x] Use effective delivery date in next shifts, board cards, swap labels, and calendar admin flow.
+- [x] Keep swap-request eligibility aligned with the effective future date.
+
+## 4. Backend / Google Sheets
+- [x] Export delivery rows using effective exception dates.
+- [x] Re-export sheets when `deliveryCalendar/{weekKey}` changes.
+- [x] Keep incremental row updates aligned with effective week date matching.
+
+## 5. Testing
+- [x] Android validation executed.
+- [x] iOS validation executed.
+- [x] Functions validation executed.
+- [ ] Manual acceptance validation in app + sheet.
+
+## 6. Documentation
+- [x] Add HU-042 spec and issue note.
+- [x] Document scope and parity.
+
+## 7. Closure
+- [ ] Create/update linked issue and connect PR.

--- a/spec/issues/hu-042-reflect-delivery-day-exceptions-issue.md
+++ b/spec/issues/hu-042-reflect-delivery-day-exceptions-issue.md
@@ -1,0 +1,22 @@
+# [HU-042] Reflect delivery day exceptions across app texts and Google Sheets
+
+## Summary
+
+When an admin changes the delivery day for a specific week from the app, that exception should propagate consistently to all derived texts in the apps and to the linked Google Sheet row/cell where that week is shown.
+
+## Links
+- Issue: #68
+- Spec: spec/admin/hu-042-reflect-delivery-day-exceptions/spec.md
+- Tasks: spec/admin/hu-042-reflect-delivery-day-exceptions/tasks.md
+
+## Acceptance criteria
+
+- A weekly exception saved from the app updates the effective delivery date shown in app UI for that week.
+- The same exception is reflected in the Google Sheet for that week.
+- Android and iOS behave the same.
+
+## Implementation notes
+
+- Android and iOS resolve an effective delivery date by combining `shift.date` with any `deliveryCalendar/{weekKey}` override.
+- Google Sheets export now uses the effective date for delivery rows and re-exports when a delivery-calendar override changes.
+- Incremental delivery row updates match rows by ISO week key so an override can move the displayed day without losing the row mapping.


### PR DESCRIPTION
## Summary
- reflect weekly delivery exceptions in Android and iOS shift texts, swap flows, and delivery-calendar admin screens
- reflect delivery-calendar overrides in Google Sheets exports and incremental sync
- add HU-042 spec/tasks/issue notes for the follow-up from HU-011

## Validation
- Android: `./gradlew app:testDebugUnitTest`
- Android: `./gradlew app:lintDebug`
- iOS: `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:ReguertaTests test`
- Functions: `npm run lint`
- Functions: `npm run build`
