### PR TITLE
docs(spec): add HU-044 to HU-049 drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - 2026-04-15 | 📝 docs(agents): require conventional-commits skill before commits
 - 2026-04-17 | 📝 docs(reviewer): finalize HU-018 closure checklists
 - 2026-04-17 | 📝 docs(admin): finalize HU-010 closure checklists and links
+- 2026-04-17 | 📝 docs(spec): add HU-044..HU-049 specs and issue links
 
 ### Maintenance
 

--- a/spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/plan.md
+++ b/spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/plan.md
@@ -1,0 +1,53 @@
+# Plan - HU-044 (Canonical role permission matrix and test fixtures)
+
+## 1. Technical approach
+
+Establish a single source of truth for role permissions, then align platform permission checks and seeded fixtures to that contract with automated drift detection.
+
+## 2. Layer impact
+- UI: Gate module visibility and actions from canonical role capabilities.
+- Domain: Centralize capability checks and remove implicit role assumptions.
+- Data: Align seeded member fixtures and test repositories with matrix-defined privileges.
+- Backend: Keep authorization semantics consistent with matrix expectations.
+- Docs: Add matrix artifact and link from affected HUs.
+
+## 3. Platform-specific changes
+### Android
+- Refactor capability checks to consume canonical matrix mapping.
+- Update in-memory fixtures and tests to mirror matrix roles.
+
+### iOS
+- Refactor capability checks to consume canonical matrix mapping.
+- Update in-memory fixtures and tests to mirror matrix roles.
+
+### Functions/Backend
+- Validate role assumptions against matrix where admin/producer behavior is enforced server-side.
+
+## 4. Test strategy
+- Unit tests for role-to-capability resolution.
+- Snapshot/contract tests for canonical matrix consistency.
+- Manual validation for key role-gated screens in both platforms.
+
+## 5. Rollout and functional validation
+- Introduce matrix and fixtures in develop first.
+- Run full Android/iOS suites and compare role behavior parity.
+- Confirm no regressions in existing admin/producer flows.
+
+## 6. Phased implementation sequence
+### Phase 1 - Preparation
+- Define matrix schema and canonical location.
+- List all current role checks affected by drift.
+
+### Phase 2 - Implementation
+- Wire Android/iOS permission checks to canonical mapping.
+- Align fixtures and role-based tests.
+
+### Phase 3 - Closure
+- Execute parity validation.
+- Update issue/spec/tasks with evidence.
+
+## 7. Technical risks and mitigation
+- Risk: hidden role checks remain outside matrix.
+  - Mitigation: search-and-audit all role-gating entry points.
+- Risk: fixture churn breaks unrelated tests.
+  - Mitigation: stage fixture updates with focused regression suite.

--- a/spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/spec.md
+++ b/spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/spec.md
@@ -1,0 +1,61 @@
+# HU-044 - Canonical role permission matrix and test fixtures
+
+## Metadata
+- issue_id: #105
+- priority: P1
+- platform: both
+- status: ready
+
+## Context and problem
+
+Permission checks, role-based UI visibility, and test fixtures can drift over time, creating regressions and inconsistent behavior between Android, iOS, and tests.
+
+## User story
+
+As a product and engineering team I want one canonical role-permission matrix and aligned fixtures so behavior stays consistent across app code and test suites.
+
+## Scope
+
+### In Scope
+- Define one canonical matrix for `member`, `producer`, `admin`, and `reviewer` capabilities.
+- Align Android/iOS permission helpers and UI gating against that matrix.
+- Align in-memory/test fixtures with the same permission contract.
+- Add guardrails to detect drift (tests and/or static checks).
+
+### Out of Scope
+- New business roles beyond current MVP roles.
+- Broad redesign of home/navigation UX.
+
+## Linked functional requirements
+
+- RF-ROL-03, RF-ROL-04, RF-ROL-05, RF-ROL-06, RF-ROL-08
+
+## Acceptance criteria
+
+- A single canonical permission matrix exists in-repo and is referenced by implementation and tests.
+- Android and iOS role-gating behavior matches the matrix for core modules.
+- Test fixtures for seeded users match matrix expectations (including admin capabilities).
+- CI detects permission drift when role rules and fixtures diverge.
+
+## Dependencies
+
+- Base references: docs-es/requirements/requisitos-mvp-reguerta-v1.md.
+- Functional references: docs-es/requirements/historias-usuario-mvp-reguerta-v1.md.
+- Data references: docs-es/requirements/firestore-estructura-mvp-propuesta-v1.md.
+- Depends on HU-010 role model and HU-039 role-aware shell.
+
+## Risks
+
+- Risk: over-constraining future role evolution.
+  - Mitigation: keep matrix extensible and versioned.
+- Risk: parity drift after future feature additions.
+  - Mitigation: enforce matrix-based tests in both platforms.
+
+## Definition of Done (DoD)
+
+- [ ] Story acceptance criteria validated.
+- [ ] Implementation aligned with linked RFs.
+- [ ] Android/iOS parity reviewed or temporary gap documented.
+- [ ] Agreed tests executed.
+- [ ] Technical/functional documentation updated.
+- [ ] Issue and PR linked.

--- a/spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/tasks.md
+++ b/spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/tasks.md
@@ -1,0 +1,35 @@
+# Tasks - HU-044 (Canonical role permission matrix and test fixtures)
+
+## 1. Preparation
+- [ ] Define canonical role-permission matrix schema and storage path.
+- [ ] Inventory current permission checks and fixture role assumptions.
+- [ ] Confirm MVP role list and capability boundaries.
+
+## 2. Android implementation
+- [ ] Align Android capability checks with matrix.
+- [ ] Update Android test fixtures/seeds to match matrix.
+- [ ] Add drift-detection tests for Android role gating.
+
+## 3. iOS implementation
+- [ ] Align iOS capability checks with matrix.
+- [ ] Update iOS test fixtures/seeds to match matrix.
+- [ ] Add drift-detection tests for iOS role gating.
+
+## 4. Backend / Firestore
+- [ ] Validate backend role assumptions against matrix.
+- [ ] Update any backend role checks that diverge from canonical contract.
+
+## 5. Testing
+- [ ] Execute Android unit/integration tests for role gating.
+- [ ] Execute iOS unit/UI tests for role gating.
+- [ ] Perform manual cross-role validation in develop.
+
+## 6. Documentation
+- [ ] Document canonical matrix and ownership.
+- [ ] Link matrix from related HU specs/issues.
+- [ ] Record parity status and known exceptions (if any).
+
+## 7. Closure
+- [ ] Create/update linked issue and connect PR.
+- [ ] Complete DoD checklist in spec.md.
+- [ ] Attach test evidence and drift-check results.

--- a/spec/app/hu-047-mvp-role-based-e2e-parity-suite/plan.md
+++ b/spec/app/hu-047-mvp-role-based-e2e-parity-suite/plan.md
@@ -1,0 +1,53 @@
+# Plan - HU-047 (MVP role-based E2E parity suite)
+
+## 1. Technical approach
+
+Define a compact but strict MVP E2E matrix by role, then automate representative flows for Android and iOS with deterministic fixtures and parity reporting.
+
+## 2. Layer impact
+- UI: Stable selectors and deterministic route states for testability.
+- Domain: Expose deterministic preconditions for role-based flows.
+- Data: Seed data contracts for role scenarios.
+- Backend: Provide predictable environment state for E2E execution.
+- Docs: Role-to-scenario matrix and release-gate criteria.
+
+## 3. Platform-specific changes
+### Android
+- Add/extend connected/UI tests for MVP role journeys.
+- Add utilities for deterministic setup and cleanup.
+
+### iOS
+- Add/extend UI tests for MVP role journeys.
+- Add utilities for deterministic setup and cleanup.
+
+### Functions/Backend
+- Define stable test fixtures and reset hooks where required.
+
+## 4. Test strategy
+- Smoke E2E per role and platform.
+- Parity checklist comparing expected outcomes Android vs iOS.
+- Manual fallback checklist for known simulator/emulator limitations.
+
+## 5. Rollout and functional validation
+- Start with develop-only nightly runs.
+- Stabilize flaky scenarios before enforcing gate.
+- Promote to mandatory pre-release gate.
+
+## 6. Phased implementation sequence
+### Phase 1 - Preparation
+- Select MVP-critical journeys and map to roles.
+- Define deterministic fixture setup contract.
+
+### Phase 2 - Implementation
+- Implement Android and iOS E2E scenarios.
+- Add parity report generation.
+
+### Phase 3 - Closure
+- Execute repeated runs for stability.
+- Update docs and release checklist.
+
+## 7. Technical risks and mitigation
+- Risk: environment-dependent flakiness.
+  - Mitigation: deterministic test data and explicit reset steps.
+- Risk: long runtime increases CI cost.
+  - Mitigation: keep smoke subset focused and parallelize safely.

--- a/spec/app/hu-047-mvp-role-based-e2e-parity-suite/spec.md
+++ b/spec/app/hu-047-mvp-role-based-e2e-parity-suite/spec.md
@@ -1,0 +1,63 @@
+# HU-047 - MVP role-based E2E parity suite
+
+## Metadata
+- issue_id: #108
+- priority: P2
+- platform: both
+- status: ready
+
+## Context and problem
+
+Core flows now span multiple roles and platforms. Without an explicit E2E suite, regressions can ship even when unit/integration tests pass.
+
+## User story
+
+As a release owner I want a role-based MVP E2E suite so we can validate critical journeys with parity across Android and iOS before release.
+
+## Scope
+
+### In Scope
+- Define MVP E2E matrix by role: member, producer, admin, reviewer.
+- Implement automated smoke E2E scenarios for both Android and iOS.
+- Standardize seed/fixture prerequisites per role and environment.
+- Produce parity evidence and known-gap reporting per run.
+
+### Out of Scope
+- Full non-MVP regression test expansion.
+- Performance benchmarking.
+
+## Linked functional requirements
+
+- RF-APP-02
+- RF-ROL-03, RF-ROL-04
+- RF-PROD-01, RF-PROD-04
+
+## Acceptance criteria
+
+- Each MVP role has at least one automated end-to-end scenario on Android and iOS.
+- E2E suite includes preconditions, expected results, and deterministic test data contract.
+- CI publishes pass/fail evidence and clearly flags parity gaps.
+- Release checklist references this suite as a required gate.
+
+## Dependencies
+
+- Base references: docs-es/requirements/requisitos-mvp-reguerta-v1.md.
+- Functional references: docs-es/requirements/historias-usuario-mvp-reguerta-v1.md.
+- Data references: docs-es/requirements/firestore-estructura-mvp-propuesta-v1.md.
+- Depends on HU-008, HU-009, HU-010, HU-018, and HU-023.
+
+## Risks
+
+- Risk: flaky UI tests reduce trust in the suite.
+  - Mitigation: deterministic seeds, stable selectors, and non-parallel fallback where needed.
+- Risk: high maintenance cost.
+  - Mitigation: keep smoke set focused on MVP-critical paths.
+
+## Definition of Done (DoD)
+
+- [ ] Story acceptance criteria validated.
+- [ ] Implementation aligned with linked RFs.
+- [ ] Android/iOS parity reviewed or temporary gap documented.
+- [ ] Agreed tests executed.
+- [ ] Technical/functional documentation updated.
+- [ ] Issue and PR linked.

--- a/spec/app/hu-047-mvp-role-based-e2e-parity-suite/tasks.md
+++ b/spec/app/hu-047-mvp-role-based-e2e-parity-suite/tasks.md
@@ -1,0 +1,35 @@
+# Tasks - HU-047 (MVP role-based E2E parity suite)
+
+## 1. Preparation
+- [ ] Define MVP E2E role matrix and scenario list.
+- [ ] Define deterministic fixture and reset contract.
+- [ ] Define parity-report format and pass/fail thresholds.
+
+## 2. Android implementation
+- [ ] Implement Android E2E smoke scenarios for all MVP roles.
+- [ ] Add shared Android helpers for setup and cleanup.
+- [ ] Add Android evidence artifacts in CI.
+
+## 3. iOS implementation
+- [ ] Implement iOS E2E smoke scenarios for all MVP roles.
+- [ ] Add shared iOS helpers for setup and cleanup.
+- [ ] Add iOS evidence artifacts in CI.
+
+## 4. Backend / Firestore
+- [ ] Provide deterministic test data setup/reset hooks.
+- [ ] Ensure role fixtures are stable across repeated E2E runs.
+
+## 5. Testing
+- [ ] Execute repeated Android E2E runs for stability.
+- [ ] Execute repeated iOS E2E runs for stability.
+- [ ] Perform manual parity review for scenario outcomes.
+
+## 6. Documentation
+- [ ] Document role-to-scenario matrix and release gate usage.
+- [ ] Document known flaky scenarios and mitigation strategy.
+- [ ] Record parity status and gaps.
+
+## 7. Closure
+- [ ] Create/update linked issue and connect PR.
+- [ ] Complete DoD checklist in spec.md.
+- [ ] Attach CI artifacts and parity evidence.

--- a/spec/issues/hu-044-canonical-role-permission-matrix-and-test-fixtures-issue.md
+++ b/spec/issues/hu-044-canonical-role-permission-matrix-and-test-fixtures-issue.md
@@ -1,0 +1,43 @@
+# [HU-044] Canonical role permission matrix and test fixtures
+
+## Summary
+
+As a product and engineering team we want one canonical role-permission matrix and aligned fixtures so behavior stays consistent across app code and tests.
+
+## Links
+- Spec: spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/spec.md
+- Plan: spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/plan.md
+- Tasks: spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/tasks.md
+
+## Acceptance criteria
+
+- A single canonical permission matrix exists in-repo and is referenced by implementation and tests.
+- Android and iOS role-gating behavior matches the matrix for core modules.
+- Test fixtures for seeded users match matrix expectations (including admin capabilities).
+- CI detects permission drift when role rules and fixtures diverge.
+
+## Scope
+### In Scope
+- Implement story HU-044 within MVP scope.
+- Satisfy linked RFs: RF-ROL-03, RF-ROL-04, RF-ROL-05, RF-ROL-06, RF-ROL-08.
+
+### Out of Scope
+- New business roles beyond current MVP roles.
+- Broad redesign of home/navigation UX.
+
+## Implementation checklist
+- [ ] Android
+- [ ] iOS
+- [ ] Backend / Firestore
+- [ ] Testing
+- [ ] Documentation
+
+## Suggested labels
+- type:feature
+- area:app
+- platform:cross
+- priority:P1
+
+## Dependencies
+- #1 (HU-010)
+- #56 (HU-039)

--- a/spec/issues/hu-045-firestore-security-for-producer-order-status-issue.md
+++ b/spec/issues/hu-045-firestore-security-for-producer-order-status-issue.md
@@ -1,0 +1,44 @@
+# [HU-045] Firestore security for producer order status
+
+## Summary
+
+As an admin I want strict Firestore rules for producer status updates so only authorized actors can change status and data remains trustworthy.
+
+## Links
+- Spec: spec/orders/hu-045-firestore-security-for-producer-order-status/spec.md
+- Plan: spec/orders/hu-045-firestore-security-for-producer-order-status/plan.md
+- Tasks: spec/orders/hu-045-firestore-security-for-producer-order-status/tasks.md
+
+## Acceptance criteria
+
+- Consumers cannot write producer status fields.
+- Producers can only update status for their own producer-scoped lines/orders.
+- Admin role can apply status corrections under explicit rule constraints.
+- Security tests cover allow/deny cases per role and environment and pass in CI.
+
+## Scope
+### In Scope
+- Implement story HU-045 within MVP scope.
+- Satisfy linked RFs: RF-PROD-04, RF-ROL-05.
+
+### Out of Scope
+- Replacing the current status model with a new domain model.
+- Non-status order editing workflows.
+
+## Implementation checklist
+- [ ] Android
+- [ ] iOS
+- [ ] Backend / Firestore
+- [ ] Testing
+- [ ] Documentation
+
+## Suggested labels
+- type:feature
+- area:orders
+- platform:cross
+- priority:P1
+
+## Dependencies
+- #9 (HU-008)
+- #15 (HU-009)
+- #13 (HU-018)

--- a/spec/issues/hu-046-reminder-scheduler-idempotency-and-retries-issue.md
+++ b/spec/issues/hu-046-reminder-scheduler-idempotency-and-retries-issue.md
@@ -1,0 +1,42 @@
+# [HU-046] Reminder scheduler idempotency and retries
+
+## Summary
+
+As a member with commitments I want reminder jobs to run reliably and only once per slot so I can trust pending-order notifications.
+
+## Links
+- Spec: spec/notifications/hu-046-reminder-scheduler-idempotency-and-retries/spec.md
+- Plan: spec/notifications/hu-046-reminder-scheduler-idempotency-and-retries/plan.md
+- Tasks: spec/notifications/hu-046-reminder-scheduler-idempotency-and-retries/tasks.md
+
+## Acceptance criteria
+
+- Reminder jobs execute at configured weekly slots in Europe/Madrid timezone.
+- A user receives at most one reminder per slot for the same target week.
+- Transient failures trigger bounded retries and are observable in logs/metrics.
+- Operators can inspect run-level outcomes (processed, sent, skipped, failed).
+
+## Scope
+### In Scope
+- Implement story HU-046 within MVP scope.
+- Satisfy linked RFs: RF-NOTI-02, RF-NOTI-03.
+
+### Out of Scope
+- Redesign of reminder content/copy.
+- Full campaign-management features.
+
+## Implementation checklist
+- [ ] Android
+- [ ] iOS
+- [ ] Backend / Firestore
+- [ ] Testing
+- [ ] Documentation
+
+## Suggested labels
+- type:feature
+- area:notifications
+- platform:cross
+- priority:P1
+
+## Dependencies
+- #10 (HU-006)

--- a/spec/issues/hu-047-mvp-role-based-e2e-parity-suite-issue.md
+++ b/spec/issues/hu-047-mvp-role-based-e2e-parity-suite-issue.md
@@ -1,0 +1,46 @@
+# [HU-047] MVP role-based E2E parity suite
+
+## Summary
+
+As a release owner I want a role-based MVP E2E suite so we can validate critical journeys with parity across Android and iOS before release.
+
+## Links
+- Spec: spec/app/hu-047-mvp-role-based-e2e-parity-suite/spec.md
+- Plan: spec/app/hu-047-mvp-role-based-e2e-parity-suite/plan.md
+- Tasks: spec/app/hu-047-mvp-role-based-e2e-parity-suite/tasks.md
+
+## Acceptance criteria
+
+- Each MVP role has at least one automated end-to-end scenario on Android and iOS.
+- E2E suite includes preconditions, expected results, and deterministic test data contract.
+- CI publishes pass/fail evidence and clearly flags parity gaps.
+- Release checklist references this suite as a required gate.
+
+## Scope
+### In Scope
+- Implement story HU-047 within MVP scope.
+- Satisfy linked RFs: RF-APP-02, RF-ROL-03, RF-ROL-04, RF-PROD-01, RF-PROD-04.
+
+### Out of Scope
+- Full non-MVP regression test expansion.
+- Performance benchmarking.
+
+## Implementation checklist
+- [ ] Android
+- [ ] iOS
+- [ ] Backend / Firestore
+- [ ] Testing
+- [ ] Documentation
+
+## Suggested labels
+- type:feature
+- area:app
+- platform:cross
+- priority:P2
+
+## Dependencies
+- #9 (HU-008)
+- #15 (HU-009)
+- #1 (HU-010)
+- #13 (HU-018)
+- #23 (HU-023)

--- a/spec/issues/hu-048-environment-and-impersonation-policy-hardening-issue.md
+++ b/spec/issues/hu-048-environment-and-impersonation-policy-hardening-issue.md
@@ -1,0 +1,42 @@
+# [HU-048] Environment and impersonation policy hardening
+
+## Summary
+
+As a security owner I want a hardened environment and impersonation policy so production data remains protected from debug-only capabilities.
+
+## Links
+- Spec: spec/reviewer/hu-048-environment-and-impersonation-policy-hardening/spec.md
+- Plan: spec/reviewer/hu-048-environment-and-impersonation-policy-hardening/plan.md
+- Tasks: spec/reviewer/hu-048-environment-and-impersonation-policy-hardening/tasks.md
+
+## Acceptance criteria
+
+- Release builds cannot enable impersonation through UI, hidden arguments, or persisted flags.
+- Develop-only environment overrides remain available for QA and are clearly bounded.
+- Reviewer routing and environment behavior are validated with explicit no-contamination checks.
+- Android and iOS enforce equivalent hardening behavior.
+
+## Scope
+### In Scope
+- Implement story HU-048 within MVP scope.
+- Satisfy linked RFs: RF-REV-01, RF-REV-02, RF-REV-03, RF-ROL-05.
+
+### Out of Scope
+- Full IAM redesign outside app/runtime boundaries.
+- New business reviewer features unrelated to environment safety.
+
+## Implementation checklist
+- [ ] Android
+- [ ] iOS
+- [ ] Backend / Firestore
+- [ ] Testing
+- [ ] Documentation
+
+## Suggested labels
+- type:feature
+- area:reviewer
+- platform:cross
+- priority:P1
+
+## Dependencies
+- #13 (HU-018)

--- a/spec/issues/hu-049-minimum-operational-observability-for-critical-jobs-issue.md
+++ b/spec/issues/hu-049-minimum-operational-observability-for-critical-jobs-issue.md
@@ -1,0 +1,43 @@
+# [HU-049] Minimum operational observability for critical jobs
+
+## Summary
+
+As an operator I want minimum observability for critical jobs so failures are detected early and triaged quickly.
+
+## Links
+- Spec: spec/notifications/hu-049-minimum-operational-observability-for-critical-jobs/spec.md
+- Plan: spec/notifications/hu-049-minimum-operational-observability-for-critical-jobs/plan.md
+- Tasks: spec/notifications/hu-049-minimum-operational-observability-for-critical-jobs/tasks.md
+
+## Acceptance criteria
+
+- Critical jobs emit structured logs and basic counters (`processed`, `sent`, `failed`, `duration`).
+- Alerts trigger for repeated failures and missing scheduled executions.
+- Push failure reasons are classified and queryable.
+- Runbook exists and is linked from the story docs.
+
+## Scope
+### In Scope
+- Implement story HU-049 within MVP scope.
+- Satisfy linked RFs: RF-NOTI-03, RF-APP-04.
+
+### Out of Scope
+- Full SRE platform migration.
+- Advanced long-term analytics dashboards.
+
+## Implementation checklist
+- [ ] Android
+- [ ] iOS
+- [ ] Backend / Firestore
+- [ ] Testing
+- [ ] Documentation
+
+## Suggested labels
+- type:feature
+- area:notifications
+- platform:backend
+- priority:P2
+
+## Dependencies
+- #10 (HU-006)
+- #107 (HU-046)

--- a/spec/notifications/hu-046-reminder-scheduler-idempotency-and-retries/plan.md
+++ b/spec/notifications/hu-046-reminder-scheduler-idempotency-and-retries/plan.md
@@ -1,0 +1,53 @@
+# Plan - HU-046 (Reminder scheduler idempotency and retries)
+
+## 1. Technical approach
+
+Implement scheduler-driven reminder orchestration with idempotency keys, bounded retries, and run-level telemetry so reminder delivery is reliable and diagnosable.
+
+## 2. Layer impact
+- UI: No major UI redesign; ensure client tolerates duplicate-avoidance semantics.
+- Domain: Define reminder slot identity and idempotency contract.
+- Data: Persist job execution state and send-attempt outcomes.
+- Backend: Scheduler jobs, retry policy, and push dispatch orchestration.
+- Docs: Runbook and operational notes for reminder jobs.
+
+## 3. Platform-specific changes
+### Android
+- Validate push handling and user-visible behavior with orchestrated reminder events.
+
+### iOS
+- Validate push handling and user-visible behavior with orchestrated reminder events.
+
+### Functions/Backend
+- Add Cloud Scheduler triggers and orchestrator entrypoint.
+- Implement idempotent send flow with transaction-safe write markers.
+- Implement retry behavior for transient failures.
+
+## 4. Test strategy
+- Unit tests for slot/idempotency key generation.
+- Integration tests for retry and duplicate suppression logic.
+- Manual validation with controlled time-machine and scheduler windows.
+
+## 5. Rollout and functional validation
+- Dry-run in develop with trace-only mode.
+- Enable sends for selected test cohort.
+- Promote to broader develop validation after stability checks.
+
+## 6. Phased implementation sequence
+### Phase 1 - Preparation
+- Define slot model and idempotency key format.
+- Define retry taxonomy (transient vs terminal failures).
+
+### Phase 2 - Implementation
+- Build scheduler + orchestrator + retry flow.
+- Persist run metrics and result logs.
+
+### Phase 3 - Closure
+- Execute end-to-end reminder validation.
+- Document runbook and monitoring hooks.
+
+## 7. Technical risks and mitigation
+- Risk: race conditions create duplicates.
+  - Mitigation: transaction/lock + unique idempotency records.
+- Risk: retries overwhelm push provider.
+  - Mitigation: exponential backoff and capped attempts.

--- a/spec/notifications/hu-046-reminder-scheduler-idempotency-and-retries/spec.md
+++ b/spec/notifications/hu-046-reminder-scheduler-idempotency-and-retries/spec.md
@@ -1,0 +1,61 @@
+# HU-046 - Reminder scheduler idempotency and retries
+
+## Metadata
+- issue_id: #107
+- priority: P1
+- platform: both
+- status: ready
+
+## Context and problem
+
+Reminder delivery requires stable orchestration. Without idempotency, retries, and traceability, users may miss reminders or receive duplicates.
+
+## User story
+
+As a member with commitments I want reminder jobs to run reliably and only once per slot so I can trust pending-order notifications.
+
+## Scope
+
+### In Scope
+- Implement scheduler-driven reminder orchestration in Functions.
+- Guarantee idempotent send behavior by reminder slot/week/user.
+- Add retry policy for transient errors with bounded attempts.
+- Add execution traces for operational diagnostics.
+
+### Out of Scope
+- Redesign of reminder content/copy.
+- Full campaign-management features.
+
+## Linked functional requirements
+
+- RF-NOTI-02, RF-NOTI-03
+
+## Acceptance criteria
+
+- Reminder jobs execute at configured weekly slots in Europe/Madrid timezone.
+- A user receives at most one reminder per slot for the same target week.
+- Transient failures trigger bounded retries and are observable in logs/metrics.
+- Operators can inspect run-level outcomes (processed, sent, skipped, failed).
+
+## Dependencies
+
+- Base references: docs-es/requirements/requisitos-mvp-reguerta-v1.md.
+- Functional references: docs-es/requirements/historias-usuario-mvp-reguerta-v1.md.
+- Data references: docs-es/requirements/firestore-estructura-mvp-propuesta-v1.md.
+- Depends on HU-006 reminder functional behavior.
+
+## Risks
+
+- Risk: duplicate notifications from concurrent executions.
+  - Mitigation: enforce idempotency keys and transactional writes.
+- Risk: silent failures in push provider paths.
+  - Mitigation: structured error logging and retry telemetry.
+
+## Definition of Done (DoD)
+
+- [ ] Story acceptance criteria validated.
+- [ ] Implementation aligned with linked RFs.
+- [ ] Android/iOS parity reviewed or temporary gap documented.
+- [ ] Agreed tests executed.
+- [ ] Technical/functional documentation updated.
+- [ ] Issue and PR linked.

--- a/spec/notifications/hu-046-reminder-scheduler-idempotency-and-retries/tasks.md
+++ b/spec/notifications/hu-046-reminder-scheduler-idempotency-and-retries/tasks.md
@@ -1,0 +1,35 @@
+# Tasks - HU-046 (Reminder scheduler idempotency and retries)
+
+## 1. Preparation
+- [ ] Define reminder slot identity and idempotency key contract.
+- [ ] Define retry policy (attempts, backoff, terminal states).
+- [ ] Confirm operator observability requirements for job runs.
+
+## 2. Android implementation
+- [ ] Validate Android push behavior under idempotent reminder delivery.
+- [ ] Ensure no client-side assumptions conflict with retry orchestration.
+
+## 3. iOS implementation
+- [ ] Validate iOS push behavior under idempotent reminder delivery.
+- [ ] Ensure no client-side assumptions conflict with retry orchestration.
+
+## 4. Backend / Firestore
+- [ ] Implement scheduler trigger and reminder orchestrator.
+- [ ] Implement idempotent send markers and transaction-safe writes.
+- [ ] Implement retry flow for transient failures.
+- [ ] Persist run outcomes for observability.
+
+## 5. Testing
+- [ ] Execute unit tests for slot/idempotency/retry logic.
+- [ ] Execute integration tests for duplicate suppression and retry outcomes.
+- [ ] Perform manual time-window validation in develop.
+
+## 6. Documentation
+- [ ] Document reminder orchestration contract and retry taxonomy.
+- [ ] Document operator runbook for failed runs.
+- [ ] Record Android/iOS parity notes.
+
+## 7. Closure
+- [ ] Create/update linked issue and connect PR.
+- [ ] Complete DoD checklist in spec.md.
+- [ ] Attach scheduler run evidence and validation logs.

--- a/spec/notifications/hu-049-minimum-operational-observability-for-critical-jobs/plan.md
+++ b/spec/notifications/hu-049-minimum-operational-observability-for-critical-jobs/plan.md
@@ -1,0 +1,55 @@
+# Plan - HU-049 (Minimum operational observability for critical jobs)
+
+## 1. Technical approach
+
+Define and implement a minimal observability baseline (structured logs, key metrics, and alerts) for critical backend jobs and push delivery paths.
+
+## 2. Layer impact
+- UI: Optional admin-facing diagnostics only if needed later.
+- Domain: Define canonical event taxonomy for job outcomes.
+- Data: Persist operational counters and failure classifications.
+- Backend: Emit metrics/logs and configure alerting routes.
+- Docs: Create runbook for triage and escalation.
+
+## 3. Platform-specific changes
+### Android
+- No direct feature changes expected.
+- Validate push client behavior against new failure classifications if surfaced.
+
+### iOS
+- No direct feature changes expected.
+- Validate push client behavior against new failure classifications if surfaced.
+
+### Functions/Backend
+- Instrument critical jobs with structured logging and counters.
+- Configure baseline alerts for failure spikes and missing runs.
+- Add push failure reason classification.
+
+## 4. Test strategy
+- Unit tests for telemetry/event formatting.
+- Integration tests for metrics/log emission paths.
+- Manual alert drill in develop/staging.
+
+## 5. Rollout and functional validation
+- Enable instrumentation first with alerts muted.
+- Tune thresholds after baseline observation period.
+- Enable actionable alerts after noise reduction.
+
+## 6. Phased implementation sequence
+### Phase 1 - Preparation
+- Define minimum telemetry contract and alert policy.
+- Identify critical jobs and owner mapping.
+
+### Phase 2 - Implementation
+- Add instrumentation and failure taxonomy.
+- Configure alerts and dashboards.
+
+### Phase 3 - Closure
+- Run alert-drill and incident simulation.
+- Document runbook and ownership.
+
+## 7. Technical risks and mitigation
+- Risk: high-noise alerts reduce response quality.
+  - Mitigation: staged thresholds and owner feedback loop.
+- Risk: telemetry gaps limit root-cause analysis.
+  - Mitigation: enforce required fields in structured logs.

--- a/spec/notifications/hu-049-minimum-operational-observability-for-critical-jobs/spec.md
+++ b/spec/notifications/hu-049-minimum-operational-observability-for-critical-jobs/spec.md
@@ -1,0 +1,62 @@
+# HU-049 - Minimum operational observability for critical jobs
+
+## Metadata
+- issue_id: #110
+- priority: P2
+- platform: backend
+- status: ready
+
+## Context and problem
+
+Critical backend jobs currently lack a minimal, standardized observability baseline. Without this, incidents on reminders/push/jobs can go unnoticed or be slow to diagnose.
+
+## User story
+
+As an operator I want minimum observability for critical jobs so failures are detected early and triaged quickly.
+
+## Scope
+
+### In Scope
+- Define minimum metrics/logging contract for critical Functions jobs.
+- Add alerting thresholds for job failures and abnormal inactivity.
+- Track push delivery failure categories with actionable diagnostics.
+- Document runbook steps for first-response triage.
+
+### Out of Scope
+- Full SRE platform migration.
+- Advanced long-term analytics dashboards.
+
+## Linked functional requirements
+
+- RF-NOTI-03
+- RF-APP-04
+
+## Acceptance criteria
+
+- Critical jobs emit structured logs and basic counters (`processed`, `sent`, `failed`, `duration`).
+- Alerts trigger for repeated failures and missing scheduled executions.
+- Push failure reasons are classified and queryable.
+- Runbook exists and is linked from the story docs.
+
+## Dependencies
+
+- Base references: docs-es/requirements/requisitos-mvp-reguerta-v1.md.
+- Functional references: docs-es/requirements/historias-usuario-mvp-reguerta-v1.md.
+- Data references: docs-es/requirements/firestore-estructura-mvp-propuesta-v1.md.
+- Depends on HU-006 and HU-046 orchestration scope.
+
+## Risks
+
+- Risk: alert noise leads to ignored incidents.
+  - Mitigation: tune thresholds with staged rollout.
+- Risk: incomplete telemetry misses key failure modes.
+  - Mitigation: define and enforce a minimum event taxonomy.
+
+## Definition of Done (DoD)
+
+- [ ] Story acceptance criteria validated.
+- [ ] Implementation aligned with linked RFs.
+- [ ] Android/iOS parity reviewed or temporary gap documented.
+- [ ] Agreed tests executed.
+- [ ] Technical/functional documentation updated.
+- [ ] Issue and PR linked.

--- a/spec/notifications/hu-049-minimum-operational-observability-for-critical-jobs/tasks.md
+++ b/spec/notifications/hu-049-minimum-operational-observability-for-critical-jobs/tasks.md
@@ -1,0 +1,34 @@
+# Tasks - HU-049 (Minimum operational observability for critical jobs)
+
+## 1. Preparation
+- [ ] Identify critical jobs and define owner map.
+- [ ] Define minimum telemetry schema (logs, counters, duration, errors).
+- [ ] Define alert thresholds and escalation channels.
+
+## 2. Android implementation
+- [ ] Validate Android-side push diagnostics integration (if surfaced).
+- [ ] Confirm no regressions from backend telemetry changes.
+
+## 3. iOS implementation
+- [ ] Validate iOS-side push diagnostics integration (if surfaced).
+- [ ] Confirm no regressions from backend telemetry changes.
+
+## 4. Backend / Firestore
+- [ ] Add structured logs and counters for critical jobs.
+- [ ] Add push failure reason classification.
+- [ ] Configure baseline alerts for failures and missing runs.
+
+## 5. Testing
+- [ ] Execute telemetry unit/integration tests.
+- [ ] Execute controlled alert-drill in develop/staging.
+- [ ] Perform manual verification of incident triage flow.
+
+## 6. Documentation
+- [ ] Create operational runbook and escalation steps.
+- [ ] Update issue notes with telemetry and alert evidence.
+- [ ] Document known limitations and next improvements.
+
+## 7. Closure
+- [ ] Create/update linked issue and connect PR.
+- [ ] Complete DoD checklist in spec.md.
+- [ ] Attach observability evidence and drill output.

--- a/spec/orders/hu-045-firestore-security-for-producer-order-status/plan.md
+++ b/spec/orders/hu-045-firestore-security-for-producer-order-status/plan.md
@@ -1,0 +1,54 @@
+# Plan - HU-045 (Firestore security for producer order status)
+
+## 1. Technical approach
+
+Harden producer status writes at Firestore rules level and back that policy with explicit security tests per role and environment.
+
+## 2. Layer impact
+- UI: Handle permission-denied responses gracefully for status updates.
+- Domain: Keep status transition constraints aligned with backend rules.
+- Data: Ensure write payloads and paths match rule expectations.
+- Backend: Implement rules for ownership, role constraints, and transition validity.
+- Docs: Document rule contract and test matrix.
+
+## 3. Platform-specific changes
+### Android
+- Update repository/error mapping for denied writes.
+- Add tests covering expected behavior when writes are rejected.
+
+### iOS
+- Update repository/error mapping for denied writes.
+- Add tests covering expected behavior when writes are rejected.
+
+### Functions/Backend
+- Add/adjust Firestore rules for producer status updates.
+- Add emulator-based security tests for allow/deny matrix.
+
+## 4. Test strategy
+- Rule tests: producer/admin/member/reviewer allow/deny scenarios.
+- Integration tests: status update flow with valid and invalid actors.
+- Manual tests: status updates across develop and production-like configs.
+
+## 5. Rollout and functional validation
+- Validate in local/emulator first.
+- Deploy rules to develop and run end-to-end producer checks.
+- Confirm no regressions in HU-008/HU-009 flows.
+
+## 6. Phased implementation sequence
+### Phase 1 - Preparation
+- Define exact write paths and transition constraints.
+- Build rule test matrix by role and environment.
+
+### Phase 2 - Implementation
+- Implement rules and tests.
+- Align app-side error handling.
+
+### Phase 3 - Closure
+- Run emulator + platform validations.
+- Update issue/spec/tasks with proof.
+
+## 7. Technical risks and mitigation
+- Risk: strict rules block valid legacy payloads.
+  - Mitigation: include backward-compatible rule clauses where safe.
+- Risk: transition validation duplicated inconsistently.
+  - Mitigation: define one canonical transition table used across layers.

--- a/spec/orders/hu-045-firestore-security-for-producer-order-status/spec.md
+++ b/spec/orders/hu-045-firestore-security-for-producer-order-status/spec.md
@@ -1,0 +1,62 @@
+# HU-045 - Firestore security for producer order status
+
+## Metadata
+- issue_id: #106
+- priority: P1
+- platform: both
+- status: ready
+
+## Context and problem
+
+Producer order status updates are business-critical and currently risk inconsistent authorization if backend rules are not explicit per role and environment.
+
+## User story
+
+As an admin I want strict Firestore rules for producer status updates so only authorized actors can change status and data remains trustworthy.
+
+## Scope
+
+### In Scope
+- Define and apply Firestore rules for `orders/orderLines/producerStatus` writes.
+- Restrict writes by role and producer ownership.
+- Validate allowed status transitions for producer status lifecycle.
+- Add security-rule tests for develop and production environments.
+
+### Out of Scope
+- Replacing the current status model with a new domain model.
+- Non-status order editing workflows.
+
+## Linked functional requirements
+
+- RF-PROD-04
+- RF-ROL-05
+
+## Acceptance criteria
+
+- Consumers cannot write producer status fields.
+- Producers can only update status for their own producer-scoped lines/orders.
+- Admin role can apply status corrections under explicit rule constraints.
+- Security tests cover allow/deny cases per role and environment and pass in CI.
+
+## Dependencies
+
+- Base references: docs-es/requirements/requisitos-mvp-reguerta-v1.md.
+- Functional references: docs-es/requirements/historias-usuario-mvp-reguerta-v1.md.
+- Data references: docs-es/requirements/firestore-estructura-mvp-propuesta-v1.md.
+- Depends on HU-008/HU-009 producer order flows and HU-018 environment routing safeguards.
+
+## Risks
+
+- Risk: overly strict rules block legitimate producer updates.
+  - Mitigation: codify rule tests with realistic producer/admin fixtures.
+- Risk: environment path mismatch causes false negatives.
+  - Mitigation: include explicit tests for develop and production path roots.
+
+## Definition of Done (DoD)
+
+- [ ] Story acceptance criteria validated.
+- [ ] Implementation aligned with linked RFs.
+- [ ] Android/iOS parity reviewed or temporary gap documented.
+- [ ] Agreed tests executed.
+- [ ] Technical/functional documentation updated.
+- [ ] Issue and PR linked.

--- a/spec/orders/hu-045-firestore-security-for-producer-order-status/tasks.md
+++ b/spec/orders/hu-045-firestore-security-for-producer-order-status/tasks.md
@@ -1,0 +1,36 @@
+# Tasks - HU-045 (Firestore security for producer order status)
+
+## 1. Preparation
+- [ ] Define producer status write paths and ownership rules.
+- [ ] Define status transition constraints for rule validation.
+- [ ] Prepare security test matrix by role and environment.
+
+## 2. Android implementation
+- [ ] Align status write payload/path with hardened rule contract.
+- [ ] Handle permission-denied errors with explicit UX feedback.
+- [ ] Add Android tests for denied/allowed write behavior.
+
+## 3. iOS implementation
+- [ ] Align status write payload/path with hardened rule contract.
+- [ ] Handle permission-denied errors with explicit UX feedback.
+- [ ] Add iOS tests for denied/allowed write behavior.
+
+## 4. Backend / Firestore
+- [ ] Implement Firestore rules for producer status writes.
+- [ ] Add emulator security tests for role-based allow/deny cases.
+- [ ] Validate develop/production path coverage in rule tests.
+
+## 5. Testing
+- [ ] Execute Firestore rules test suite.
+- [ ] Execute Android and iOS integration checks for status updates.
+- [ ] Perform manual producer/admin validation in develop.
+
+## 6. Documentation
+- [ ] Document rule contract and transition table.
+- [ ] Update issue notes with allow/deny evidence.
+- [ ] Document parity status and temporary gaps (if any).
+
+## 7. Closure
+- [ ] Create/update linked issue and connect PR.
+- [ ] Complete DoD checklist in spec.md.
+- [ ] Attach rule test logs and functional validation output.

--- a/spec/reviewer/hu-048-environment-and-impersonation-policy-hardening/plan.md
+++ b/spec/reviewer/hu-048-environment-and-impersonation-policy-hardening/plan.md
@@ -1,0 +1,53 @@
+# Plan - HU-048 (Environment and impersonation policy hardening)
+
+## 1. Technical approach
+
+Create a hardening layer for environment and impersonation controls based on compile-time guards, runtime checks, and explicit validation for production safety.
+
+## 2. Layer impact
+- UI: Remove or hide impersonation entry points outside debug builds.
+- Domain: Centralize environment policy decisions and constraints.
+- Data: Prevent persisted flags from re-enabling restricted behavior.
+- Backend: Validate environment-bound constraints where applicable.
+- Docs: Publish policy and release verification checklist.
+
+## 3. Platform-specific changes
+### Android
+- Enforce debug-only impersonation with build-type checks.
+- Add tests for release-mode behavior and blocked toggles.
+
+### iOS
+- Enforce debug-only impersonation with build configuration checks.
+- Add tests for release-mode behavior and blocked toggles.
+
+### Functions/Backend
+- Validate reviewer routing safety assumptions against production paths.
+
+## 4. Test strategy
+- Unit tests for environment policy resolution.
+- Build-configuration checks for release artifacts.
+- Manual validation of no-contamination reviewer flows.
+
+## 5. Rollout and functional validation
+- Validate in develop and release-like builds.
+- Confirm reviewer QA workflows remain usable in debug.
+- Confirm production safety gates hold in release.
+
+## 6. Phased implementation sequence
+### Phase 1 - Preparation
+- Define policy document and expected behavior matrix.
+- Inventory all impersonation and env-switch entry points.
+
+### Phase 2 - Implementation
+- Enforce guards and remove unsafe paths.
+- Add automated checks.
+
+### Phase 3 - Closure
+- Execute release safety validation.
+- Update docs/issues with evidence.
+
+## 7. Technical risks and mitigation
+- Risk: hidden entry points remain unguarded.
+  - Mitigation: repo-wide audit and targeted tests.
+- Risk: broken QA workflows after hardening.
+  - Mitigation: maintain explicit debug-only paths and docs.

--- a/spec/reviewer/hu-048-environment-and-impersonation-policy-hardening/spec.md
+++ b/spec/reviewer/hu-048-environment-and-impersonation-policy-hardening/spec.md
@@ -1,0 +1,62 @@
+# HU-048 - Environment and impersonation policy hardening
+
+## Metadata
+- issue_id: #109
+- priority: P1
+- platform: both
+- status: ready
+
+## Context and problem
+
+Environment switching and impersonation controls are sensitive. Any production exposure of debug impersonation paths can create severe security and data-isolation risks.
+
+## User story
+
+As a security owner I want a hardened environment and impersonation policy so production data remains protected from debug-only capabilities.
+
+## Scope
+
+### In Scope
+- Define canonical environment policy for develop vs production across platforms.
+- Ensure impersonation capabilities are debug-only and blocked in release builds.
+- Add explicit safeguards against production contamination in reviewer/test flows.
+- Add verification checks in tests and release validation steps.
+
+### Out of Scope
+- Full IAM redesign outside app/runtime boundaries.
+- New business reviewer features unrelated to environment safety.
+
+## Linked functional requirements
+
+- RF-REV-01, RF-REV-02, RF-REV-03
+- RF-ROL-05
+
+## Acceptance criteria
+
+- Release builds cannot enable impersonation through UI, hidden arguments, or persisted flags.
+- Develop-only environment overrides remain available for QA and are clearly bounded.
+- Reviewer routing and environment behavior are validated with explicit no-contamination checks.
+- Android and iOS enforce equivalent hardening behavior.
+
+## Dependencies
+
+- Base references: docs-es/requirements/requisitos-mvp-reguerta-v1.md.
+- Functional references: docs-es/requirements/historias-usuario-mvp-reguerta-v1.md.
+- Data references: docs-es/requirements/firestore-estructura-mvp-propuesta-v1.md.
+- Depends on HU-018 runtime routing behavior.
+
+## Risks
+
+- Risk: accidental disablement of legitimate QA tooling.
+  - Mitigation: separate debug-only tooling with explicit compile-time guards.
+- Risk: platform divergence in build configuration.
+  - Mitigation: add mirrored checks in Android/iOS release pipelines.
+
+## Definition of Done (DoD)
+
+- [ ] Story acceptance criteria validated.
+- [ ] Implementation aligned with linked RFs.
+- [ ] Android/iOS parity reviewed or temporary gap documented.
+- [ ] Agreed tests executed.
+- [ ] Technical/functional documentation updated.
+- [ ] Issue and PR linked.

--- a/spec/reviewer/hu-048-environment-and-impersonation-policy-hardening/tasks.md
+++ b/spec/reviewer/hu-048-environment-and-impersonation-policy-hardening/tasks.md
@@ -1,0 +1,35 @@
+# Tasks - HU-048 (Environment and impersonation policy hardening)
+
+## 1. Preparation
+- [ ] Define canonical environment and impersonation policy.
+- [ ] Inventory all current environment-switch and impersonation entry points.
+- [ ] Define release safety checks and expected outcomes.
+
+## 2. Android implementation
+- [ ] Enforce debug-only impersonation on Android.
+- [ ] Remove/block unsafe release pathways.
+- [ ] Add Android tests for release build hardening.
+
+## 3. iOS implementation
+- [ ] Enforce debug-only impersonation on iOS.
+- [ ] Remove/block unsafe release pathways.
+- [ ] Add iOS tests for release build hardening.
+
+## 4. Backend / Firestore
+- [ ] Validate backend assumptions for environment-bound writes.
+- [ ] Add safeguards/tests preventing production contamination paths.
+
+## 5. Testing
+- [ ] Execute Android release-like validation.
+- [ ] Execute iOS release-like validation.
+- [ ] Perform manual reviewer flow checks for no contamination.
+
+## 6. Documentation
+- [ ] Document policy and release verification checklist.
+- [ ] Update issue notes with security hardening evidence.
+- [ ] Document parity status and exceptions.
+
+## 7. Closure
+- [ ] Create/update linked issue and connect PR.
+- [ ] Complete DoD checklist in spec.md.
+- [ ] Attach validation and security evidence.


### PR DESCRIPTION
## Summary
- add HU-044 to HU-049 story packages (spec/plan/tasks)
- add corresponding local issue templates under spec/issues
- update issue references with created GitHub issue IDs (#105-#110)
- update changelog with spec drafting entry

## Scope
- docs/spec only

## Testing
- not run (documentation-only changes)
