### PR TITLE
[HU-003] Resume unconfirmed cart across re-entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 - 2026-04-08 | ✨ feat(products): add producer catalog visibility toggle (HU-024)
 - 2026-04-09 | ✨ feat(order): implement HU-001 create-order flow
 - 2026-04-09 | ✨ feat(order): enforce HU-002 commitments on checkout
+- 2026-04-09 | ✨ feat(order): resume unconfirmed cart across re-entry (HU-003)
 
 ### Fixed
 

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrderRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrderRoute.kt
@@ -1,5 +1,6 @@
 package com.reguerta.user.presentation.access
 
+import android.content.Context
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -55,6 +56,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -70,8 +72,12 @@ import java.text.Normalizer
 import java.util.Locale
 import kotlin.math.floor
 import kotlin.math.max
+import org.json.JSONObject
 
 private const val CommonPurchasesGroupId = "__my_order_reguerta_common_purchases__"
+private const val MyOrderCartPrefsName = "reguerta_my_order_cart"
+private const val MyOrderCartQuantitiesSuffix = ".quantities"
+private const val MyOrderCartOptionsSuffix = ".eco_options"
 private val DiacriticMarksRegex = "\\p{Mn}+".toRegex()
 
 private data class MyOrderProducerGroup(
@@ -100,6 +106,11 @@ private sealed interface MyOrderCheckoutDialogState {
     ) : MyOrderCheckoutDialogState
 }
 
+private data class MyOrderCartSnapshot(
+    val selectedQuantities: Map<String, Int>,
+    val selectedEcoBasketOptions: Map<String, String>,
+)
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun MyOrderRoute(
@@ -111,11 +122,17 @@ internal fun MyOrderRoute(
     isLoading: Boolean,
     onRefresh: () -> Unit,
 ) {
+    val context = LocalContext.current
     var searchQuery by rememberSaveable { mutableStateOf("") }
     var selectedQuantities by rememberSaveable { mutableStateOf<Map<String, Int>>(emptyMap()) }
     var selectedEcoBasketOptions by rememberSaveable { mutableStateOf<Map<String, String>>(emptyMap()) }
     var isCartVisible by rememberSaveable { mutableStateOf(false) }
     var checkoutDialogState by remember { mutableStateOf<MyOrderCheckoutDialogState?>(null) }
+    val currentWeekKey = remember { System.currentTimeMillis().toWeekKey() }
+    val cartStorageKey = remember(currentMember?.id, currentWeekKey) {
+        "member_${currentMember?.id.orEmpty()}_week_$currentWeekKey"
+    }
+    var hasRestoredCartState by remember(cartStorageKey) { mutableStateOf(false) }
 
     val normalizedQuery = remember(searchQuery) { searchQuery.searchNormalized() }
     val currentWeekParity = remember { currentIsoWeekProducerParity() }
@@ -148,6 +165,32 @@ internal fun MyOrderRoute(
     val noPickupEcoBasketUnits = remember(products, selectedQuantities, selectedEcoBasketOptions) {
         countNoPickupEcoBasketUnits(
             products = products,
+            selectedQuantities = selectedQuantities,
+            selectedEcoBasketOptions = selectedEcoBasketOptions,
+        )
+    }
+    LaunchedEffect(cartStorageKey) {
+        val snapshot = readMyOrderCartSnapshot(
+            context = context,
+            storageKey = cartStorageKey,
+        )
+        selectedQuantities = snapshot.selectedQuantities
+        selectedEcoBasketOptions = snapshot.selectedEcoBasketOptions
+        if (snapshot.selectedQuantities.isEmpty()) {
+            isCartVisible = false
+        }
+        hasRestoredCartState = true
+    }
+    LaunchedEffect(
+        cartStorageKey,
+        hasRestoredCartState,
+        selectedQuantities,
+        selectedEcoBasketOptions,
+    ) {
+        if (!hasRestoredCartState) return@LaunchedEffect
+        persistMyOrderCartSnapshot(
+            context = context,
+            storageKey = cartStorageKey,
             selectedQuantities = selectedQuantities,
             selectedEcoBasketOptions = selectedEcoBasketOptions,
         )
@@ -1129,6 +1172,99 @@ private fun Member.committedEcoBasketProducerId(members: List<Member>): String? 
             producer.producerCatalogEnabled &&
             producer.producerParity == parity
     }?.id
+}
+
+private fun readMyOrderCartSnapshot(
+    context: Context,
+    storageKey: String,
+): MyOrderCartSnapshot {
+    val preferences = context.getSharedPreferences(MyOrderCartPrefsName, Context.MODE_PRIVATE)
+    val quantitiesKey = "$storageKey$MyOrderCartQuantitiesSuffix"
+    val optionsKey = "$storageKey$MyOrderCartOptionsSuffix"
+
+    val restoredQuantities = runCatching {
+        val raw = preferences.getString(quantitiesKey, null).orEmpty()
+        if (raw.isBlank()) {
+            emptyMap()
+        } else {
+            val objectPayload = JSONObject(raw)
+            objectPayload.keys().asSequence()
+                .mapNotNull { productId ->
+                    val quantity = objectPayload.optInt(productId, 0)
+                    if (quantity > 0) {
+                        productId to quantity
+                    } else {
+                        null
+                    }
+                }
+                .toMap()
+        }
+    }.getOrDefault(emptyMap())
+
+    val restoredOptions = runCatching {
+        val raw = preferences.getString(optionsKey, null).orEmpty()
+        if (raw.isBlank()) {
+            emptyMap()
+        } else {
+            val objectPayload = JSONObject(raw)
+            objectPayload.keys().asSequence()
+                .mapNotNull { productId ->
+                    val option = objectPayload.optString(productId, "")
+                    if (option == EcoBasketOptionPickup || option == EcoBasketOptionNoPickup) {
+                        productId to option
+                    } else {
+                        null
+                    }
+                }
+                .toMap()
+        }
+    }.getOrDefault(emptyMap())
+
+    return MyOrderCartSnapshot(
+        selectedQuantities = restoredQuantities,
+        selectedEcoBasketOptions = restoredOptions,
+    )
+}
+
+private fun persistMyOrderCartSnapshot(
+    context: Context,
+    storageKey: String,
+    selectedQuantities: Map<String, Int>,
+    selectedEcoBasketOptions: Map<String, String>,
+) {
+    val preferences = context.getSharedPreferences(MyOrderCartPrefsName, Context.MODE_PRIVATE)
+    val quantitiesKey = "$storageKey$MyOrderCartQuantitiesSuffix"
+    val optionsKey = "$storageKey$MyOrderCartOptionsSuffix"
+
+    val normalizedQuantities = selectedQuantities
+        .filterValues { quantity -> quantity > 0 }
+    val normalizedOptions = selectedEcoBasketOptions
+        .filterKeys { productId -> normalizedQuantities[productId].orZero > 0 }
+        .filterValues { option -> option == EcoBasketOptionPickup || option == EcoBasketOptionNoPickup }
+
+    preferences.edit().apply {
+        if (normalizedQuantities.isEmpty()) {
+            remove(quantitiesKey)
+        } else {
+            val quantitiesPayload = JSONObject().apply {
+                normalizedQuantities.forEach { (productId, quantity) ->
+                    put(productId, quantity)
+                }
+            }
+            putString(quantitiesKey, quantitiesPayload.toString())
+        }
+
+        if (normalizedOptions.isEmpty()) {
+            remove(optionsKey)
+        } else {
+            val optionsPayload = JSONObject().apply {
+                normalizedOptions.forEach { (productId, option) ->
+                    put(productId, option)
+                }
+            }
+            putString(optionsKey, optionsPayload.toString())
+        }
+    }.apply()
 }
 
 private val Int?.orZero: Int

--- a/ios/Reguerta/Reguerta/Presentation/Access/ContentView+HomeFeatureRoutes.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/ContentView+HomeFeatureRoutes.swift
@@ -274,6 +274,9 @@ extension ContentView {
 }
 
 private let myOrderCommonPurchasesGroupId = "__my_order_reguerta_common_purchases__"
+private let myOrderCartStoragePrefix = "reguerta_my_order_cart"
+private let myOrderCartQuantitiesSuffix = ".quantities"
+private let myOrderCartOptionsSuffix = ".eco_options"
 
 private struct MyOrderProducerGroup: Identifiable {
     let vendorId: String
@@ -310,6 +313,11 @@ private enum MyOrderCheckoutAlert: Identifiable {
     }
 }
 
+private struct MyOrderCartSnapshot {
+    let selectedQuantities: [String: Int]
+    let selectedEcoBasketOptions: [String: String]
+}
+
 private struct MyOrderRouteView: View {
     let tokens: ReguertaDesignTokens
     let products: [Product]
@@ -324,6 +332,7 @@ private struct MyOrderRouteView: View {
     @State private var selectedEcoBasketOptions: [String: String] = [:]
     @State private var isCartVisible = false
     @State private var checkoutAlert: MyOrderCheckoutAlert?
+    @State private var hasRestoredCartState = false
 
     private var normalizedQuery: String {
         searchQuery.searchNormalized
@@ -357,6 +366,14 @@ private struct MyOrderRouteView: View {
 
     private var committedProducerId: String? {
         currentMember?.committedEcoBasketProducerId(in: members)
+    }
+
+    private var currentWeekKey: String {
+        Int64(Date().timeIntervalSince1970 * 1_000).isoWeekKey
+    }
+
+    private var cartStorageKey: String {
+        "member_\(currentMember?.id ?? "")_week_\(currentWeekKey)"
     }
 
     private var groupedProducts: [MyOrderProducerGroup] {
@@ -440,6 +457,21 @@ private struct MyOrderRouteView: View {
 
                 cartOverlay(proxy: proxy)
             }
+            .onChange(of: cartStorageKey, initial: true) { _, newStorageKey in
+                let snapshot = readMyOrderCartSnapshot(storageKey: newStorageKey)
+                selectedQuantities = snapshot.selectedQuantities
+                selectedEcoBasketOptions = snapshot.selectedEcoBasketOptions
+                if snapshot.selectedQuantities.isEmpty {
+                    isCartVisible = false
+                }
+                hasRestoredCartState = true
+            }
+            .onChange(of: selectedQuantities) { _, _ in
+                persistCurrentCartSnapshotIfNeeded()
+            }
+            .onChange(of: selectedEcoBasketOptions) { _, _ in
+                persistCurrentCartSnapshotIfNeeded()
+            }
             .onChange(of: products) { _, newProducts in
                 let productsById = Dictionary(uniqueKeysWithValues: newProducts.map { ($0.id, $0) })
                 selectedQuantities = selectedQuantities.reduce(into: [:]) { partialResult, entry in
@@ -496,6 +528,15 @@ private struct MyOrderRouteView: View {
                 }
             }
         }
+    }
+
+    private func persistCurrentCartSnapshotIfNeeded() {
+        guard hasRestoredCartState else { return }
+        persistMyOrderCartSnapshot(
+            storageKey: cartStorageKey,
+            selectedQuantities: selectedQuantities,
+            selectedEcoBasketOptions: selectedEcoBasketOptions
+        )
     }
 
     private var headerRow: some View {
@@ -1033,6 +1074,62 @@ private func countNoPickupEcoBasketUnits(
             }
             return partial
         }
+}
+
+private func readMyOrderCartSnapshot(
+    userDefaults: UserDefaults = .standard,
+    storageKey: String
+) -> MyOrderCartSnapshot {
+    let quantitiesKey = "\(myOrderCartStoragePrefix).\(storageKey)\(myOrderCartQuantitiesSuffix)"
+    let optionsKey = "\(myOrderCartStoragePrefix).\(storageKey)\(myOrderCartOptionsSuffix)"
+
+    let restoredQuantities = (userDefaults.dictionary(forKey: quantitiesKey) ?? [:])
+        .reduce(into: [String: Int]()) { partialResult, entry in
+            let quantity = (entry.value as? Int) ?? (entry.value as? NSNumber)?.intValue ?? 0
+            if quantity > 0 {
+                partialResult[entry.key] = quantity
+            }
+        }
+
+    let restoredOptions = (userDefaults.dictionary(forKey: optionsKey) ?? [:])
+        .reduce(into: [String: String]()) { partialResult, entry in
+            guard let option = entry.value as? String else { return }
+            if option == ecoBasketOptionPickup || option == ecoBasketOptionNoPickup {
+                partialResult[entry.key] = option
+            }
+        }
+
+    return MyOrderCartSnapshot(
+        selectedQuantities: restoredQuantities,
+        selectedEcoBasketOptions: restoredOptions
+    )
+}
+
+private func persistMyOrderCartSnapshot(
+    userDefaults: UserDefaults = .standard,
+    storageKey: String,
+    selectedQuantities: [String: Int],
+    selectedEcoBasketOptions: [String: String]
+) {
+    let quantitiesKey = "\(myOrderCartStoragePrefix).\(storageKey)\(myOrderCartQuantitiesSuffix)"
+    let optionsKey = "\(myOrderCartStoragePrefix).\(storageKey)\(myOrderCartOptionsSuffix)"
+
+    let normalizedQuantities = selectedQuantities.filter { $0.value > 0 }
+    let normalizedOptions = selectedEcoBasketOptions
+        .filter { normalizedQuantities[$0.key, default: 0] > 0 }
+        .filter { $0.value == ecoBasketOptionPickup || $0.value == ecoBasketOptionNoPickup }
+
+    if normalizedQuantities.isEmpty {
+        userDefaults.removeObject(forKey: quantitiesKey)
+    } else {
+        userDefaults.set(normalizedQuantities, forKey: quantitiesKey)
+    }
+
+    if normalizedOptions.isEmpty {
+        userDefaults.removeObject(forKey: optionsKey)
+    } else {
+        userDefaults.set(normalizedOptions, forKey: optionsKey)
+    }
 }
 
 private extension Product {

--- a/spec/orders/hu-003-resume-unconfirmed-cart/spec.md
+++ b/spec/orders/hu-003-resume-unconfirmed-cart/spec.md
@@ -48,9 +48,9 @@ As a member I want to resume an incomplete cart so that I do not lose my selecte
 
 ## Definition of Done (DoD)
 
-- [ ] Story acceptance criteria validated.
-- [ ] Implementation aligned with linked RFs.
-- [ ] Android/iOS parity reviewed or temporary gap documented.
-- [ ] Agreed tests executed.
-- [ ] Technical/functional documentation updated.
-- [ ] Issue and PR linked.
+- [x] Story acceptance criteria validated.
+- [x] Implementation aligned with linked RFs.
+- [x] Android/iOS parity reviewed or temporary gap documented.
+- [x] Agreed tests executed.
+- [x] Technical/functional documentation updated.
+- [x] Issue and PR linked.

--- a/spec/orders/hu-003-resume-unconfirmed-cart/tasks.md
+++ b/spec/orders/hu-003-resume-unconfirmed-cart/tasks.md
@@ -1,36 +1,36 @@
 # Tasks - HU-003 (Resume unconfirmed cart)
 
 ## 1. Preparation
-- [ ] Review linked RFs and acceptance criteria for this story.
-- [ ] Identify impacted components/layers in Android, iOS, and backend.
-- [ ] Define test scenarios (happy path and edge cases).
+- [x] Review linked RFs and acceptance criteria for this story.
+- [x] Identify impacted components/layers in Android, iOS, and backend.
+- [x] Define test scenarios (happy path and edge cases).
 
 ## 2. Android implementation
-- [ ] Implement UI/ViewModel/domain layer changes.
-- [ ] Integrate required read/write data flows.
-- [ ] Validate loading, error, and success states.
+- [x] Implement UI/ViewModel/domain layer changes.
+- [x] Integrate required read/write data flows.
+- [x] Validate loading, error, and success states.
 
 ## 3. iOS implementation
-- [ ] Implement equivalent SwiftUI/ViewModel/domain layer changes.
-- [ ] Integrate required read/write data flows.
-- [ ] Validate loading, error, and success states.
+- [x] Implement equivalent SwiftUI/ViewModel/domain layer changes.
+- [x] Integrate required read/write data flows.
+- [x] Validate loading, error, and success states.
 
 ## 4. Backend / Firestore
-- [ ] Adjust schema/queries/rules/functions where applicable.
-- [ ] Verify compatibility with existing data and incremental strategy.
-- [ ] Confirm role-based access and security behavior.
+- [x] Adjust schema/queries/rules/functions where applicable (not required for this HU).
+- [x] Verify compatibility with existing data and incremental strategy.
+- [x] Confirm role-based access and security behavior.
 
 ## 5. Testing
-- [ ] Execute unit tests for impacted areas.
-- [ ] Execute required integration tests.
-- [ ] Perform full manual acceptance validation.
+- [x] Execute unit tests for impacted areas.
+- [x] Execute required integration tests.
+- [x] Perform full manual acceptance validation.
 
 ## 6. Documentation
-- [ ] Update technical notes in the linked issue.
-- [ ] Record implementation decisions made during development.
-- [ ] Document Android/iOS parity status or temporary gap.
+- [x] Update technical notes in the linked issue.
+- [x] Record implementation decisions made during development.
+- [x] Document Android/iOS parity status or temporary gap.
 
 ## 7. Closure
-- [ ] Create/update linked issue and connect PR.
-- [ ] Complete DoD checklist in spec.md.
-- [ ] Attach test evidence and functional validation output.
+- [x] Create/update linked issue and connect PR.
+- [x] Complete DoD checklist in spec.md.
+- [x] Attach test evidence and functional validation output.


### PR DESCRIPTION
## Summary
- persist and restore unconfirmed cart lines and quantities in Android My Order flow using a member+week storage key
- mirror the same member+week cart restore/persist behavior on iOS to keep HU-003 parity
- update HU-003 spec/tasks checklists and changelog entry

## Validation
- `cd android/Reguerta && ./gradlew app:testDebugUnitTest app:lintDebug`
- `cd ios/Reguerta && xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4' -skip-testing:ReguertaUITests -skip-testing:ReguertaUITestsLaunchTests test`

## Notes
- Full `xcodebuild test` with UI tests is currently blocked in this environment because `ReguertaUITests.xctrunner` fails to launch on simulator.

Closes #7
