### PR TITLE
Refine Home Liquid Glass order buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- 2026-05-14 | ♻️ refactor(ios-orders): split previous order fetch
 - 2026-05-14 | ♻️ refactor(ios-ui): split design components
 - 2026-05-12 | ♻️ refactor(ios-ui): organize presentation layout
 - 2026-05-12 | ♻️ refactor(ios-session): move session adjuncts to root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-05-14 | 🐛 fix(ios-home): refine order buttons glass
 - 2026-05-13 | 🐛 fix(firestore): remove legacy collection paths
 - 2026-05-13 | 🐛 fix(order): restore last order lookup
 - 2026-05-13 | 🐛 fix(ios): fix side drawer layout

--- a/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderPreviousOrder.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderPreviousOrder.swift
@@ -143,51 +143,26 @@ func fetchPreviousWeekOrderSnapshot(
     previousWeekKey: String,
     db: Firestore
 ) async throws -> MyOrderPreviousOrderSnapshot? {
-    var orderDocuments: [String: [String: Any]] = [:]
-    let deterministicOrderSnapshot = try await db.document("\(target.orders)/\(deterministicOrderId)").getDocument()
-    if deterministicOrderSnapshot.exists {
-        orderDocuments[deterministicOrderSnapshot.documentID] = deterministicOrderSnapshot.data() ?? [:]
-    }
-
-    let weekOrdersSnapshot = try await db.collection(target.orders)
-        .whereField("weekKey", isEqualTo: previousWeekKey)
-        .getDocuments()
-    for document in weekOrdersSnapshot.documents where document.matchesMemberOrder(
+    let orderDocuments = try await fetchPreviousOrderDocuments(
+        target: target,
+        deterministicOrderId: deterministicOrderId,
         memberId: memberId,
         weekKey: previousWeekKey,
-        deterministicOrderId: deterministicOrderId
-    ) {
-        orderDocuments[document.documentID] = document.data()
-    }
+        db: db
+    )
 
     let candidateOrderIds = Array(([deterministicOrderId] + Array(orderDocuments.keys))
         .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
         .filter { !$0.isEmpty })
         .uniquePreservingOrder()
 
-    var lineDocuments: [String: [String: Any]] = [:]
-    for orderId in candidateOrderIds {
-        let linesSnapshot = try await db.collection(target.orderlines)
-            .whereField("orderId", isEqualTo: orderId)
-            .getDocuments()
-        for document in linesSnapshot.documents {
-            lineDocuments[document.documentID] = document.data()
-        }
-    }
-
-    let weekLinesSnapshot = try await db.collection(target.orderlines)
-        .whereField("weekKey", isEqualTo: previousWeekKey)
-        .getDocuments()
-    for document in weekLinesSnapshot.documents {
-        let data = document.data()
-        if data.matchesPreviousOrderLine(
-            memberId: memberId,
-            weekKey: previousWeekKey,
-            candidateOrderIds: candidateOrderIds
-        ) {
-            lineDocuments[document.documentID] = data
-        }
-    }
+    let lineDocuments = try await fetchPreviousOrderLineDocuments(
+        target: target,
+        candidateOrderIds: candidateOrderIds,
+        memberId: memberId,
+        weekKey: previousWeekKey,
+        db: db
+    )
 
     let lines = lineDocuments.values.map { data in
         myOrderPreviousLine(from: data)
@@ -207,6 +182,67 @@ func fetchPreviousWeekOrderSnapshot(
         groups: groups,
         total: total
     )
+}
+
+private func fetchPreviousOrderDocuments(
+    target: MyOrderCheckoutWriteTarget,
+    deterministicOrderId: String,
+    memberId: String,
+    weekKey: String,
+    db: Firestore
+) async throws -> [String: [String: Any]] {
+    var orderDocuments: [String: [String: Any]] = [:]
+    let deterministicOrderSnapshot = try await db.document("\(target.orders)/\(deterministicOrderId)").getDocument()
+    if deterministicOrderSnapshot.exists {
+        orderDocuments[deterministicOrderSnapshot.documentID] = deterministicOrderSnapshot.data() ?? [:]
+    }
+
+    let weekOrdersSnapshot = try await db.collection(target.orders)
+        .whereField("weekKey", isEqualTo: weekKey)
+        .getDocuments()
+    for document in weekOrdersSnapshot.documents where document.matchesMemberOrder(
+        memberId: memberId,
+        weekKey: weekKey,
+        deterministicOrderId: deterministicOrderId
+    ) {
+        orderDocuments[document.documentID] = document.data()
+    }
+
+    return orderDocuments
+}
+
+private func fetchPreviousOrderLineDocuments(
+    target: MyOrderCheckoutWriteTarget,
+    candidateOrderIds: [String],
+    memberId: String,
+    weekKey: String,
+    db: Firestore
+) async throws -> [String: [String: Any]] {
+    var lineDocuments: [String: [String: Any]] = [:]
+    for orderId in candidateOrderIds {
+        let linesSnapshot = try await db.collection(target.orderlines)
+            .whereField("orderId", isEqualTo: orderId)
+            .getDocuments()
+        for document in linesSnapshot.documents {
+            lineDocuments[document.documentID] = document.data()
+        }
+    }
+
+    let weekLinesSnapshot = try await db.collection(target.orderlines)
+        .whereField("weekKey", isEqualTo: weekKey)
+        .getDocuments()
+    for document in weekLinesSnapshot.documents {
+        let data = document.data()
+        if data.matchesPreviousOrderLine(
+            memberId: memberId,
+            weekKey: weekKey,
+            candidateOrderIds: candidateOrderIds
+        ) {
+            lineDocuments[document.documentID] = data
+        }
+    }
+
+    return lineDocuments
 }
 
 private extension QueryDocumentSnapshot {

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellComponents.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellComponents.swift
@@ -181,6 +181,8 @@ struct HomeWeeklySummaryCardView: View {
 }
 
 struct HomeActionRowView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     let tokens: ReguertaDesignTokens
     let myOrderFreshnessState: MyOrderFreshnessState
     let canOpenReceivedOrders: Bool
@@ -255,26 +257,27 @@ struct HomeActionRowView: View {
             VStack(alignment: .center, spacing: tokens.spacing.xs) {
                 Text(localizedKey(titleKey))
                     .font(tokens.typography.titleCard.weight(.semibold))
+                    .foregroundStyle(primary ? tokens.colors.actionPrimary : tokens.colors.textPrimary)
                     .multilineTextAlignment(.center)
                     .lineLimit(subtitleKey == nil ? 2 : 1)
                     .minimumScaleFactor(0.82)
                 if let subtitleKey {
                     Text(localizedKey(subtitleKey))
                         .font(tokens.typography.label)
+                        .foregroundStyle(tokens.colors.textSecondary)
                         .multilineTextAlignment(.center)
                         .lineLimit(1)
                 }
             }
             .frame(maxWidth: .infinity, minHeight: 82.resize, alignment: .center)
             .padding(tokens.spacing.md)
-            .foregroundStyle(primary ? tokens.colors.actionOnPrimary : tokens.colors.actionPrimary)
-            .background(primary ? tokens.colors.actionPrimary.opacity(0.82) : tokens.colors.surfacePrimary.opacity(0.34))
-            .overlay(
-                RoundedRectangle(cornerRadius: tokens.radius.md)
-                    .stroke(primary ? Color.clear : tokens.colors.actionPrimary.opacity(0.82), lineWidth: 1)
+            .contentShape(RoundedRectangle(cornerRadius: tokens.radius.md))
+            .homeActionTileGlass(
+                tokens: tokens,
+                primary: primary,
+                enabled: enabled,
+                colorScheme: colorScheme
             )
-            .clipShape(RoundedRectangle(cornerRadius: tokens.radius.md))
-            .homeActionTileGlass(tokens: tokens, primary: primary)
             .opacity(enabled ? 1 : 0.55)
         }
         .disabled(!enabled)
@@ -285,20 +288,29 @@ struct HomeActionRowView: View {
 
 private extension View {
     @ViewBuilder
-    func homeActionTileGlass(tokens: ReguertaDesignTokens, primary: Bool) -> some View {
+    func homeActionTileGlass(
+        tokens: ReguertaDesignTokens,
+        primary: Bool,
+        enabled: Bool,
+        colorScheme: ColorScheme
+    ) -> some View {
         let shape = RoundedRectangle(cornerRadius: tokens.radius.md)
+        let isDarkMode = colorScheme == .dark
+        let neutralTint = isDarkMode ? Color.black.opacity(0.32) : Color.white.opacity(0.40)
+        let primaryTint = tokens.colors.actionPrimary.opacity(isDarkMode ? 0.26 : 0.20)
+        let tint = primary ? primaryTint : neutralTint
 
         if #available(iOS 26.0, *) {
             self.glassEffect(
                 .regular
-                    .tint((primary ? tokens.colors.actionPrimary : tokens.colors.surfaceSecondary).opacity(0.22))
-                    .interactive(true),
+                    .tint(tint)
+                    .interactive(enabled),
                 in: shape
             )
         } else {
             self
                 .background(.ultraThinMaterial, in: shape)
-                .shadow(color: .black.opacity(0.12), radius: 8.resize, y: 3.resize)
+                .background(tint, in: shape)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Refine the Home `Mi pedido` and `Pedidos recibidos` action tiles with the simpler Liquid Glass pattern used by the header buttons.
- Remove the remaining SwiftLint function-length warning by splitting previous-order Firestore reads into focused helpers.

## Validation
- `git diff --check`
- `swiftlint lint Reguerta/Data/Orders/FirestoreMyOrderPreviousOrder.swift`
- `swiftlint lint Reguerta/Presentation/Home/ContentView+HomeShellComponents.swift`
- `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' build`
