### PR TITLE
[HU-044] Canonical role permission matrix and fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 - 2026-04-14 | ✨ feat(producers): add producer status visual feedback (HU-009)
 - 2026-04-15 | ✨ feat(access): route production reviewer to develop (HU-018)
 - 2026-04-16 | ✨ feat(functions): add pending-order reminders (HU-006)
+- 2026-04-17 | ✨ feat(access): add HU-044 role capability matrix
 
 ### Fixed
 

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/data/firestore/FirestoreReviewerEnvironmentRouter.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/data/firestore/FirestoreReviewerEnvironmentRouter.kt
@@ -3,7 +3,9 @@ package com.reguerta.user.data.firestore
 import com.google.android.gms.tasks.Tasks
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
+import com.reguerta.user.domain.access.AccessCapability
 import com.reguerta.user.domain.access.AuthPrincipal
+import com.reguerta.user.domain.access.MemberPermissionMatrix
 import com.reguerta.user.presentation.access.ReviewerEnvironmentRouter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -20,7 +22,10 @@ class FirestoreReviewerEnvironmentRouter(
         val normalizedEmail = principal.email.trim().lowercase()
         val isAllowlisted = reviewerPolicy.emails.contains(normalizedEmail) ||
             reviewerPolicy.uids.contains(principal.uid)
-        val targetEnvironment = if (isAllowlisted) {
+        val reviewerRoutingEnabled = MemberPermissionMatrix.reviewerCapabilities.contains(
+            AccessCapability.ROUTE_PRODUCTION_REVIEWER_TO_DEVELOP,
+        )
+        val targetEnvironment = if (isAllowlisted && reviewerRoutingEnabled) {
             ReguertaFirestoreEnvironment.DEVELOP
         } else {
             ReguertaFirestoreEnvironment.PRODUCTION

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/domain/access/MemberPermissionMatrix.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/domain/access/MemberPermissionMatrix.kt
@@ -1,0 +1,111 @@
+package com.reguerta.user.domain.access
+
+enum class AccessCapability(val wireValue: String) {
+    ACCESS_COMMON_HOME_MODULES("access_common_home_modules"),
+    MANAGE_PRODUCT_CATALOG("manage_product_catalog"),
+    ACCESS_RECEIVED_ORDERS("access_received_orders"),
+    MANAGE_MEMBERS("manage_members"),
+    GRANT_ADMIN_ROLE("grant_admin_role"),
+    PUBLISH_NEWS("publish_news"),
+    SEND_ADMIN_NOTIFICATIONS("send_admin_notifications"),
+    ROUTE_PRODUCTION_REVIEWER_TO_DEVELOP("route_production_reviewer_to_develop"),
+    ;
+
+    companion object {
+        private val byWireValue = entries.associateBy(AccessCapability::wireValue)
+
+        fun fromWireValue(value: String): AccessCapability? = byWireValue[value]
+    }
+}
+
+enum class CanonicalAccessRole(val wireValue: String) {
+    MEMBER("member"),
+    PRODUCER("producer"),
+    ADMIN("admin"),
+    REVIEWER("reviewer"),
+    ;
+
+    companion object {
+        private val byWireValue = entries.associateBy(CanonicalAccessRole::wireValue)
+
+        fun fromWireValue(value: String): CanonicalAccessRole? = byWireValue[value]
+    }
+}
+
+object MemberPermissionMatrix {
+    private val roleCapabilities = mapOf(
+        CanonicalAccessRole.MEMBER to setOf(
+            AccessCapability.ACCESS_COMMON_HOME_MODULES,
+        ),
+        CanonicalAccessRole.PRODUCER to setOf(
+            AccessCapability.ACCESS_COMMON_HOME_MODULES,
+            AccessCapability.MANAGE_PRODUCT_CATALOG,
+            AccessCapability.ACCESS_RECEIVED_ORDERS,
+        ),
+        CanonicalAccessRole.ADMIN to setOf(
+            AccessCapability.ACCESS_COMMON_HOME_MODULES,
+            AccessCapability.MANAGE_MEMBERS,
+            AccessCapability.GRANT_ADMIN_ROLE,
+            AccessCapability.PUBLISH_NEWS,
+            AccessCapability.SEND_ADMIN_NOTIFICATIONS,
+        ),
+        CanonicalAccessRole.REVIEWER to setOf(
+            AccessCapability.ACCESS_COMMON_HOME_MODULES,
+            AccessCapability.ROUTE_PRODUCTION_REVIEWER_TO_DEVELOP,
+        ),
+    )
+
+    fun capabilitiesFor(role: CanonicalAccessRole): Set<AccessCapability> =
+        roleCapabilities.getValue(role)
+
+    fun capabilitiesFor(role: MemberRole): Set<AccessCapability> =
+        when (role) {
+            MemberRole.MEMBER -> capabilitiesFor(CanonicalAccessRole.MEMBER)
+            MemberRole.PRODUCER -> capabilitiesFor(CanonicalAccessRole.PRODUCER)
+            MemberRole.ADMIN -> capabilitiesFor(CanonicalAccessRole.ADMIN)
+        }
+
+    fun capabilitiesFor(member: Member): Set<AccessCapability> {
+        val merged = member.roles
+            .asSequence()
+            .flatMap { role -> capabilitiesFor(role).asSequence() }
+            .toMutableSet()
+        if (member.isCommonPurchaseManager) {
+            merged += AccessCapability.MANAGE_PRODUCT_CATALOG
+        }
+        return merged
+    }
+
+    fun hasCapability(member: Member, capability: AccessCapability): Boolean =
+        capabilitiesFor(member).contains(capability)
+
+    val reviewerCapabilities: Set<AccessCapability>
+        get() = capabilitiesFor(CanonicalAccessRole.REVIEWER)
+}
+
+val Member.isMember: Boolean
+    get() = roles.contains(MemberRole.MEMBER)
+
+val Member.isProducer: Boolean
+    get() = roles.contains(MemberRole.PRODUCER)
+
+val Member.canAccessCommonHomeModules: Boolean
+    get() = MemberPermissionMatrix.hasCapability(this, AccessCapability.ACCESS_COMMON_HOME_MODULES)
+
+val Member.canManageProductCatalog: Boolean
+    get() = MemberPermissionMatrix.hasCapability(this, AccessCapability.MANAGE_PRODUCT_CATALOG)
+
+val Member.canAccessReceivedOrders: Boolean
+    get() = MemberPermissionMatrix.hasCapability(this, AccessCapability.ACCESS_RECEIVED_ORDERS)
+
+val Member.canManageMembers: Boolean
+    get() = MemberPermissionMatrix.hasCapability(this, AccessCapability.MANAGE_MEMBERS)
+
+val Member.canGrantAdminRole: Boolean
+    get() = MemberPermissionMatrix.hasCapability(this, AccessCapability.GRANT_ADMIN_ROLE)
+
+val Member.canPublishNews: Boolean
+    get() = MemberPermissionMatrix.hasCapability(this, AccessCapability.PUBLISH_NEWS)
+
+val Member.canSendAdminNotifications: Boolean
+    get() = MemberPermissionMatrix.hasCapability(this, AccessCapability.SEND_ADMIN_NOTIFICATIONS)

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/MyOrderCommitmentValidation.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/MyOrderCommitmentValidation.kt
@@ -2,8 +2,9 @@ package com.reguerta.user.presentation.access
 
 import com.reguerta.user.domain.access.EcoCommitmentMode
 import com.reguerta.user.domain.access.Member
-import com.reguerta.user.domain.access.MemberRole
 import com.reguerta.user.domain.access.ProducerParity
+import com.reguerta.user.domain.access.isMember
+import com.reguerta.user.domain.access.isProducer
 import com.reguerta.user.domain.commitments.SeasonalCommitment
 import com.reguerta.user.domain.products.Product
 import com.reguerta.user.domain.products.ProductPricingMode
@@ -130,7 +131,7 @@ private fun requiredEcoBasketCommitmentProducts(
     currentWeekParity: ProducerParity,
 ): List<Product> {
     val member = currentMember ?: return emptyList()
-    if (!member.isActive || !member.roles.contains(MemberRole.MEMBER)) {
+    if (!member.isActive || !member.isMember) {
         return emptyList()
     }
 
@@ -151,7 +152,7 @@ private fun requiredEcoBasketCommitmentProducts(
             val eligibleProducerIds = members
                 .asSequence()
                 .filter { producer ->
-                    producer.roles.contains(MemberRole.PRODUCER) &&
+                    producer.isProducer &&
                         producer.isActive &&
                         producer.producerCatalogEnabled &&
                         producer.producerParity == parity

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootDashboardAdmin.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootDashboardAdmin.kt
@@ -34,6 +34,8 @@ import com.reguerta.user.R
 import com.reguerta.user.domain.access.Member
 import com.reguerta.user.domain.access.MemberRole
 import com.reguerta.user.domain.access.UnauthorizedReason
+import com.reguerta.user.domain.access.canManageProductCatalog
+
 @Composable
 internal fun UnauthorizedCard(
     mode: SessionMode.Unauthorized,
@@ -288,12 +290,6 @@ private fun Set<MemberRole>.toPrettyRoles(context: Context): String =
             MemberRole.ADMIN -> context.getString(R.string.role_value_admin)
         }
     }
-
-private val Member.isProducer: Boolean
-    get() = roles.contains(MemberRole.PRODUCER)
-
-private val Member.canManageProductCatalog: Boolean
-    get() = isProducer || isCommonPurchaseManager
 
 private fun UnauthorizedReason.toMessageResId(): Int =
     when (this) {

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeRoute.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.unit.dp
 import androidx.activity.compose.BackHandler
 import com.reguerta.user.R
 import com.reguerta.user.domain.access.Member
+import com.reguerta.user.domain.access.canPublishNews
+import com.reguerta.user.domain.access.canSendAdminNotifications
 import com.reguerta.user.domain.calendar.DeliveryCalendarOverride
 import com.reguerta.user.domain.calendar.DeliveryWeekday
 import com.reguerta.user.domain.commitments.SeasonalCommitment
@@ -323,7 +325,7 @@ internal fun HomeRoute(
                     HomeDestination.NEWS -> NewsFeedRoute(
                     articles = newsFeed,
                     isLoading = isLoadingNews,
-                    isAdmin = member?.isAdmin == true,
+                    isAdmin = member?.canPublishNews == true,
                     onRefresh = onRefreshNews,
                     onCreateNews = {
                         onStartCreatingNews()
@@ -357,7 +359,7 @@ internal fun HomeRoute(
                     HomeDestination.NOTIFICATIONS -> NotificationsFeedRoute(
                     notifications = notificationsFeed,
                     isLoading = isLoadingNotifications,
-                    isAdmin = member?.isAdmin == true,
+                    isAdmin = member?.canSendAdminNotifications == true,
                     onRefresh = onRefreshNotifications,
                     onCreateNotification = {
                         onStartCreatingNotification()

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeShellComponents.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeShellComponents.kt
@@ -46,17 +46,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.reguerta.user.R
 import com.reguerta.user.domain.access.Member
-import com.reguerta.user.domain.access.MemberRole
+import com.reguerta.user.domain.access.canAccessReceivedOrders
+import com.reguerta.user.domain.access.canManageMembers
+import com.reguerta.user.domain.access.canManageProductCatalog
+import com.reguerta.user.domain.access.canPublishNews
+import com.reguerta.user.domain.access.canSendAdminNotifications
 import com.reguerta.user.domain.calendar.DeliveryCalendarOverride
 import com.reguerta.user.domain.news.NewsArticle
 import com.reguerta.user.domain.shifts.ShiftAssignment
 import com.reguerta.user.ui.components.auth.ReguertaFlatButton
-
-private val Member.isProducerInShell: Boolean
-    get() = roles.contains(MemberRole.PRODUCER)
-
-private val Member.canManageProductCatalogInShell: Boolean
-    get() = isProducerInShell || isCommonPurchaseManager
 
 @Composable
 fun HomeShellTopBar(
@@ -111,6 +109,10 @@ fun HomeDrawerContent(
     onSignOut: () -> Unit,
 ) {
     val drawerScrollState = rememberScrollState()
+    val canManageMembers = member?.canManageMembers == true
+    val canPublishNews = member?.canPublishNews == true
+    val canSendAdminNotifications = member?.canSendAdminNotifications == true
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -217,10 +219,10 @@ fun HomeDrawerContent(
                 onClick = { onNavigate(HomeDestination.SETTINGS) },
             )
 
-            if (member?.canManageProductCatalogInShell == true || member?.isProducerInShell == true) {
+            if (member?.canManageProductCatalog == true || member?.canAccessReceivedOrders == true) {
                 HomeDrawerSection(title = stringResource(R.string.home_shell_section_producer))
             }
-            if (member?.canManageProductCatalogInShell == true) {
+            if (member?.canManageProductCatalog == true) {
                 HomeDrawerItem(
                     icon = Icons.Filled.Storefront,
                     label = stringResource(R.string.home_shell_action_products),
@@ -228,7 +230,7 @@ fun HomeDrawerContent(
                     onClick = { onNavigate(HomeDestination.PRODUCTS) },
                 )
             }
-            if (member?.isProducerInShell == true) {
+            if (member?.canAccessReceivedOrders == true) {
                 HomeDrawerItem(
                     icon = Icons.Filled.Inbox,
                     label = stringResource(R.string.home_shell_action_received_orders),
@@ -237,26 +239,32 @@ fun HomeDrawerContent(
                 )
             }
 
-            if (member?.isAdmin == true) {
+            if (canManageMembers || canPublishNews || canSendAdminNotifications) {
                 HomeDrawerSection(title = stringResource(R.string.home_shell_section_admin))
-                HomeDrawerItem(
-                    icon = Icons.Filled.Group,
-                    label = stringResource(R.string.home_shell_action_users),
-                    selected = currentDestination == HomeDestination.USERS,
-                    onClick = { onNavigate(HomeDestination.USERS) },
-                )
-                HomeDrawerItem(
-                    icon = Icons.Filled.Add,
-                    label = stringResource(R.string.home_shell_action_publish_news),
-                    selected = currentDestination == HomeDestination.PUBLISH_NEWS,
-                    onClick = { onNavigate(HomeDestination.PUBLISH_NEWS) },
-                )
-                HomeDrawerItem(
-                    icon = Icons.Filled.Campaign,
-                    label = stringResource(R.string.home_shell_action_admin_broadcast),
-                    selected = currentDestination == HomeDestination.ADMIN_BROADCAST,
-                    onClick = { onNavigate(HomeDestination.ADMIN_BROADCAST) },
-                )
+                if (canManageMembers) {
+                    HomeDrawerItem(
+                        icon = Icons.Filled.Group,
+                        label = stringResource(R.string.home_shell_action_users),
+                        selected = currentDestination == HomeDestination.USERS,
+                        onClick = { onNavigate(HomeDestination.USERS) },
+                    )
+                }
+                if (canPublishNews) {
+                    HomeDrawerItem(
+                        icon = Icons.Filled.Add,
+                        label = stringResource(R.string.home_shell_action_publish_news),
+                        selected = currentDestination == HomeDestination.PUBLISH_NEWS,
+                        onClick = { onNavigate(HomeDestination.PUBLISH_NEWS) },
+                    )
+                }
+                if (canSendAdminNotifications) {
+                    HomeDrawerItem(
+                        icon = Icons.Filled.Campaign,
+                        label = stringResource(R.string.home_shell_action_admin_broadcast),
+                        selected = currentDestination == HomeDestination.ADMIN_BROADCAST,
+                        onClick = { onNavigate(HomeDestination.ADMIN_BROADCAST) },
+                    )
+                }
             }
         }
 

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrderRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrderRoute.kt
@@ -77,7 +77,7 @@ import com.reguerta.user.data.firestore.ReguertaFirestoreEnvironment
 import com.reguerta.user.data.firestore.ReguertaFirestorePath
 import com.reguerta.user.data.firestore.ReguertaRuntimeEnvironment
 import com.reguerta.user.domain.access.Member
-import com.reguerta.user.domain.access.MemberRole
+import com.reguerta.user.domain.access.isProducer
 import com.reguerta.user.domain.calendar.DeliveryCalendarOverride
 import com.reguerta.user.domain.calendar.DeliveryWeekday
 import com.reguerta.user.domain.commitments.SeasonalCommitment
@@ -2035,7 +2035,7 @@ private fun Member.committedEcoBasketProducerId(members: List<Member>): String? 
     val parity = ecoCommitmentParity ?: return null
     return members.firstOrNull { producer ->
         producer.id != id &&
-            producer.roles.contains(MemberRole.PRODUCER) &&
+            producer.isProducer &&
             producer.isActive &&
             producer.producerCatalogEnabled &&
             producer.producerParity == parity

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootProductsRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootProductsRoute.kt
@@ -45,15 +45,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.reguerta.user.R
 import com.reguerta.user.domain.access.Member
-import com.reguerta.user.domain.access.MemberRole
+import com.reguerta.user.domain.access.isProducer
 import com.reguerta.user.domain.products.CommonPurchaseType
 import com.reguerta.user.domain.products.Product
 import com.reguerta.user.domain.products.ProductStockMode
 import com.reguerta.user.ui.components.auth.ReguertaButton
 import com.reguerta.user.ui.components.auth.ReguertaButtonVariant
-
-private val Member.isProducerInProducts: Boolean
-    get() = roles.contains(MemberRole.PRODUCER)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -78,8 +75,10 @@ fun ProductsRoute(
     val activeProducts = remember(products) { products.filterNot { it.archived } }
     val archivedProducts = remember(products) { products.filter { it.archived } }
     val isEditing = editingProductId != null
-    val canManageEcoBasket = currentMember?.isProducerInProducts == true
-    val canManageCommonPurchase = currentMember?.isCommonPurchaseManager == true && !currentMember.isProducerInProducts
+    val canManageEcoBasket = currentMember?.isProducer == true
+    val canManageCommonPurchase = currentMember?.let { member ->
+        member.isCommonPurchaseManager && !member.isProducer
+    } == true
     var commonPurchaseExpanded by rememberSaveable { mutableStateOf(false) }
     var pendingCatalogVisibility by rememberSaveable { mutableStateOf<Boolean?>(null) }
 
@@ -366,7 +365,7 @@ fun ProductsRoute(
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.SemiBold,
                         )
-                        if (currentMember?.isProducerInProducts == true) {
+                        if (currentMember?.isProducer == true) {
                             Button(
                                 onClick = {
                                     pendingCatalogVisibility = !currentMember.producerCatalogEnabled

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootReceivedOrdersRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootReceivedOrdersRoute.kt
@@ -55,7 +55,7 @@ import com.reguerta.user.data.firestore.ReguertaFirestoreEnvironment
 import com.reguerta.user.data.firestore.ReguertaFirestorePath
 import com.reguerta.user.data.firestore.ReguertaRuntimeEnvironment
 import com.reguerta.user.domain.access.Member
-import com.reguerta.user.domain.access.MemberRole
+import com.reguerta.user.domain.access.canAccessReceivedOrders
 import com.reguerta.user.domain.calendar.DeliveryCalendarOverride
 import com.reguerta.user.domain.calendar.DeliveryWeekday
 import com.reguerta.user.domain.shifts.ShiftAssignment
@@ -178,7 +178,7 @@ internal fun ReceivedOrdersRoute(
     deliveryCalendarOverrides: List<DeliveryCalendarOverride>,
     nowOverrideMillis: Long?,
 ) {
-    val isProducer = currentMember?.roles?.contains(MemberRole.PRODUCER) == true
+    val isProducer = currentMember?.canAccessReceivedOrders == true
     val effectiveNowMillis = remember(nowOverrideMillis) { nowOverrideMillis ?: System.currentTimeMillis() }
     val window = remember(defaultDeliveryDayOfWeek, deliveryCalendarOverrides, shifts, effectiveNowMillis) {
         resolveReceivedOrdersWindow(

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionCommunityActions.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionCommunityActions.kt
@@ -7,6 +7,8 @@ import com.reguerta.user.domain.notifications.NotificationEvent
 import com.reguerta.user.domain.notifications.NotificationRepository
 import com.reguerta.user.domain.profiles.SharedProfile
 import com.reguerta.user.domain.profiles.SharedProfileRepository
+import com.reguerta.user.domain.access.canPublishNews
+import com.reguerta.user.domain.access.canSendAdminNotifications
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
@@ -103,7 +105,7 @@ internal class SessionCommunityActions(
         scope.launch {
             uiState.update { it.copy(isLoadingNews = true) }
             val allNews = newsRepository.getAllNews()
-            val visibleNews = if (mode.member.isAdmin) {
+            val visibleNews = if (mode.member.canPublishNews) {
                 allNews
             } else {
                 allNews.filter { article -> article.active }
@@ -146,7 +148,7 @@ internal class SessionCommunityActions(
 
     fun saveNews(onSuccess: () -> Unit = {}) {
         val mode = uiState.value.mode as? SessionMode.Authorized ?: return
-        if (!mode.member.isAdmin) {
+        if (!mode.member.canPublishNews) {
             emitMessage(R.string.feedback_only_admin_publish_news)
             return
         }
@@ -205,7 +207,7 @@ internal class SessionCommunityActions(
         onSuccess: () -> Unit = {},
     ) {
         val mode = uiState.value.mode as? SessionMode.Authorized ?: return
-        if (!mode.member.isAdmin) {
+        if (!mode.member.canPublishNews) {
             emitMessage(R.string.feedback_only_admin_delete_news)
             return
         }
@@ -232,7 +234,7 @@ internal class SessionCommunityActions(
 
     fun sendNotification(onSuccess: () -> Unit = {}) {
         val mode = uiState.value.mode as? SessionMode.Authorized ?: return
-        if (!mode.member.isAdmin) {
+        if (!mode.member.canSendAdminNotifications) {
             emitMessage(R.string.feedback_only_admin_send_notification)
             return
         }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionFormActions.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionFormActions.kt
@@ -1,6 +1,8 @@
 package com.reguerta.user.presentation.access
 
 import com.reguerta.user.R
+import com.reguerta.user.domain.access.canPublishNews
+import com.reguerta.user.domain.access.canSendAdminNotifications
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 
@@ -128,7 +130,7 @@ internal class SessionFormActions(
 
     fun startCreatingNews() {
         val mode = uiState.value.mode as? SessionMode.Authorized ?: return
-        if (!mode.member.isAdmin) {
+        if (!mode.member.canPublishNews) {
             emitMessage(R.string.feedback_only_admin_publish_news)
             return
         }
@@ -143,7 +145,7 @@ internal class SessionFormActions(
 
     fun startEditingNews(newsId: String) {
         val mode = uiState.value.mode as? SessionMode.Authorized ?: return
-        if (!mode.member.isAdmin) {
+        if (!mode.member.canPublishNews) {
             emitMessage(R.string.feedback_only_admin_edit_news)
             return
         }
@@ -173,7 +175,7 @@ internal class SessionFormActions(
 
     fun startCreatingNotification() {
         val mode = uiState.value.mode as? SessionMode.Authorized ?: return
-        if (!mode.member.isAdmin) {
+        if (!mode.member.canSendAdminNotifications) {
             emitMessage(R.string.feedback_only_admin_send_notification)
             return
         }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionMemberActions.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionMemberActions.kt
@@ -6,6 +6,8 @@ import com.reguerta.user.domain.access.MemberManagementException
 import com.reguerta.user.domain.access.MemberRepository
 import com.reguerta.user.domain.access.MemberRole
 import com.reguerta.user.domain.access.UpsertMemberByAdminUseCase
+import com.reguerta.user.domain.access.canGrantAdminRole
+import com.reguerta.user.domain.access.canManageMembers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
@@ -20,7 +22,7 @@ internal class SessionMemberActions(
 ) {
     fun createAuthorizedMember() {
         val mode = uiState.value.mode as? SessionMode.Authorized ?: return
-        if (!mode.member.isAdmin) {
+        if (!mode.member.canManageMembers) {
             emitMessage(R.string.feedback_only_admin_create)
             return
         }
@@ -63,7 +65,7 @@ internal class SessionMemberActions(
 
     fun toggleAdmin(memberId: String) {
         val mode = uiState.value.mode as? SessionMode.Authorized ?: return
-        if (!mode.member.isAdmin) {
+        if (!mode.member.canGrantAdminRole) {
             emitMessage(R.string.feedback_only_admin_edit_roles)
             return
         }
@@ -86,7 +88,7 @@ internal class SessionMemberActions(
 
     fun toggleActive(memberId: String) {
         val mode = uiState.value.mode as? SessionMode.Authorized ?: return
-        if (!mode.member.isAdmin) {
+        if (!mode.member.canManageMembers) {
             emitMessage(R.string.feedback_only_admin_toggle_active)
             return
         }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionViewModelSupport.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionViewModelSupport.kt
@@ -2,6 +2,8 @@ package com.reguerta.user.presentation.access
 
 import com.reguerta.user.domain.access.Member
 import com.reguerta.user.domain.access.MemberRole
+import com.reguerta.user.domain.access.canManageProductCatalog
+import com.reguerta.user.domain.access.isProducer
 import com.reguerta.user.domain.calendar.DeliveryCalendarOverride
 import com.reguerta.user.domain.calendar.DeliveryWeekday
 import com.reguerta.user.domain.notifications.NotificationAudience
@@ -71,10 +73,10 @@ internal fun String.toNonNegativeDoubleOrNull(): Double? =
     replace(",", ".").toDoubleOrNull()?.takeIf { it >= 0.0 }
 
 internal val Member.isSessionProducer: Boolean
-    get() = roles.contains(MemberRole.PRODUCER)
+    get() = isProducer
 
 internal val Member.canManageSessionProductCatalog: Boolean
-    get() = isSessionProducer || isCommonPurchaseManager
+    get() = canManageProductCatalog
 
 internal fun Double.toSessionUiDecimal(): String =
     if (this % 1.0 == 0.0) {

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/domain/access/MemberPermissionMatrixDriftTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/domain/access/MemberPermissionMatrixDriftTest.kt
@@ -1,0 +1,157 @@
+package com.reguerta.user.domain.access
+
+import com.reguerta.user.data.access.InMemoryMemberRepository
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MemberPermissionMatrixDriftTest {
+    @Test
+    fun `canonical matrix capabilities match android permission matrix`() {
+        val matrix = loadCanonicalMatrix()
+
+        CanonicalAccessRole.entries.forEach { role ->
+            val expected = matrix
+                .resolvedCapabilitiesByRole
+                .getValue(role.wireValue)
+                .mapNotNull(AccessCapability::fromWireValue)
+                .toSet()
+            val actual = MemberPermissionMatrix.capabilitiesFor(role)
+            assertEquals("Role ${role.wireValue} drift detected", expected, actual)
+        }
+    }
+
+    @Test
+    fun `common purchase manager override grants catalog management`() {
+        val member = Member(
+            id = "member_common_purchase_001",
+            displayName = "Compra común",
+            normalizedEmail = "compras@reguerta.app",
+            authUid = null,
+            roles = setOf(MemberRole.MEMBER),
+            isActive = true,
+            producerCatalogEnabled = true,
+            isCommonPurchaseManager = true,
+        )
+
+        assertTrue(member.canManageProductCatalog)
+    }
+
+    @Test
+    fun `in-memory fixtures stay aligned with canonical matrix`() = runBlocking {
+        val membersById = InMemoryMemberRepository()
+            .getAllMembers()
+            .associateBy(Member::id)
+
+        val admin = checkNotNull(membersById["member_admin_001"])
+        assertTrue(admin.canManageMembers)
+        assertTrue(admin.canGrantAdminRole)
+        assertTrue(admin.canPublishNews)
+        assertTrue(admin.canSendAdminNotifications)
+
+        val producer = checkNotNull(membersById["member_producer_001"])
+        assertTrue(producer.canManageProductCatalog)
+        assertTrue(producer.canAccessReceivedOrders)
+
+        val member = checkNotNull(membersById["member_member_001"])
+        assertTrue(member.canAccessCommonHomeModules)
+        assertTrue(!member.canManageMembers)
+        assertTrue(!member.canAccessReceivedOrders)
+    }
+
+    private fun loadCanonicalMatrix(): CanonicalMatrix {
+        val matrixPath = findRepoRoot(Path.of(System.getProperty("user.dir")))
+            .resolve(MATRIX_RELATIVE_PATH)
+        val raw = String(Files.readAllBytes(matrixPath))
+        val directCapabilitiesByRole = mutableMapOf<String, MutableSet<String>>()
+        val inheritedRolesByRole = mutableMapOf<String, MutableSet<String>>()
+        val tokenRegex = "\"([a-z_]+)\"".toRegex()
+
+        var inRolesSection = false
+        var currentRole: String? = null
+        var currentArrayKey: String? = null
+
+        raw.lineSequence().forEach { originalLine ->
+            val line = originalLine.trim()
+            if (line.isEmpty()) return@forEach
+
+            if (!inRolesSection) {
+                if (line.startsWith("\"roles\"")) {
+                    inRolesSection = true
+                }
+                return@forEach
+            }
+
+            if (currentRole == null && line.startsWith("},")) {
+                inRolesSection = false
+                return@forEach
+            }
+
+            if (currentRole == null) {
+                tokenRegex.find(line)
+                    ?.groupValues
+                    ?.getOrNull(1)
+                    ?.takeIf { line.endsWith("{") && it in setOf("member", "producer", "admin", "reviewer") }
+                    ?.let { roleName ->
+                        currentRole = roleName
+                        directCapabilitiesByRole.putIfAbsent(roleName, mutableSetOf())
+                        inheritedRolesByRole.putIfAbsent(roleName, mutableSetOf())
+                    }
+                return@forEach
+            }
+
+            if (line.startsWith("\"capabilities\"")) {
+                currentArrayKey = "capabilities"
+            } else if (line.startsWith("\"inherits\"")) {
+                currentArrayKey = "inherits"
+            }
+
+            if (currentArrayKey != null) {
+                val matches = tokenRegex.findAll(line).map { matchResult -> matchResult.groupValues[1] }
+                when (currentArrayKey) {
+                    "capabilities" -> directCapabilitiesByRole.getValue(currentRole).addAll(matches.toList())
+                    "inherits" -> inheritedRolesByRole.getValue(currentRole).addAll(matches.toList())
+                }
+                if (line.contains(']')) {
+                    currentArrayKey = null
+                }
+            }
+
+            if (currentArrayKey == null && (line == "}" || line == "},")) {
+                currentRole = null
+            }
+        }
+
+        fun resolveRoleCapabilities(roleName: String, visiting: MutableSet<String> = mutableSetOf()): Set<String> {
+            if (!visiting.add(roleName)) {
+                error("Cycle detected while resolving role inheritance for $roleName")
+            }
+            val directCapabilities = directCapabilitiesByRole[roleName].orEmpty()
+            val inheritedCapabilities = inheritedRolesByRole[roleName]
+                .orEmpty()
+                .flatMap { inheritedRole -> resolveRoleCapabilities(inheritedRole, visiting) }
+                .toSet()
+            visiting.remove(roleName)
+            return directCapabilities + inheritedCapabilities
+        }
+
+        val resolved = directCapabilitiesByRole.keys.associateWith { roleName -> resolveRoleCapabilities(roleName) }
+        return CanonicalMatrix(resolvedCapabilitiesByRole = resolved)
+    }
+
+    private fun findRepoRoot(start: Path): Path =
+        generateSequence(start) { path -> path.parent }
+            .firstOrNull { candidate -> Files.exists(candidate.resolve(MATRIX_RELATIVE_PATH)) }
+            ?: error("Could not locate repository root from ${start.toAbsolutePath()}")
+
+    private data class CanonicalMatrix(
+        val resolvedCapabilitiesByRole: Map<String, Set<String>>,
+    )
+
+    private companion object {
+        const val MATRIX_RELATIVE_PATH = "spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/role-permission-matrix.v1.json"
+    }
+}

--- a/ios/Reguerta/Reguerta/Data/Firestore/FirestoreReviewerEnvironmentRouter.swift
+++ b/ios/Reguerta/Reguerta/Data/Firestore/FirestoreReviewerEnvironmentRouter.swift
@@ -16,7 +16,8 @@ final class FirestoreReviewerEnvironmentRouter: @unchecked Sendable, ReviewerEnv
         let policy = await loadReviewerPolicy()
         let normalizedEmail = principal.email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let isAllowlisted = policy.emails.contains(normalizedEmail) || policy.uids.contains(principal.uid)
-        ReguertaRuntimeEnvironment.applySessionEnvironment(isAllowlisted ? .develop : .production)
+        let reviewerRoutingEnabled = MemberPermissionMatrix.reviewerCapabilities.contains(.routeProductionReviewerToDevelop)
+        ReguertaRuntimeEnvironment.applySessionEnvironment((isAllowlisted && reviewerRoutingEnabled) ? .develop : .production)
     }
 
     func resetToBaseEnvironment() {

--- a/ios/Reguerta/Reguerta/Domain/Access/MemberPermissionMatrix.swift
+++ b/ios/Reguerta/Reguerta/Domain/Access/MemberPermissionMatrix.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+enum AccessCapability: String, CaseIterable, Sendable {
+    case accessCommonHomeModules = "access_common_home_modules"
+    case manageProductCatalog = "manage_product_catalog"
+    case accessReceivedOrders = "access_received_orders"
+    case manageMembers = "manage_members"
+    case grantAdminRole = "grant_admin_role"
+    case publishNews = "publish_news"
+    case sendAdminNotifications = "send_admin_notifications"
+    case routeProductionReviewerToDevelop = "route_production_reviewer_to_develop"
+}
+
+enum CanonicalAccessRole: String, CaseIterable, Sendable {
+    case member
+    case producer
+    case admin
+    case reviewer
+}
+
+enum MemberPermissionMatrix {
+    private static let roleCapabilities: [CanonicalAccessRole: Set<AccessCapability>] = [
+        .member: [.accessCommonHomeModules],
+        .producer: [.accessCommonHomeModules, .manageProductCatalog, .accessReceivedOrders],
+        .admin: [.accessCommonHomeModules, .manageMembers, .grantAdminRole, .publishNews, .sendAdminNotifications],
+        .reviewer: [.accessCommonHomeModules, .routeProductionReviewerToDevelop],
+    ]
+
+    static var reviewerCapabilities: Set<AccessCapability> {
+        capabilities(for: .reviewer)
+    }
+
+    static func capabilities(for role: CanonicalAccessRole) -> Set<AccessCapability> {
+        roleCapabilities[role, default: []]
+    }
+
+    static func capabilities(for role: MemberRole) -> Set<AccessCapability> {
+        switch role {
+        case .member:
+            capabilities(for: CanonicalAccessRole.member)
+        case .producer:
+            capabilities(for: CanonicalAccessRole.producer)
+        case .admin:
+            capabilities(for: CanonicalAccessRole.admin)
+        }
+    }
+
+    static func capabilities(for member: Member) -> Set<AccessCapability> {
+        var merged = member.roles.reduce(into: Set<AccessCapability>()) { partialResult, role in
+            partialResult.formUnion(capabilities(for: role))
+        }
+        if member.isCommonPurchaseManager {
+            merged.insert(.manageProductCatalog)
+        }
+        return merged
+    }
+
+    static func hasCapability(_ capability: AccessCapability, for member: Member) -> Bool {
+        capabilities(for: member).contains(capability)
+    }
+}
+
+extension Member {
+    var isMember: Bool {
+        roles.contains(.member)
+    }
+
+    var isProducer: Bool {
+        roles.contains(.producer)
+    }
+
+    var canAccessCommonHomeModules: Bool {
+        MemberPermissionMatrix.hasCapability(.accessCommonHomeModules, for: self)
+    }
+
+    var canManageProductCatalog: Bool {
+        MemberPermissionMatrix.hasCapability(.manageProductCatalog, for: self)
+    }
+
+    var canAccessReceivedOrders: Bool {
+        MemberPermissionMatrix.hasCapability(.accessReceivedOrders, for: self)
+    }
+
+    var canManageMembers: Bool {
+        MemberPermissionMatrix.hasCapability(.manageMembers, for: self)
+    }
+
+    var canGrantAdminRole: Bool {
+        MemberPermissionMatrix.hasCapability(.grantAdminRole, for: self)
+    }
+
+    var canPublishNews: Bool {
+        MemberPermissionMatrix.hasCapability(.publishNews, for: self)
+    }
+
+    var canSendAdminNotifications: Bool {
+        MemberPermissionMatrix.hasCapability(.sendAdminNotifications, for: self)
+    }
+}

--- a/ios/Reguerta/Reguerta/Presentation/Access/Core/SessionViewModel+MemberActions.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/Core/SessionViewModel+MemberActions.swift
@@ -5,7 +5,7 @@ extension SessionViewModel {
         guard case .authorized(let session) = mode else {
             return
         }
-        guard session.member.isAdmin else {
+        guard session.member.canManageMembers else {
             feedbackMessageKey = AccessL10nKey.feedbackOnlyAdminCreate
             return
         }
@@ -49,7 +49,7 @@ extension SessionViewModel {
         guard case .authorized(let session) = mode else {
             return
         }
-        guard session.member.isAdmin else {
+        guard session.member.canGrantAdminRole else {
             feedbackMessageKey = AccessL10nKey.feedbackOnlyAdminEditRoles
             return
         }
@@ -87,7 +87,7 @@ extension SessionViewModel {
         guard case .authorized(let session) = mode else {
             return
         }
-        guard session.member.isAdmin else {
+        guard session.member.canManageMembers else {
             feedbackMessageKey = AccessL10nKey.feedbackOnlyAdminToggleActive
             return
         }

--- a/ios/Reguerta/Reguerta/Presentation/Access/Home/ContentView+HomeDashboardRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/Home/ContentView+HomeDashboardRoute.swift
@@ -25,7 +25,7 @@ extension ContentView {
     func authorizedHome(session: AuthorizedSession) -> some View {
         operationalModules(
             modulesEnabled: true,
-            canOpenProducts: session.member.roles.contains(.producer) || session.member.isCommonPurchaseManager,
+            canOpenProducts: session.member.canManageProductCatalog,
             myOrderFreshnessState: viewModel.myOrderFreshnessState
         )
 

--- a/ios/Reguerta/Reguerta/Presentation/Access/Home/ContentView+HomeFeatureRoutes.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/Home/ContentView+HomeFeatureRoutes.swift
@@ -85,7 +85,7 @@ extension ContentView {
             tokens: tokens,
             isLoadingNews: viewModel.isLoadingNews,
             newsFeed: viewModel.newsFeed,
-            isAdmin: currentHomeMember?.isAdmin == true,
+            isAdmin: currentHomeMember?.canPublishNews == true,
             newsMetaText: { article in
                 l10n(AccessL10nKey.newsMetaFormat, article.publishedBy)
             },
@@ -169,7 +169,7 @@ extension ContentView {
             tokens: tokens,
             isLoadingNotifications: viewModel.isLoadingNotifications,
             notificationsFeed: viewModel.notificationsFeed,
-            isAdmin: currentHomeMember?.isAdmin == true,
+            isAdmin: currentHomeMember?.canSendAdminNotifications == true,
             notificationMetaText: { notification in
                 l10n(
                     AccessL10nKey.notificationsMetaFormat,

--- a/ios/Reguerta/Reguerta/Presentation/Access/Home/ContentView+HomeShellComponents.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/Home/ContentView+HomeShellComponents.swift
@@ -197,11 +197,11 @@ struct HomeDrawerContentView: View {
 
     private var canManageProductCatalog: Bool {
         guard let currentMember else { return false }
-        return currentMember.roles.contains(.producer) || currentMember.isCommonPurchaseManager
+        return currentMember.canManageProductCatalog
     }
 
     private var isProducer: Bool {
-        currentMember?.roles.contains(.producer) == true
+        currentMember?.canAccessReceivedOrders == true
     }
 
     private func localizedKey(_ key: String) -> LocalizedStringKey {
@@ -293,11 +293,19 @@ struct HomeDrawerContentView: View {
             homeDrawerItem("tray.full.fill", titleKey: AccessL10nKey.homeShellActionReceivedOrders, destination: .receivedOrders)
         }
 
-        if currentMember?.isAdmin == true {
+        if currentMember?.canManageMembers == true ||
+            currentMember?.canPublishNews == true ||
+            currentMember?.canSendAdminNotifications == true {
             drawerSection(titleKey: AccessL10nKey.homeShellSectionAdmin)
-            homeDrawerItem("person.3.fill", titleKey: AccessL10nKey.homeShellActionUsers, destination: .users)
-            homeDrawerItem("plus.square.fill", titleKey: AccessL10nKey.homeShellActionPublishNews, destination: .publishNews)
-            homeDrawerItem("megaphone.fill", titleKey: AccessL10nKey.homeShellActionAdminBroadcast, destination: .adminBroadcast)
+            if currentMember?.canManageMembers == true {
+                homeDrawerItem("person.3.fill", titleKey: AccessL10nKey.homeShellActionUsers, destination: .users)
+            }
+            if currentMember?.canPublishNews == true {
+                homeDrawerItem("plus.square.fill", titleKey: AccessL10nKey.homeShellActionPublishNews, destination: .publishNews)
+            }
+            if currentMember?.canSendAdminNotifications == true {
+                homeDrawerItem("megaphone.fill", titleKey: AccessL10nKey.homeShellActionAdminBroadcast, destination: .adminBroadcast)
+            }
         }
     }
 

--- a/ios/Reguerta/Reguerta/Presentation/Access/Home/ContentView+MyOrderRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/Home/ContentView+MyOrderRoute.swift
@@ -2190,7 +2190,7 @@ private extension Member {
         }
         return members.first { producer in
             producer.id != id &&
-                producer.roles.contains(.producer) &&
+                producer.isProducer &&
                 producer.isActive &&
                 producer.producerCatalogEnabled &&
                 producer.producerParity == parity

--- a/ios/Reguerta/Reguerta/Presentation/Access/Home/ContentView+ReceivedOrdersRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/Home/ContentView+ReceivedOrdersRoute.swift
@@ -136,7 +136,7 @@ struct ReceivedOrdersRouteView: View {
     @State private var updatingStatusOrderId: String?
 
     private var isProducer: Bool {
-        currentMember?.roles.contains(.producer) == true
+        currentMember?.canAccessReceivedOrders == true
     }
 
     private var window: ReceivedOrdersWindow {

--- a/ios/Reguerta/Reguerta/Presentation/Access/News/SessionViewModel+NewsNotificationsActions.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/News/SessionViewModel+NewsNotificationsActions.swift
@@ -15,7 +15,7 @@ extension SessionViewModel {
 
     func startCreatingNews() {
         guard case .authorized(let session) = mode else { return }
-        guard session.member.isAdmin else {
+        guard session.member.canPublishNews else {
             feedbackMessageKey = AccessL10nKey.feedbackOnlyAdminPublishNews
             return
         }
@@ -26,7 +26,7 @@ extension SessionViewModel {
 
     func startEditingNews(newsId: String) {
         guard case .authorized(let session) = mode else { return }
-        guard session.member.isAdmin else {
+        guard session.member.canPublishNews else {
             feedbackMessageKey = AccessL10nKey.feedbackOnlyAdminEditNews
             return
         }
@@ -49,7 +49,7 @@ extension SessionViewModel {
 
     func startCreatingNotification() {
         guard case .authorized(let session) = mode else { return }
-        guard session.member.isAdmin else {
+        guard session.member.canSendAdminNotifications else {
             feedbackMessageKey = AccessL10nKey.feedbackOnlyAdminSendNotification
             return
         }
@@ -69,7 +69,7 @@ extension SessionViewModel {
         Task { @MainActor in
             let allNews = await newsRepository.allNews()
             latestNews = allNews.filter(\.active).prefix(3).map { $0 }
-            newsFeed = session.member.isAdmin ? allNews : allNews.filter(\.active)
+            newsFeed = session.member.canPublishNews ? allNews : allNews.filter(\.active)
             isLoadingNews = false
         }
     }
@@ -86,7 +86,7 @@ extension SessionViewModel {
 
     func saveNews(onSuccess: @escaping @MainActor () -> Void = {}) {
         guard case .authorized(let session) = mode else { return }
-        guard session.member.isAdmin else {
+        guard session.member.canPublishNews else {
             feedbackMessageKey = AccessL10nKey.feedbackOnlyAdminPublishNews
             return
         }
@@ -131,7 +131,7 @@ extension SessionViewModel {
 
     func deleteNews(newsId: String, onSuccess: @escaping @MainActor () -> Void = {}) {
         guard case .authorized(let session) = mode else { return }
-        guard session.member.isAdmin else {
+        guard session.member.canPublishNews else {
             feedbackMessageKey = AccessL10nKey.feedbackOnlyAdminDeleteNews
             return
         }
@@ -155,7 +155,7 @@ extension SessionViewModel {
 
     func sendNotification(onSuccess: @escaping @MainActor () -> Void = {}) {
         guard case .authorized(let session) = mode else { return }
-        guard session.member.isAdmin else {
+        guard session.member.canSendAdminNotifications else {
             feedbackMessageKey = AccessL10nKey.feedbackOnlyAdminSendNotification
             return
         }

--- a/ios/Reguerta/Reguerta/Presentation/Access/Orders/MyOrderCommitmentValidation.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/Orders/MyOrderCommitmentValidation.swift
@@ -107,7 +107,7 @@ private func requiredEcoBasketCommitmentProducts(
 ) -> [Product] {
     guard let member = currentMember,
           member.isActive,
-          member.roles.contains(.member)
+          member.isMember
     else {
         return []
     }
@@ -134,7 +134,7 @@ private func requiredEcoBasketCommitmentProducts(
         let eligibleProducerIds = Set(
             members
                 .filter { producer in
-                    producer.roles.contains(.producer) &&
+                    producer.isProducer &&
                         producer.isActive &&
                         producer.producerCatalogEnabled &&
                         producer.producerParity == parity

--- a/ios/Reguerta/Reguerta/Presentation/Access/Products/ContentView+ProductsRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/Products/ContentView+ProductsRoute.swift
@@ -15,7 +15,7 @@ struct ProductsRouteView: View {
         viewModel.editingProductId != nil
     }
     private var isProducer: Bool {
-        currentHomeMember?.roles.contains(.producer) == true
+        currentHomeMember?.isProducer == true
     }
     private var canManageEcoBasket: Bool {
         isProducer
@@ -248,7 +248,7 @@ private struct ProductsListRouteView: View {
     @Binding var pendingProducerCatalogVisibility: Bool?
 
     private var isProducer: Bool {
-        currentHomeMember?.roles.contains(.producer) == true
+        currentHomeMember?.isProducer == true
     }
 
     private func localizedKey(_ key: String) -> LocalizedStringKey {

--- a/ios/Reguerta/Reguerta/Presentation/Access/Products/SessionViewModel+ProductActions.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Access/Products/SessionViewModel+ProductActions.swift
@@ -399,16 +399,6 @@ private extension Product {
     }
 }
 
-extension Member {
-    var isProducer: Bool {
-        roles.contains(.producer)
-    }
-
-    var canManageProductCatalog: Bool {
-        isProducer || isCommonPurchaseManager
-    }
-}
-
 private extension Double {
     var uiDecimal: String {
         truncatingRemainder(dividingBy: 1) == 0

--- a/ios/Reguerta/ReguertaTests/ReguertaTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaTests.swift
@@ -880,6 +880,129 @@ struct ReguertaTests {
         #expect(member.seasonalCommitmentLookupKeys == ["member_1"])
     }
 
+    @Test
+    func canonicalMatrixCapabilitiesMatchIOSPermissionMatrix() throws {
+        let matrix = try loadCanonicalMatrix()
+
+        for role in CanonicalAccessRole.allCases {
+            let expected = Set(
+                matrix[role.rawValue, default: []]
+                    .compactMap(AccessCapability.init(rawValue:))
+            )
+            #expect(MemberPermissionMatrix.capabilities(for: role) == expected)
+        }
+    }
+
+    @Test
+    func commonPurchaseManagerOverrideGrantsCatalogManagement() {
+        let member = Member(
+            id: "member_common_purchase_001",
+            displayName: "Compra común",
+            normalizedEmail: "compras@reguerta.app",
+            authUid: nil,
+            roles: [.member],
+            isActive: true,
+            producerCatalogEnabled: true,
+            isCommonPurchaseManager: true
+        )
+
+        #expect(member.canManageProductCatalog)
+    }
+
+    @Test
+    func inMemoryFixturesStayAlignedWithCanonicalMatrix() async {
+        let repository = InMemoryMemberRepository()
+        let membersById = Dictionary(
+            uniqueKeysWithValues: await repository.allMembers().map { ($0.id, $0) }
+        )
+
+        if let admin = membersById["member_admin_001"] {
+            #expect(admin.canManageMembers)
+            #expect(admin.canGrantAdminRole)
+            #expect(admin.canPublishNews)
+            #expect(admin.canSendAdminNotifications)
+        } else {
+            Issue.record("Missing seeded admin fixture")
+        }
+
+        if let producer = membersById["member_producer_001"] {
+            #expect(producer.canManageProductCatalog)
+            #expect(producer.canAccessReceivedOrders)
+        } else {
+            Issue.record("Missing seeded producer fixture")
+        }
+
+        if let member = membersById["member_member_001"] {
+            #expect(member.canAccessCommonHomeModules)
+            #expect(member.canManageMembers == false)
+            #expect(member.canAccessReceivedOrders == false)
+        } else {
+            Issue.record("Missing seeded member fixture")
+        }
+    }
+
+    private func loadCanonicalMatrix() throws -> [String: Set<String>] {
+        let matrixURL = try findCanonicalMatrixURL()
+        let data = try Data(contentsOf: matrixURL)
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let roles = root["roles"] as? [String: [String: Any]] else {
+            throw MatrixLoadError.invalidPayload
+        }
+
+        func resolveCapabilities(
+            roleName: String,
+            visiting: inout Set<String>
+        ) throws -> Set<String> {
+            guard let role = roles[roleName] else { return [] }
+            if visiting.contains(roleName) {
+                throw MatrixLoadError.inheritanceCycle(roleName)
+            }
+            visiting.insert(roleName)
+            defer { visiting.remove(roleName) }
+
+            let direct = Set(stringArray(role["capabilities"]))
+            let inherited = stringArray(role["inherits"])
+            let inheritedCapabilities = try inherited.reduce(into: Set<String>()) { partialResult, inheritedRole in
+                partialResult.formUnion(try resolveCapabilities(roleName: inheritedRole, visiting: &visiting))
+            }
+            return direct.union(inheritedCapabilities)
+        }
+
+        return try roles.keys.reduce(into: [String: Set<String>]()) { partialResult, roleName in
+            var visiting = Set<String>()
+            partialResult[roleName] = try resolveCapabilities(roleName: roleName, visiting: &visiting)
+        }
+    }
+
+    private func findCanonicalMatrixURL() throws -> URL {
+        var cursor = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let fileManager = FileManager.default
+        while true {
+            let candidate = cursor.appendingPathComponent(Self.matrixRelativePath)
+            if fileManager.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+            let parent = cursor.deletingLastPathComponent()
+            if parent.path == cursor.path {
+                break
+            }
+            cursor = parent
+        }
+        throw MatrixLoadError.fileNotFound
+    }
+
+    private func stringArray(_ value: Any?) -> [String] {
+        (value as? [String])?
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty } ?? []
+    }
+
+    private enum MatrixLoadError: Error {
+        case fileNotFound
+        case invalidPayload
+        case inheritanceCycle(String)
+    }
+
     private func member(
         id: String,
         ecoCommitmentMode: EcoCommitmentMode,
@@ -998,6 +1121,9 @@ struct ReguertaTests {
             updatedAtMillis: 1
         )
     }
+
+    private static let matrixRelativePath =
+        "spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/role-permission-matrix.v1.json"
 }
 
 private struct FixedStartupVersionPolicyRepository: StartupVersionPolicyRepository {

--- a/spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/role-permission-matrix.v1.json
+++ b/spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/role-permission-matrix.v1.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0.0",
+  "owner": "app-platform",
+  "updated_at": "2026-04-17",
+  "description": "Canonical role-permission matrix for MVP role gating and fixture alignment.",
+  "capabilities": {
+    "access_common_home_modules": "Access common authenticated modules (dashboard, my-order, shifts, news, notifications, profile, settings).",
+    "manage_product_catalog": "Create/update/archive products in own catalog.",
+    "access_received_orders": "Open producer received orders route.",
+    "manage_members": "Open members management CRUD tools.",
+    "grant_admin_role": "Grant or revoke admin role.",
+    "publish_news": "Create/update/archive news items from admin tools.",
+    "send_admin_notifications": "Send admin broadcast notifications.",
+    "route_production_reviewer_to_develop": "When allowlisted, route production reviewer sessions to develop backend."
+  },
+  "roles": {
+    "member": {
+      "capabilities": [
+        "access_common_home_modules"
+      ]
+    },
+    "producer": {
+      "inherits": [
+        "member"
+      ],
+      "capabilities": [
+        "manage_product_catalog",
+        "access_received_orders"
+      ]
+    },
+    "admin": {
+      "inherits": [
+        "member"
+      ],
+      "capabilities": [
+        "manage_members",
+        "grant_admin_role",
+        "publish_news",
+        "send_admin_notifications"
+      ]
+    },
+    "reviewer": {
+      "inherits": [
+        "member"
+      ],
+      "capabilities": [
+        "route_production_reviewer_to_develop"
+      ],
+      "notes": "Reviewer is a runtime persona (allowlist + environment routing), not a persisted users.roles value."
+    }
+  },
+  "flag_overrides": {
+    "is_common_purchase_manager_grants": [
+      "manage_product_catalog"
+    ]
+  }
+}

--- a/spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/spec.md
+++ b/spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/spec.md
@@ -43,6 +43,7 @@ As a product and engineering team I want one canonical role-permission matrix an
 - Functional references: docs-es/requirements/historias-usuario-mvp-reguerta-v1.md.
 - Data references: docs-es/requirements/firestore-estructura-mvp-propuesta-v1.md.
 - Depends on HU-010 role model and HU-039 role-aware shell.
+- Canonical matrix artifact: spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/role-permission-matrix.v1.json.
 
 ## Risks
 
@@ -51,11 +52,16 @@ As a product and engineering team I want one canonical role-permission matrix an
 - Risk: parity drift after future feature additions.
   - Mitigation: enforce matrix-based tests in both platforms.
 
+## Parity status
+
+- Android/iOS parity: aligned for role-gated core modules (`products`, `received-orders`, `members`, `news`, `admin notifications`).
+- Known exception: `reviewer` remains a runtime persona (allowlist + environment routing), not a persisted `users.roles` value.
+
 ## Definition of Done (DoD)
 
-- [ ] Story acceptance criteria validated.
-- [ ] Implementation aligned with linked RFs.
-- [ ] Android/iOS parity reviewed or temporary gap documented.
-- [ ] Agreed tests executed.
-- [ ] Technical/functional documentation updated.
+- [x] Story acceptance criteria validated.
+- [x] Implementation aligned with linked RFs.
+- [x] Android/iOS parity reviewed or temporary gap documented.
+- [x] Agreed tests executed.
+- [x] Technical/functional documentation updated.
 - [ ] Issue and PR linked.

--- a/spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/tasks.md
+++ b/spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/tasks.md
@@ -1,35 +1,35 @@
 # Tasks - HU-044 (Canonical role permission matrix and test fixtures)
 
 ## 1. Preparation
-- [ ] Define canonical role-permission matrix schema and storage path.
-- [ ] Inventory current permission checks and fixture role assumptions.
-- [ ] Confirm MVP role list and capability boundaries.
+- [x] Define canonical role-permission matrix schema and storage path.
+- [x] Inventory current permission checks and fixture role assumptions.
+- [x] Confirm MVP role list and capability boundaries.
 
 ## 2. Android implementation
-- [ ] Align Android capability checks with matrix.
-- [ ] Update Android test fixtures/seeds to match matrix.
-- [ ] Add drift-detection tests for Android role gating.
+- [x] Align Android capability checks with matrix.
+- [x] Update Android test fixtures/seeds to match matrix.
+- [x] Add drift-detection tests for Android role gating.
 
 ## 3. iOS implementation
-- [ ] Align iOS capability checks with matrix.
-- [ ] Update iOS test fixtures/seeds to match matrix.
-- [ ] Add drift-detection tests for iOS role gating.
+- [x] Align iOS capability checks with matrix.
+- [x] Update iOS test fixtures/seeds to match matrix.
+- [x] Add drift-detection tests for iOS role gating.
 
 ## 4. Backend / Firestore
-- [ ] Validate backend role assumptions against matrix.
-- [ ] Update any backend role checks that diverge from canonical contract.
+- [x] Validate backend role assumptions against matrix.
+- [x] Update any backend role checks that diverge from canonical contract.
 
 ## 5. Testing
-- [ ] Execute Android unit/integration tests for role gating.
-- [ ] Execute iOS unit/UI tests for role gating.
+- [x] Execute Android unit/integration tests for role gating.
+- [x] Execute iOS unit/UI tests for role gating.
 - [ ] Perform manual cross-role validation in develop.
 
 ## 6. Documentation
-- [ ] Document canonical matrix and ownership.
-- [ ] Link matrix from related HU specs/issues.
-- [ ] Record parity status and known exceptions (if any).
+- [x] Document canonical matrix and ownership.
+- [x] Link matrix from related HU specs/issues.
+- [x] Record parity status and known exceptions (if any).
 
 ## 7. Closure
 - [ ] Create/update linked issue and connect PR.
-- [ ] Complete DoD checklist in spec.md.
-- [ ] Attach test evidence and drift-check results.
+- [x] Complete DoD checklist in spec.md.
+- [x] Attach test evidence and drift-check results.

--- a/spec/issues/hu-044-canonical-role-permission-matrix-and-test-fixtures-issue.md
+++ b/spec/issues/hu-044-canonical-role-permission-matrix-and-test-fixtures-issue.md
@@ -8,6 +8,7 @@ As a product and engineering team we want one canonical role-permission matrix a
 - Spec: spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/spec.md
 - Plan: spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/plan.md
 - Tasks: spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/tasks.md
+- Matrix: spec/app/hu-044-canonical-role-permission-matrix-and-test-fixtures/role-permission-matrix.v1.json
 
 ## Acceptance criteria
 


### PR DESCRIPTION
## Summary
- add canonical HU-044 role/capability matrix artifact (`v1`) in spec
- align Android and iOS role-gating helpers and core route/action checks to matrix capabilities
- add drift tests on Android and iOS that validate local permission mapping against the canonical matrix
- wire reviewer routing guardrails through the canonical reviewer capability
- update HU-044 spec/tasks/issue docs and changelog entry

## Validation
- `./gradlew app:testDebugUnitTest`
- `./gradlew app:lintDebug`
- `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' test`
- `npm run lint && npm run build` (functions)

## Notes
- `iPhone 16` simulator is not available locally; validation used `iPhone 17`.
- `connectedDebugAndroidTest` was not run (no dedicated device/emulator run in this pass).

Closes #105
