### PR TITLE
[HU-052] iOS Liquid Glass screen header component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- 2026-05-13 | ✨ feat(ios-ui): add screen header component
 - 2026-05-03 | ✨ feat(home): apply HU-051 redesign
 - 2026-04-28 | ✨ feat(access): implement HU-019 bylaws hybrid mode
 - 2026-04-19 | ✨ feat(media): integrate image picker in news and profile

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaScreenHeader/ReguertaScreenHeaderView.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaScreenHeader/ReguertaScreenHeaderView.swift
@@ -1,0 +1,264 @@
+import SwiftUI
+
+struct ReguertaScreenHeaderView: View {
+    @Environment(\.reguertaTokens) private var tokens
+
+    let viewModel: ReguertaScreenHeaderViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: tokens.spacing.sm) {
+            ReguertaScreenHeaderTopRowView(viewModel: viewModel)
+
+            if let title = viewModel.title {
+                ReguertaScreenHeaderTitleView(title: title)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .reguertaScreenHeaderGlassContainer(spacing: tokens.spacing.xl)
+    }
+}
+
+private struct ReguertaScreenHeaderTopRowView: View {
+    @Environment(\.reguertaTokens) private var tokens
+
+    let viewModel: ReguertaScreenHeaderViewModel
+
+    var body: some View {
+        HStack(alignment: .center, spacing: tokens.spacing.md) {
+            if let leadingAction = viewModel.leadingAction {
+                ReguertaGlassIconButton(iconAction: leadingAction)
+            }
+
+            ReguertaScreenHeaderLeadingTextView(text: viewModel.leadingText)
+
+            if let trailingAction = viewModel.trailingAction {
+                ReguertaGlassIconButton(iconAction: trailingAction)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 58.resize)
+    }
+}
+
+private struct ReguertaScreenHeaderLeadingTextView: View {
+    @Environment(\.reguertaTokens) private var tokens
+
+    let text: ReguertaHeaderText?
+
+    var body: some View {
+        Group {
+            if let text {
+                text.viewText
+                    .font(tokens.typography.titleCard)
+                    .foregroundStyle(tokens.colors.textPrimary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.78)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityIdentifier("reguerta.screenHeader.leadingText")
+            } else {
+                Spacer(minLength: 0)
+            }
+        }
+    }
+}
+
+private struct ReguertaScreenHeaderTitleView: View {
+    @Environment(\.reguertaTokens) private var tokens
+
+    let title: ReguertaHeaderText
+
+    var body: some View {
+        title.viewText
+            .font(tokens.typography.titleSection)
+            .foregroundStyle(tokens.colors.textPrimary)
+            .lineLimit(2)
+            .minimumScaleFactor(0.78)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityAddTraits(.isHeader)
+            .accessibilityIdentifier("reguerta.screenHeader.title")
+    }
+}
+
+struct ReguertaGlassIconButton: View {
+    @Environment(\.reguertaTokens) private var tokens
+
+    let iconAction: ReguertaHeaderAction
+
+    var body: some View {
+        Button(action: iconAction.action) {
+            ZStack(alignment: .topTrailing) {
+                Image(systemName: iconAction.systemImageName)
+                    .font(.system(size: 21.resize, weight: .semibold))
+                    .foregroundStyle(iconAction.iconColor(tokens: tokens))
+                    .frame(width: 58.resize, height: 58.resize)
+                    .contentShape(Circle())
+
+                ReguertaHeaderBadgeView(badge: iconAction.badge)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(!iconAction.isEnabled)
+        .opacity(iconAction.opacity)
+        .reguertaHeaderGlassButton(tokens: tokens, isEnabled: iconAction.isEnabled)
+        .accessibilityLabel(iconAction.accessibilityLabel.viewText)
+        .reguertaHeaderAccessibilityIdentifier(iconAction.accessibilityIdentifier)
+    }
+}
+
+private struct ReguertaHeaderBadgeView: View {
+    let badge: ReguertaHeaderBadge?
+
+    var body: some View {
+        Group {
+            if badge?.showsDot == true {
+                ReguertaHeaderDotBadgeView()
+            } else if let countText = badge?.countText {
+                ReguertaHeaderCountBadgeView(text: countText)
+            } else {
+                EmptyView()
+            }
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+private struct ReguertaHeaderDotBadgeView: View {
+    @Environment(\.reguertaTokens) private var tokens
+
+    var body: some View {
+        Circle()
+            .fill(tokens.colors.feedbackError)
+            .frame(width: 9.resize, height: 9.resize)
+            .overlay(Circle().stroke(tokens.colors.surfacePrimary, lineWidth: 1.resize))
+            .padding(.top, 12.resize)
+            .padding(.trailing, 12.resize)
+    }
+}
+
+private struct ReguertaHeaderCountBadgeView: View {
+    @Environment(\.reguertaTokens) private var tokens
+
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(tokens.typography.label)
+            .foregroundStyle(tokens.colors.actionOnPrimary)
+            .frame(minWidth: 18.resize, minHeight: 18.resize)
+            .padding(.horizontal, 4.resize)
+            .background(tokens.colors.feedbackError, in: Capsule())
+            .overlay(Capsule().stroke(tokens.colors.surfacePrimary, lineWidth: 1.5.resize))
+            .padding(.top, 5.resize)
+            .padding(.trailing, 5.resize)
+    }
+}
+
+private struct ReguertaScreenHeaderPreviewSurface: View {
+    @Environment(\.reguertaTokens) private var tokens
+
+    let viewModel: ReguertaScreenHeaderViewModel
+
+    var body: some View {
+        ReguertaScreenHeaderView(viewModel: viewModel)
+            .padding(20.resize)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .background(tokens.colors.surfacePrimary)
+    }
+}
+
+#Preview("Back + Title") {
+    ReguertaTheme {
+        ReguertaScreenHeaderPreviewSurface(
+            viewModel: ReguertaScreenHeaderViewModel(
+                title: .verbatim("Pedidos a preparar"),
+                leadingAction: ReguertaHeaderAction(
+                    systemImageName: "chevron.left",
+                    accessibilityLabel: .localized(AccessL10nKey.commonBack),
+                    accessibilityIdentifier: "preview.header.backButton",
+                    action: {}
+                )
+            )
+        )
+    }
+}
+
+#Preview("Back + Leading Text + Title") {
+    ReguertaTheme {
+        ReguertaScreenHeaderPreviewSurface(
+            viewModel: ReguertaScreenHeaderViewModel(
+                title: .verbatim("Crear tu pedido semanal"),
+                leadingAction: ReguertaHeaderAction(
+                    systemImageName: "chevron.left",
+                    accessibilityLabel: .localized(AccessL10nKey.commonBack),
+                    action: {}
+                ),
+                leadingText: .verbatim("Semana 21")
+            )
+        )
+    }
+}
+
+#Preview("Menu + Date + Notifications") {
+    ReguertaTheme {
+        ReguertaScreenHeaderPreviewSurface(
+            viewModel: ReguertaScreenHeaderViewModel(
+                leadingAction: ReguertaHeaderAction(
+                    systemImageName: "line.3.horizontal",
+                    accessibilityLabel: .localized(AccessL10nKey.homeShellMenu),
+                    accessibilityIdentifier: "preview.header.menuButton",
+                    action: {}
+                ),
+                leadingText: .verbatim("miercoles 13 mayo"),
+                trailingAction: ReguertaHeaderAction(
+                    systemImageName: "bell",
+                    accessibilityLabel: .localized(AccessL10nKey.homeShellNotifications),
+                    accessibilityIdentifier: "preview.header.notificationsButton",
+                    badge: .dot,
+                    action: {}
+                )
+            )
+        )
+    }
+}
+
+#Preview("Back + Title + Cart Count") {
+    ReguertaTheme {
+        ReguertaScreenHeaderPreviewSurface(
+            viewModel: ReguertaScreenHeaderViewModel(
+                title: .verbatim("Lista de productos"),
+                leadingAction: ReguertaHeaderAction(
+                    systemImageName: "chevron.left",
+                    accessibilityLabel: .localized(AccessL10nKey.commonBack),
+                    action: {}
+                ),
+                trailingAction: ReguertaHeaderAction(
+                    systemImageName: "cart",
+                    accessibilityLabel: .verbatim("Ver carrito"),
+                    accessibilityIdentifier: "preview.header.cartButton",
+                    badge: .count(12),
+                    action: {}
+                )
+            )
+        )
+    }
+}
+
+#Preview("Disabled Trailing Action") {
+    ReguertaTheme {
+        ReguertaScreenHeaderPreviewSurface(
+            viewModel: ReguertaScreenHeaderViewModel(
+                title: .verbatim("Notificaciones"),
+                leadingAction: ReguertaHeaderAction(
+                    systemImageName: "chevron.left",
+                    accessibilityLabel: .localized(AccessL10nKey.commonBack),
+                    action: {}
+                ),
+                trailingAction: ReguertaHeaderAction(
+                    systemImageName: "paperplane",
+                    accessibilityLabel: .verbatim("Enviar"),
+                    isEnabled: false,
+                    action: {}
+                )
+            )
+        )
+    }
+}

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaScreenHeader/ReguertaScreenHeaderViewModel.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaScreenHeader/ReguertaScreenHeaderViewModel.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+
+typealias ReguertaScreenHeader = ReguertaScreenHeaderView
+
+enum ReguertaHeaderText {
+    case localized(String)
+    case verbatim(String)
+
+    var viewText: Text {
+        switch self {
+        case .localized(let key):
+            Text(LocalizedStringKey(key))
+        case .verbatim(let value):
+            Text(verbatim: value)
+        }
+    }
+}
+
+enum ReguertaHeaderBadge {
+    case dot
+    case count(Int)
+
+    var showsDot: Bool {
+        switch self {
+        case .dot:
+            true
+        case .count:
+            false
+        }
+    }
+
+    var countText: String? {
+        switch self {
+        case .count(let count) where count > 0:
+            "\(min(count, 99))"
+        case .count, .dot:
+            nil
+        }
+    }
+}
+
+struct ReguertaHeaderAction {
+    let systemImageName: String
+    let accessibilityLabel: ReguertaHeaderText
+    let accessibilityIdentifier: String?
+    let isEnabled: Bool
+    let badge: ReguertaHeaderBadge?
+    let action: () -> Void
+
+    init(
+        systemImageName: String,
+        accessibilityLabel: ReguertaHeaderText,
+        accessibilityIdentifier: String? = nil,
+        isEnabled: Bool = true,
+        badge: ReguertaHeaderBadge? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.systemImageName = systemImageName
+        self.accessibilityLabel = accessibilityLabel
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.isEnabled = isEnabled
+        self.badge = badge
+        self.action = action
+    }
+
+    var opacity: Double {
+        isEnabled ? 1 : 0.66
+    }
+
+    func iconColor(tokens: ReguertaDesignTokens) -> Color {
+        isEnabled ? tokens.colors.textPrimary : tokens.colors.textSecondary
+    }
+}
+
+struct ReguertaScreenHeaderViewModel {
+    let title: ReguertaHeaderText?
+    let leadingAction: ReguertaHeaderAction?
+    let leadingText: ReguertaHeaderText?
+    let trailingAction: ReguertaHeaderAction?
+
+    init(
+        title: ReguertaHeaderText? = nil,
+        leadingAction: ReguertaHeaderAction? = nil,
+        leadingText: ReguertaHeaderText? = nil,
+        trailingAction: ReguertaHeaderAction? = nil
+    ) {
+        self.title = title
+        self.leadingAction = leadingAction
+        self.leadingText = leadingText
+        self.trailingAction = trailingAction
+    }
+}
+
+extension View {
+    @ViewBuilder
+    func reguertaScreenHeaderGlassContainer(spacing: CGFloat) -> some View {
+        if #available(iOS 26.0, *) {
+            GlassEffectContainer(spacing: spacing) {
+                self
+            }
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    func reguertaHeaderGlassButton(tokens: ReguertaDesignTokens, isEnabled: Bool) -> some View {
+        let shape = Circle()
+
+        if #available(iOS 26.0, *) {
+            self.glassEffect(
+                .regular
+                    .tint(tokens.colors.surfaceSecondary.opacity(0.18))
+                    .interactive(isEnabled),
+                in: shape
+            )
+        } else {
+            self
+                .background(.ultraThinMaterial, in: shape)
+                .overlay(
+                    shape.stroke(tokens.colors.borderSubtle.opacity(0.42), lineWidth: 1)
+                )
+                .shadow(color: .black.opacity(0.18), radius: 10.resize, y: 4.resize)
+        }
+    }
+
+    @ViewBuilder
+    func reguertaHeaderAccessibilityIdentifier(_ identifier: String?) -> some View {
+        if let identifier {
+            accessibilityIdentifier(identifier)
+        } else {
+            self
+        }
+    }
+}

--- a/spec/app/hu-052-ios-liquid-glass-screen-header-component/plan.md
+++ b/spec/app/hu-052-ios-liquid-glass-screen-header-component/plan.md
@@ -1,0 +1,67 @@
+# Plan - HU-052 (iOS Liquid Glass screen header component)
+
+## 1. Technical approach
+
+Introduce `ReguertaScreenHeaderView` as a small SwiftUI design-system primitive before replacing route-specific headers. The component should be layout-stable, token-driven, and independent from current route state so HU-053 can migrate screens incrementally.
+
+The implementation will keep all screen migration out of scope and only add previews for visual iteration. The component lives in its own folder with a view file and a view-model file so the UI structure stays separate from helper models and presentation decisions.
+
+## 2. Layer impact
+- UI: new iOS design-system component and previews.
+- Domain: no changes.
+- Data: no changes.
+- Backend: no changes.
+- Docs: HU-052 spec, plan, and tasks.
+
+## 3. Platform-specific changes
+
+### Android
+- No implementation in HU-052.
+- Record Android/Compose parity as deferred to a future story.
+
+### iOS
+- Add `ReguertaScreenHeader/ReguertaScreenHeaderView.swift` under `DesignSystem/Components`.
+- Add `ReguertaScreenHeader/ReguertaScreenHeaderViewModel.swift` under `DesignSystem/Components`.
+- Add `ReguertaHeaderText`, `ReguertaHeaderAction`, and `ReguertaHeaderBadge` to the view-model file.
+- Add the glass icon button implementation as a subview in the view file.
+- Avoid custom `init` declarations in all SwiftUI views.
+- Use `GlassEffectContainer` when header actions are present.
+- Keep icon action size fixed at `58.resize`.
+- Add previews for the agreed variants.
+
+### Functions/Backend
+- Not applicable.
+
+## 4. Test strategy
+- Unit: not required; the change is a stateless SwiftUI component.
+- Build/test: run the iOS scheme test command.
+- Manual: inspect previews in light and dark modes, especially long text, badges, disabled state, and fallback styling.
+
+## 5. Rollout and functional validation
+- Ship the component unused by production screens.
+- Review the component visually before HU-053 begins.
+- Use HU-053 for the actual app-wide migration after design feedback.
+
+## 6. Phased implementation sequence
+
+### Phase 1 - Tracking and docs
+- Create GitHub issue #132.
+- Add HU-052 `spec.md`, `plan.md`, and `tasks.md`.
+
+### Phase 2 - Component
+- Add header text/action/badge models.
+- Implement `ReguertaScreenHeader`.
+- Implement the Liquid Glass icon button and fallback.
+
+### Phase 3 - Preview and validation
+- Add previews for all required states.
+- Run iOS validation.
+- Review the final diff and record any existing unrelated worktree changes.
+
+## 7. Technical risks and mitigation
+- Risk: previews compile but later route migration needs more configuration.
+  - Mitigation: model text and actions as generic values rather than route-specific enums.
+- Risk: badges shift button layout.
+  - Mitigation: overlay badges on fixed-size icon buttons.
+- Risk: fallback style drifts from Home shell.
+  - Mitigation: match current material, border, and shadow conventions.

--- a/spec/app/hu-052-ios-liquid-glass-screen-header-component/spec.md
+++ b/spec/app/hu-052-ios-liquid-glass-screen-header-component/spec.md
@@ -1,0 +1,92 @@
+# HU-052 - iOS Liquid Glass screen header component
+
+## Metadata
+- issue_id: 132
+- priority: P2
+- platform: ios
+- status: in-progress
+
+## Context and problem
+
+Most authenticated iOS routes already sit inside a shared Home shell, but screen-level headers, back affordances, and titles are still implemented in several local shapes. The next migration will touch many screens, so the reusable header should be designed and reviewed first as an isolated design-system component.
+
+This story creates the iOS Liquid Glass screen header component only. Existing screens must not be migrated in this story.
+
+## User story
+
+As an iOS app user I want a consistent screen header with clear navigation and optional contextual actions so that every route can later use the same accessible top-of-screen pattern.
+
+## Scope
+
+### In Scope
+- Add a reusable SwiftUI `ReguertaScreenHeaderView` design-system component.
+- Keep a `ReguertaScreenHeader` type alias for the component contract.
+- Split the component into a view file and a view-model/presentation-logic file.
+- Support optional screen title, optional leading text, optional leading icon action, and optional trailing icon action.
+- Support enabled/disabled icon actions.
+- Support optional dot and count badges for trailing or leading icon actions.
+- Use native Liquid Glass for icon actions on iOS 26+.
+- Provide a material fallback for environments where the glass API is not active.
+- Add SwiftUI previews covering the agreed design variants.
+- Add HU spec, plan, and tasks artifacts.
+
+### Out of Scope
+- Migrating `HomeShellTopBarView`.
+- Replacing existing screen back buttons.
+- Removing duplicated screen titles.
+- Changing route navigation behavior.
+- Android or Compose parity.
+- Backend, data, or domain changes.
+
+## Linked functional requirements
+
+- RF-APP-HEADER-01
+- RF-APP-HEADER-02
+- RF-APP-ACCESSIBILITY-01
+
+## Acceptance criteria
+
+- `ReguertaScreenHeaderView` exists under its own iOS design-system component folder.
+- `ReguertaScreenHeaderView.swift` contains only the view, subviews, and previews.
+- `ReguertaScreenHeaderViewModel.swift` contains text/action/badge models and presentation helpers.
+- No SwiftUI `View` in the component declares a custom `init`.
+- `ReguertaScreenHeaderViewModel` exposes:
+  - `title: ReguertaHeaderText?`
+  - `leadingAction: ReguertaHeaderAction?`
+  - `leadingText: ReguertaHeaderText?`
+  - `trailingAction: ReguertaHeaderAction?`
+- `ReguertaHeaderText` supports `.localized(String)` and `.verbatim(String)`.
+- `ReguertaHeaderAction` supports SF Symbol name, accessibility label, optional accessibility identifier, enabled state, optional badge, and action closure.
+- `ReguertaHeaderBadge` supports `.dot` and `.count(Int)`.
+- Icon actions render with Liquid Glass on iOS 26+ and material fallback otherwise.
+- Icon action frames remain stable at `58.resize` square.
+- Previews cover:
+  - back + title,
+  - back + leading text + title,
+  - menu + date + notification dot with no title,
+  - back + title + cart count,
+  - disabled trailing action.
+- No existing app screen is migrated in this story.
+
+## Dependencies
+
+- Existing iOS design tokens in `ReguertaDesignTokens`.
+- Existing responsive sizing helpers such as `.resize`.
+- iOS 26+ Liquid Glass API availability.
+- GitHub issue #132.
+
+## Risks
+
+- Risk: component API may become too narrow for the future migration.
+  - Mitigation: keep title/action/text models generic and independent from Home-specific destinations.
+- Risk: Liquid Glass usage may diverge from existing Home shell glass style.
+  - Mitigation: reuse the same circle shape, tint, material fallback, border, and shadow conventions.
+- Risk: long leading text or titles may overlap actions.
+  - Mitigation: use stable icon dimensions, line limits, and minimum scale factors.
+
+## Definition of Done (DoD)
+
+- [ ] Acceptance criteria validated.
+- [ ] iOS validation executed or blocker documented.
+- [ ] Android impact reviewed and recorded as out of scope.
+- [ ] Documentation artifacts added.

--- a/spec/app/hu-052-ios-liquid-glass-screen-header-component/tasks.md
+++ b/spec/app/hu-052-ios-liquid-glass-screen-header-component/tasks.md
@@ -1,0 +1,35 @@
+# Tasks - HU-052 (iOS Liquid Glass screen header component)
+
+GitHub tracking:
+
+- #132 - iOS Liquid Glass screen header component.
+
+## 1. Preparation
+- [x] Create implementation branch.
+- [x] Create GitHub issue.
+- [x] Confirm HU number and spec path.
+
+## 2. Documentation
+- [x] Add `spec.md`.
+- [x] Add `plan.md`.
+- [x] Add `tasks.md`.
+
+## 3. iOS implementation
+- [x] Add `ReguertaHeaderText`.
+- [x] Add `ReguertaHeaderBadge`.
+- [x] Add `ReguertaHeaderAction`.
+- [x] Add `ReguertaScreenHeaderView`.
+- [x] Split component into `ReguertaScreenHeaderView.swift` and `ReguertaScreenHeaderViewModel.swift`.
+- [x] Remove custom `init` declarations from SwiftUI views.
+- [x] Add Liquid Glass icon action button with fallback.
+- [x] Add previews for required variants.
+
+## 4. Testing
+- [x] Run `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' test`.
+- [x] Confirm `iPhone 17` was available; no fallback simulator was needed.
+- [ ] Manually inspect previews where possible.
+
+## 5. Closure
+- [x] Confirm no existing screens were migrated.
+- [x] Review git diff.
+- [x] Document Android parity gap as deferred.


### PR DESCRIPTION
## Summary
- Add the iOS `ReguertaScreenHeaderView` design-system component in its own folder.
- Split view/subviews/previews from presentation models and helpers.
- Add HU-052 spec, plan, tasks, and changelog entry.

## Validation
- `swiftlint lint --config .swiftlint.yml Reguerta/DesignSystem/Components/ReguertaScreenHeader/ReguertaScreenHeaderView.swift Reguerta/DesignSystem/Components/ReguertaScreenHeader/ReguertaScreenHeaderViewModel.swift`
- `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' test`

Closes #132