### PR TITLE
✨ feat(ui): add reusable list controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- 2026-05-16 | ✨ feat(ui): add reusable list controls
 - 2026-05-14 | ✨ feat(home): add weekly market context
 - 2026-05-14 | ✨ feat(ios-ui): migrate liquid glass headers
 - 2026-05-13 | ✨ feat(ios-ui): add screen header component

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeModels.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeModels.kt
@@ -31,9 +31,9 @@ internal fun HomeDestination.titleRes(): Int = when (this) {
     HomeDestination.NOTIFICATIONS -> R.string.home_shell_notifications
     HomeDestination.PROFILE -> R.string.home_shell_action_profile
     HomeDestination.SETTINGS -> R.string.home_shell_action_settings
-    HomeDestination.PRODUCTS -> R.string.home_shell_action_products
+    HomeDestination.PRODUCTS -> R.string.products_catalog_title
     HomeDestination.RECEIVED_ORDERS -> R.string.home_shell_action_received_orders
-    HomeDestination.USERS -> R.string.home_shell_action_users
+    HomeDestination.USERS -> R.string.users_list_title
     HomeDestination.PUBLISH_NEWS -> R.string.home_shell_action_publish_news
     HomeDestination.ADMIN_BROADCAST -> R.string.home_shell_action_admin_broadcast
 }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeRoute.kt
@@ -119,7 +119,7 @@ internal fun HomeRoute(
     onToggleAdmin: (String) -> Unit,
     onToggleActive: (String) -> Unit,
     onCreateMember: () -> Unit,
-    onSaveMemberDraft: (String?, onSuccess: () -> Unit) -> Unit,
+    onSaveMemberDraft: (String?, onSuccess: (String) -> Unit) -> Unit,
     onStartCreatingNews: () -> Unit,
     onStartCreatingNotification: () -> Unit,
     onStartCreatingProduct: () -> Unit,
@@ -132,7 +132,7 @@ internal fun HomeRoute(
     onUploadSharedProfileImageFromUri: (Uri) -> Unit,
     onClearSharedProfileImage: () -> Unit,
     onSaveNews: (onSuccess: () -> Unit) -> Unit,
-    onSaveProduct: (onSuccess: () -> Unit) -> Unit,
+    onSaveProduct: (onSuccess: (String) -> Unit) -> Unit,
     onSetProducerCatalogVisibility: (Boolean, onSuccess: () -> Unit) -> Unit,
     onSendNotification: (onSuccess: () -> Unit) -> Unit,
     onDeleteNews: (String, () -> Unit) -> Unit,
@@ -281,6 +281,7 @@ internal fun HomeRoute(
         val usesRouteScroll =
             currentDestination != HomeDestination.MY_ORDER &&
                 currentDestination != HomeDestination.RECEIVED_ORDERS &&
+                currentDestination != HomeDestination.PRODUCTS &&
                 currentDestination != HomeDestination.USERS
         Column(
             modifier = Modifier
@@ -492,7 +493,7 @@ internal fun HomeRoute(
                     onPickImage = onUploadProductImageFromUri,
                     onClearImage = onClearProductImage,
                     onCancelEditor = onClearProductEditor,
-                    onSaveProduct = { onSaveProduct { } },
+                    onSaveProduct = onSaveProduct,
                     onArchiveProduct = onArchiveProduct,
                     onSetProducerCatalogVisibility = onSetProducerCatalogVisibility,
                     )

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrderRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrderRoute.kt
@@ -93,6 +93,7 @@ import com.reguerta.user.domain.shifts.ShiftType
 import com.reguerta.user.ui.components.auth.ReguertaDialog
 import com.reguerta.user.ui.components.auth.ReguertaDialogAction
 import com.reguerta.user.ui.components.auth.ReguertaDialogType
+import com.reguerta.user.ui.components.auth.ReguertaFloatingActionButton
 import com.reguerta.user.ui.theme.ColorFeedbackWarningDefault
 import com.reguerta.user.ui.theme.ReguertaThemeTokens
 import java.text.Normalizer
@@ -720,8 +721,9 @@ internal fun MyOrderRoute(
                         }
 
                     if (!isReadOnlyMode) {
-                        Button(
-                            onClick = {
+                        ReguertaFloatingActionButton(
+                            label = finalizeActionLabel,
+                            onClick = checkoutClick@{
                                 val validationResult = validateMyOrderCheckout(
                                     currentMember = currentMember,
                                     members = members,
@@ -759,7 +761,7 @@ internal fun MyOrderRoute(
                                     }
                                 }
                                 if (checkoutDialogState != null) {
-                                    return@Button
+                                    return@checkoutClick
                                 }
 
                                 coroutineScope.launch {
@@ -793,24 +795,10 @@ internal fun MyOrderRoute(
                                 }
                             },
                             enabled = canSubmitOrder,
+                            loading = isSubmittingCheckout,
                             modifier = Modifier
-                                .align(Alignment.BottomCenter)
-                                .fillMaxWidth()
-                                .padding(horizontal = 28.dp)
-                                .padding(bottom = 8.dp)
-                                .height(52.dp)
-                                .shadow(
-                                    elevation = 8.dp,
-                                    shape = RoundedCornerShape(28.dp),
-                                    clip = false,
-                                ),
-                            shape = RoundedCornerShape(28.dp),
-                        ) {
-                            Text(
-                                text = finalizeActionLabel,
-                                fontWeight = FontWeight.SemiBold,
-                            )
-                        }
+                                .align(Alignment.BottomCenter),
+                        )
                     }
                 }
             }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootProductsComponents.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootProductsComponents.kt
@@ -5,35 +5,35 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Image
-import androidx.compose.material3.Card
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.reguerta.user.R
 import com.reguerta.user.domain.products.Product
 import com.reguerta.user.domain.products.ProductStockMode
+import com.reguerta.user.ui.components.auth.ReguertaDeleteListActionButton
+import com.reguerta.user.ui.components.auth.ReguertaEditListActionButton
+import com.reguerta.user.ui.components.auth.ReguertaListItemCard
 import java.util.Locale
 
 private fun Double.toUiDecimal(): String =
@@ -102,110 +102,109 @@ internal fun ProducerCatalogVisibilityDialog(
 @Composable
 internal fun ProductListItem(
     product: Product,
+    isHighlighted: Boolean,
     onEdit: () -> Unit,
     onArchive: () -> Unit,
 ) {
-    Card {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            verticalAlignment = Alignment.Top,
+    ReguertaListItemCard(isHighlighted = isHighlighted) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Box(
-                modifier = Modifier
-                    .size(96.dp)
-                    .clip(RoundedCornerShape(20.dp))
-                    .background(MaterialTheme.colorScheme.surfaceVariant),
-                contentAlignment = Alignment.Center,
-            ) {
-                if (product.productImageUrl.isNullOrBlank()) {
-                    Icon(
-                        imageVector = Icons.Default.Image,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(32.dp),
+            Box(modifier = Modifier.fillMaxWidth()) {
+                ProductImage(
+                    product = product,
+                    modifier = Modifier.align(Alignment.TopStart),
+                )
+                Row(
+                    modifier = Modifier.align(Alignment.TopEnd),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    ReguertaEditListActionButton(
+                        contentDescription = stringResource(R.string.products_edit_action),
+                        onClick = onEdit,
                     )
-                } else {
-                    AsyncImage(
-                        model = product.productImageUrl,
-                        contentDescription = null,
-                        modifier = Modifier.fillMaxSize(),
-                        contentScale = ContentScale.Crop,
-                    )
+                    if (!product.archived) {
+                        ReguertaDeleteListActionButton(
+                            contentDescription = stringResource(R.string.products_archive_action),
+                            onClick = onArchive,
+                        )
+                    }
                 }
             }
             Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
+                Text(
+                    text = product.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = product.description.ifBlank { stringResource(R.string.products_description_empty) },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.Top,
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Column(
-                        modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(6.dp),
-                    ) {
-                        Text(
-                            text = product.name,
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.SemiBold,
-                        )
-                        Text(
-                            text = product.description.ifBlank { "Sin descripcion." },
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                    Row {
-                        IconButton(onClick = onEdit) {
-                            Icon(
-                                imageVector = Icons.Default.Edit,
-                                contentDescription = stringResource(R.string.products_edit_action),
-                            )
-                        }
-                        if (!product.archived) {
-                            IconButton(onClick = onArchive) {
-                                Icon(
-                                    imageVector = Icons.Default.Delete,
-                                    contentDescription = stringResource(R.string.products_archive_action),
-                                )
-                            }
-                        }
-                    }
-                }
-                Text(
-                    text = "${product.price.toUiDecimal()} €",
-                    style = MaterialTheme.typography.headlineSmall,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Text(
-                    text = when {
-                        product.archived -> stringResource(R.string.products_status_archived)
-                        product.stockMode == ProductStockMode.INFINITE -> stringResource(R.string.products_status_infinite_stock)
-                        else -> stringResource(
-                            R.string.products_status_finite_stock_format,
-                            product.stockQty?.toUiDecimal().orEmpty().ifBlank { "0" },
-                        )
-                    },
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Text(
-                    text = "${product.unitQty.toUiDecimal()} ${product.unitAbbreviation ?: product.unitName}",
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-                if (product.packContainerName != null) {
                     Text(
-                        text = product.packContainerName,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        text = product.price.toUiPrice(),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = when {
+                            product.archived -> stringResource(R.string.products_status_archived)
+                            product.stockMode == ProductStockMode.INFINITE -> stringResource(R.string.products_status_infinite_stock)
+                            else -> stringResource(
+                                R.string.products_status_finite_stock_format,
+                                product.stockQty?.toUiDecimal().orEmpty().ifBlank { "0" },
+                            )
+                        },
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface,
                     )
                 }
             }
         }
     }
 }
+
+@Composable
+private fun ProductImage(
+    product: Product,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(72.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (product.productImageUrl.isNullOrBlank()) {
+            Icon(
+                imageVector = Icons.Default.Image,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(28.dp),
+            )
+        } else {
+            AsyncImage(
+                model = product.productImageUrl,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+            )
+        }
+    }
+}
+
+private fun Double.toUiPrice(): String = String.format(Locale.US, "%.2f €", this)

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootProductsRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootProductsRoute.kt
@@ -1,7 +1,6 @@
 package com.reguerta.user.presentation.access
 
 import android.net.Uri
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,14 +9,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Image
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -29,6 +25,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,15 +33,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.reguerta.user.R
 import com.reguerta.user.domain.access.Member
 import com.reguerta.user.domain.access.isProducer
@@ -53,6 +45,8 @@ import com.reguerta.user.domain.products.Product
 import com.reguerta.user.domain.products.ProductStockMode
 import com.reguerta.user.ui.components.auth.ReguertaButton
 import com.reguerta.user.ui.components.auth.ReguertaButtonVariant
+import com.reguerta.user.ui.components.auth.ReguertaFloatingActionButton
+import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -72,7 +66,7 @@ fun ProductsRoute(
     onPickImage: (Uri) -> Unit,
     onClearImage: () -> Unit,
     onCancelEditor: () -> Unit,
-    onSaveProduct: () -> Unit,
+    onSaveProduct: (onSuccess: (String) -> Unit) -> Unit,
     onArchiveProduct: (String, onSuccess: () -> Unit) -> Unit,
     onSetProducerCatalogVisibility: (Boolean, onSuccess: () -> Unit) -> Unit,
 ) {
@@ -85,105 +79,118 @@ fun ProductsRoute(
         member.isCommonPurchaseManager && !member.isProducer
     } == true
     var commonPurchaseExpanded by rememberSaveable { mutableStateOf(false) }
-    var pendingCatalogVisibility by rememberSaveable { mutableStateOf<Boolean?>(null) }
+    var highlightedProductId by rememberSaveable { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(highlightedProductId) {
+        val productId = highlightedProductId ?: return@LaunchedEffect
+        delay(1_600)
+        if (highlightedProductId == productId) {
+            highlightedProductId = null
+        }
+    }
 
     if (isEditing) {
-        Card {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                Text(
-                    text = stringResource(
-                        if (editingProductId.isNullOrBlank()) {
-                            R.string.products_editor_title_create
-                        } else {
-                            R.string.products_editor_title_edit
-                        },
-                    ),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                ReguertaImagePickerField(
-                    imageUrl = draft.productImageUrl,
-                    isUploading = isUploadingImage,
-                    onPickImage = onPickImage,
-                    onClearImage = onClearImage,
-                    placeholderIcon = Icons.Default.Image,
-                    subtitle = stringResource(R.string.products_editor_subtitle),
-                )
-                OutlinedTextField(
-                    value = draft.name,
-                    onValueChange = { onDraftChanged(draft.copy(name = it)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    label = { Text(stringResource(R.string.products_field_name)) },
-                )
-                OutlinedTextField(
-                    value = draft.description,
-                    onValueChange = { onDraftChanged(draft.copy(description = it)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    label = { Text(stringResource(R.string.products_field_description)) },
-                    minLines = 3,
-                )
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    OutlinedTextField(
-                        value = draft.unitQty,
-                        onValueChange = { onDraftChanged(draft.copy(unitQty = it)) },
-                        modifier = Modifier.weight(1f),
-                        label = { Text(stringResource(R.string.products_field_unit_qty)) },
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()),
+        ) {
+            Card {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Text(
+                        text = stringResource(
+                            if (editingProductId.isNullOrBlank()) {
+                                R.string.products_editor_title_create
+                            } else {
+                                R.string.products_editor_title_edit
+                            },
+                        ),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    ReguertaImagePickerField(
+                        imageUrl = draft.productImageUrl,
+                        isUploading = isUploadingImage,
+                        onPickImage = onPickImage,
+                        onClearImage = onClearImage,
+                        placeholderIcon = Icons.Default.Image,
+                        subtitle = stringResource(R.string.products_editor_subtitle),
                     )
                     OutlinedTextField(
-                        value = draft.packContainerQty,
-                        onValueChange = { onDraftChanged(draft.copy(packContainerQty = it)) },
-                        modifier = Modifier.weight(1f),
-                        label = { Text(stringResource(R.string.products_field_pack_qty)) },
-                    )
-                }
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    OutlinedTextField(
-                        value = draft.packContainerName,
-                        onValueChange = { onDraftChanged(draft.copy(packContainerName = it)) },
-                        modifier = Modifier.weight(1f),
-                        label = { Text(stringResource(R.string.products_field_pack_name)) },
+                        value = draft.name,
+                        onValueChange = { onDraftChanged(draft.copy(name = it)) },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text(stringResource(R.string.products_field_name)) },
                     )
                     OutlinedTextField(
-                        value = draft.unitName,
-                        onValueChange = { onDraftChanged(draft.copy(unitName = it)) },
-                        modifier = Modifier.weight(1f),
-                        label = { Text(stringResource(R.string.products_field_unit_name)) },
+                        value = draft.description,
+                        onValueChange = { onDraftChanged(draft.copy(description = it)) },
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text(stringResource(R.string.products_field_description)) },
+                        minLines = 3,
                     )
-                }
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    OutlinedTextField(
-                        value = draft.packContainerPlural,
-                        onValueChange = { onDraftChanged(draft.copy(packContainerPlural = it)) },
-                        modifier = Modifier.weight(1f),
-                        label = { Text(stringResource(R.string.products_field_pack_plural)) },
-                    )
-                    OutlinedTextField(
-                        value = draft.unitPlural,
-                        onValueChange = { onDraftChanged(draft.copy(unitPlural = it)) },
-                        modifier = Modifier.weight(1f),
-                        label = { Text(stringResource(R.string.products_field_unit_plural)) },
-                    )
-                }
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    OutlinedTextField(
-                        value = draft.price,
-                        onValueChange = { onDraftChanged(draft.copy(price = it)) },
-                        modifier = Modifier.weight(1f),
-                        label = { Text(stringResource(R.string.products_field_price)) },
-                    )
-                    OutlinedTextField(
-                        value = draft.stockQty,
-                        onValueChange = { onDraftChanged(draft.copy(stockQty = it)) },
-                        modifier = Modifier.weight(1f),
-                        label = { Text(stringResource(R.string.products_field_stock_qty)) },
-                        enabled = draft.stockMode == ProductStockMode.FINITE,
-                    )
-                }
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedTextField(
+                            value = draft.unitQty,
+                            onValueChange = { onDraftChanged(draft.copy(unitQty = it)) },
+                            modifier = Modifier.weight(1f),
+                            label = { Text(stringResource(R.string.products_field_unit_qty)) },
+                        )
+                        OutlinedTextField(
+                            value = draft.packContainerQty,
+                            onValueChange = { onDraftChanged(draft.copy(packContainerQty = it)) },
+                            modifier = Modifier.weight(1f),
+                            label = { Text(stringResource(R.string.products_field_pack_qty)) },
+                        )
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedTextField(
+                            value = draft.packContainerName,
+                            onValueChange = { onDraftChanged(draft.copy(packContainerName = it)) },
+                            modifier = Modifier.weight(1f),
+                            label = { Text(stringResource(R.string.products_field_pack_name)) },
+                        )
+                        OutlinedTextField(
+                            value = draft.unitName,
+                            onValueChange = { onDraftChanged(draft.copy(unitName = it)) },
+                            modifier = Modifier.weight(1f),
+                            label = { Text(stringResource(R.string.products_field_unit_name)) },
+                        )
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedTextField(
+                            value = draft.packContainerPlural,
+                            onValueChange = { onDraftChanged(draft.copy(packContainerPlural = it)) },
+                            modifier = Modifier.weight(1f),
+                            label = { Text(stringResource(R.string.products_field_pack_plural)) },
+                        )
+                        OutlinedTextField(
+                            value = draft.unitPlural,
+                            onValueChange = { onDraftChanged(draft.copy(unitPlural = it)) },
+                            modifier = Modifier.weight(1f),
+                            label = { Text(stringResource(R.string.products_field_unit_plural)) },
+                        )
+                    }
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedTextField(
+                            value = draft.price,
+                            onValueChange = { onDraftChanged(draft.copy(price = it)) },
+                            modifier = Modifier.weight(1f),
+                            label = { Text(stringResource(R.string.products_field_price)) },
+                        )
+                        OutlinedTextField(
+                            value = draft.stockQty,
+                            onValueChange = { onDraftChanged(draft.copy(stockQty = it)) },
+                            modifier = Modifier.weight(1f),
+                            label = { Text(stringResource(R.string.products_field_stock_qty)) },
+                            enabled = draft.stockMode == ProductStockMode.FINITE,
+                        )
+                    }
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -316,7 +323,10 @@ fun ProductsRoute(
                         enabled = !isSaving && !isUploadingImage,
                         onClick = {
                             focusManager.clearFocus(force = true)
-                            onSaveProduct()
+                            onSaveProduct { savedProductId ->
+                                highlightedProductId = savedProductId
+                                onCancelEditor()
+                            }
                         },
                     )
                     ReguertaButton(
@@ -332,79 +342,19 @@ fun ProductsRoute(
                 }
             }
         }
+        }
         return
     }
 
     Box(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxSize(),
     ) {
         Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            Card {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(10.dp),
-                ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource(R.string.products_catalog_title),
-                            modifier = Modifier.weight(1f),
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.SemiBold,
-                        )
-                        if (currentMember?.isProducer == true) {
-                            Button(
-                                onClick = {
-                                    pendingCatalogVisibility = !currentMember.producerCatalogEnabled
-                                },
-                                enabled = !isUpdatingProducerCatalogVisibility,
-                                shape = RoundedCornerShape(18.dp),
-                                colors = ButtonDefaults.buttonColors(
-                                    containerColor = if (currentMember.producerCatalogEnabled) {
-                                        Color(0xFFF08D43)
-                                    } else {
-                                        MaterialTheme.colorScheme.primary
-                                    },
-                                    contentColor = MaterialTheme.colorScheme.onPrimary,
-                                    disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                                    disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                ),
-                                contentPadding = androidx.compose.foundation.layout.PaddingValues(
-                                    horizontal = 14.dp,
-                                    vertical = 8.dp,
-                                ),
-                            ) {
-                                Text(
-                                    text = stringResource(
-                                        if (currentMember.producerCatalogEnabled) {
-                                            R.string.products_visibility_disable_compact_action
-                                        } else {
-                                            R.string.products_visibility_enable_compact_action
-                                        },
-                                    ),
-                                    textAlign = TextAlign.Center,
-                                    style = MaterialTheme.typography.labelMedium,
-                                    lineHeight = 16.sp,
-                                )
-                            }
-                        }
-                    }
-                    ReguertaButton(
-                        label = stringResource(R.string.products_refresh_action),
-                        variant = ReguertaButtonVariant.TEXT,
-                        fullWidth = false,
-                        onClick = onRefresh,
-                    )
-                }
-            }
-
             if (isLoading) {
                 Card {
                     Text(
@@ -424,8 +374,13 @@ fun ProductsRoute(
                     activeProducts.forEach { product ->
                         ProductListItem(
                             product = product,
+                            isHighlighted = highlightedProductId == product.id,
                             onEdit = { onEditProduct(product.id) },
-                            onArchive = { onArchiveProduct(product.id) { } },
+                            onArchive = {
+                                onArchiveProduct(product.id) {
+                                    highlightedProductId = product.id
+                                }
+                            },
                         )
                     }
                 }
@@ -440,6 +395,7 @@ fun ProductsRoute(
                     archivedProducts.forEach { product ->
                         ProductListItem(
                             product = product,
+                            isHighlighted = highlightedProductId == product.id,
                             onEdit = { onEditProduct(product.id) },
                             onArchive = {},
                         )
@@ -447,30 +403,15 @@ fun ProductsRoute(
                 }
             }
 
-            Spacer(modifier = Modifier.height(96.dp))
+            Spacer(modifier = Modifier.height(128.dp))
         }
 
-        ReguertaButton(
+        ReguertaFloatingActionButton(
             label = stringResource(R.string.products_create_action),
-            variant = ReguertaButtonVariant.PRIMARY,
             modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth()
-                .navigationBarsPadding(),
+                .align(Alignment.BottomCenter),
             onClick = onCreateProduct,
         )
     }
 
-    pendingCatalogVisibility?.let { targetEnabled ->
-        ProducerCatalogVisibilityDialog(
-            targetEnabled = targetEnabled,
-            isUpdating = isUpdatingProducerCatalogVisibility,
-            onConfirm = {
-                onSetProducerCatalogVisibility(targetEnabled) {
-                    pendingCatalogVisibility = null
-                }
-            },
-            onDismiss = { pendingCatalogVisibility = null },
-        )
-    }
 }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootUsersRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootUsersRoute.kt
@@ -8,22 +8,18 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,7 +28,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.reguerta.user.R
 import com.reguerta.user.domain.access.Member
@@ -40,9 +38,14 @@ import com.reguerta.user.domain.access.MemberRole
 import com.reguerta.user.domain.access.canManageMembers
 import com.reguerta.user.ui.components.auth.ReguertaButton
 import com.reguerta.user.ui.components.auth.ReguertaButtonVariant
+import com.reguerta.user.ui.components.auth.ReguertaDeleteListActionButton
 import com.reguerta.user.ui.components.auth.ReguertaDialog
 import com.reguerta.user.ui.components.auth.ReguertaDialogAction
 import com.reguerta.user.ui.components.auth.ReguertaDialogType
+import com.reguerta.user.ui.components.auth.ReguertaEditListActionButton
+import com.reguerta.user.ui.components.auth.ReguertaFloatingActionButton
+import com.reguerta.user.ui.components.auth.ReguertaListItemCard
+import kotlinx.coroutines.delay
 
 @Composable
 internal fun UsersRoute(
@@ -50,7 +53,7 @@ internal fun UsersRoute(
     members: List<Member>,
     draft: MemberDraft,
     onDraftChanged: (MemberDraft) -> Unit,
-    onSaveMemberDraft: (String?, onSuccess: () -> Unit) -> Unit,
+    onSaveMemberDraft: (String?, onSuccess: (String) -> Unit) -> Unit,
     onRefreshMembers: () -> Unit,
     onToggleActive: (String) -> Unit,
 ) {
@@ -59,6 +62,15 @@ internal fun UsersRoute(
     var isEditorOpen by rememberSaveable { mutableStateOf(false) }
     var editingMemberId by rememberSaveable { mutableStateOf<String?>(null) }
     var pendingToggleActiveMemberId by rememberSaveable { mutableStateOf<String?>(null) }
+    var highlightedMemberId by rememberSaveable { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(highlightedMemberId) {
+        val memberId = highlightedMemberId ?: return@LaunchedEffect
+        delay(1_600)
+        if (highlightedMemberId == memberId) {
+            highlightedMemberId = null
+        }
+    }
 
     if (isEditorOpen && canManageMembers) {
         UsersEditorCard(
@@ -66,7 +78,8 @@ internal fun UsersRoute(
             editingMember = sortedMembers.firstOrNull { it.id == editingMemberId },
             onDraftChanged = onDraftChanged,
             onSave = {
-                onSaveMemberDraft(editingMemberId) {
+                onSaveMemberDraft(editingMemberId) { savedMemberId ->
+                    highlightedMemberId = savedMemberId
                     isEditorOpen = false
                     editingMemberId = null
                 }
@@ -89,27 +102,6 @@ internal fun UsersRoute(
                         .verticalScroll(rememberScrollState()),
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
-                    Card {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(16.dp),
-                            verticalArrangement = Arrangement.spacedBy(10.dp),
-                        ) {
-                            Text(
-                                text = stringResource(R.string.users_list_title),
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.SemiBold,
-                            )
-                            ReguertaButton(
-                                label = stringResource(R.string.users_list_action_reload),
-                                variant = ReguertaButtonVariant.TEXT,
-                                fullWidth = false,
-                                onClick = onRefreshMembers,
-                            )
-                        }
-                    }
-
                     if (sortedMembers.isEmpty()) {
                         Card {
                             Text(
@@ -124,6 +116,7 @@ internal fun UsersRoute(
                             UserListItem(
                                 member = listedMember,
                                 showAdminActions = canManageMembers,
+                                isHighlighted = highlightedMemberId == listedMember.id,
                                 onEdit = {
                                     editingMemberId = listedMember.id
                                     onDraftChanged(listedMember.toDraft())
@@ -137,18 +130,15 @@ internal fun UsersRoute(
                     }
 
                     if (canManageMembers) {
-                        Spacer(modifier = Modifier.height(104.dp))
+                        Spacer(modifier = Modifier.height(128.dp))
                     }
                 }
             }
 
             if (canManageMembers) {
-                ReguertaButton(
+                ReguertaFloatingActionButton(
                     label = stringResource(R.string.users_create_action),
-                    variant = ReguertaButtonVariant.PRIMARY,
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .navigationBarsPadding()
                         .align(Alignment.BottomCenter),
                     onClick = {
                         editingMemberId = null
@@ -185,6 +175,7 @@ internal fun UsersRoute(
                     label = stringResource(R.string.common_action_accept),
                     onClick = {
                         onToggleActive(memberId)
+                        highlightedMemberId = memberId
                         pendingToggleActiveMemberId = null
                     },
                 ),
@@ -322,24 +313,27 @@ private fun UsersEditorCard(
 private fun UserListItem(
     member: Member,
     showAdminActions: Boolean,
+    isHighlighted: Boolean,
     onEdit: () -> Unit,
     onToggleActive: () -> Unit,
 ) {
-    Card {
+    ReguertaListItemCard(isHighlighted = isHighlighted) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Text(
                 text = member.displayName,
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
             )
             Text(
                 text = member.normalizedEmail,
-                style = MaterialTheme.typography.bodyMedium,
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Normal),
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
 
             if (member.roles.contains(MemberRole.PRODUCER)) {
@@ -348,16 +342,19 @@ private fun UserListItem(
                 val producerLine = stringResource(R.string.users_card_producer_company_format, companyName)
                 Text(
                     text = producerLine,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.Normal,
+                        fontStyle = FontStyle.Italic,
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
                 )
             }
 
             if (member.roles.contains(MemberRole.ADMIN)) {
                 Text(
                     text = stringResource(R.string.users_card_admin_label),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Normal),
+                    color = MaterialTheme.colorScheme.onSurface,
                 )
             }
 
@@ -367,24 +364,21 @@ private fun UserListItem(
                     horizontalArrangement = Arrangement.End,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    IconButton(onClick = onEdit) {
-                        Icon(
-                            imageVector = Icons.Default.Edit,
-                            contentDescription = stringResource(R.string.users_card_action_edit),
-                        )
-                    }
-                    IconButton(onClick = onToggleActive) {
-                        Icon(
-                            imageVector = Icons.Default.Delete,
-                            contentDescription = stringResource(
-                                if (member.isActive) {
-                                    R.string.admin_action_deactivate
-                                } else {
-                                    R.string.admin_action_activate
-                                },
-                            ),
-                        )
-                    }
+                    ReguertaEditListActionButton(
+                        contentDescription = stringResource(R.string.users_card_action_edit),
+                        onClick = onEdit,
+                    )
+                    Spacer(modifier = Modifier.size(8.dp))
+                    ReguertaDeleteListActionButton(
+                        contentDescription = stringResource(
+                            if (member.isActive) {
+                                R.string.admin_action_deactivate
+                            } else {
+                                R.string.admin_action_activate
+                            },
+                        ),
+                        onClick = onToggleActive,
+                    )
                 }
             }
         }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionMemberActions.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionMemberActions.kt
@@ -26,7 +26,7 @@ internal class SessionMemberActions(
 
     fun saveMemberDraft(
         editingMemberId: String?,
-        onSuccess: () -> Unit = {},
+        onSuccess: (String) -> Unit = {},
     ) {
         val mode = uiState.value.mode as? SessionMode.Authorized ?: return
         if (!mode.member.canManageMembers) {
@@ -159,7 +159,7 @@ internal class SessionMemberActions(
         mode: SessionMode.Authorized,
         target: Member,
         onSuccessState: (SessionUiState) -> SessionUiState = { it },
-        onSuccess: () -> Unit = {},
+        onSuccess: (String) -> Unit = {},
     ) {
         scope.launch {
             val updatedMember = try {
@@ -199,7 +199,7 @@ internal class SessionMemberActions(
                     ),
                 )
             }
-            onSuccess()
+            onSuccess(updatedMember.id)
         }
     }
 

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionProductActions.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionProductActions.kt
@@ -93,7 +93,7 @@ internal class SessionProductActions(
         }
     }
 
-    fun saveProduct(onSuccess: () -> Unit = {}) {
+    fun saveProduct(onSuccess: (String) -> Unit = {}) {
         val mode = uiState.value.mode as? SessionMode.Authorized ?: return
         if (!mode.member.canManageSessionProductCatalog) {
             emitMessage(R.string.feedback_only_producer_manage_products)
@@ -169,7 +169,7 @@ internal class SessionProductActions(
                 )
             }
             emitMessage(if (existing == null) R.string.feedback_product_created else R.string.feedback_product_updated)
-            onSuccess()
+            onSuccess(saved.id)
         }
     }
 

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionViewModel.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionViewModel.kt
@@ -291,7 +291,7 @@ class SessionViewModel(
 
     fun clearProductImage() = productActions.clearProductImage()
 
-    fun saveProduct(onSuccess: () -> Unit = {}) = productActions.saveProduct(onSuccess)
+    fun saveProduct(onSuccess: (String) -> Unit = {}) = productActions.saveProduct(onSuccess)
 
     fun archiveProduct(
         productId: String,
@@ -397,7 +397,7 @@ class SessionViewModel(
 
     fun saveMemberDraft(
         editingMemberId: String?,
-        onSuccess: () -> Unit = {},
+        onSuccess: (String) -> Unit = {},
     ) = memberActions.saveMemberDraft(editingMemberId, onSuccess)
 
     fun refreshMembers() = memberActions.refreshMembers()

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaFloatingActionButton.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaFloatingActionButton.kt
@@ -1,0 +1,82 @@
+package com.reguerta.user.ui.components.auth
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ReguertaFloatingActionButton(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    loading: Boolean = false,
+) {
+    val shape = RoundedCornerShape(28.dp)
+    val isInteractive = enabled && !loading
+    val containerAlpha = if (isInteractive) 0.82f else 0.42f
+    val contentColor = MaterialTheme.colorScheme.onPrimary
+
+    Button(
+        onClick = onClick,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 28.dp)
+            .navigationBarsPadding()
+            .padding(bottom = 8.dp)
+            .height(52.dp)
+            .shadow(
+                elevation = 8.dp,
+                shape = shape,
+                clip = false,
+            ),
+        enabled = isInteractive,
+        shape = shape,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.primary.copy(alpha = containerAlpha),
+            contentColor = contentColor,
+            disabledContainerColor = MaterialTheme.colorScheme.primary.copy(alpha = containerAlpha),
+            disabledContentColor = contentColor.copy(alpha = 0.7f),
+        ),
+        border = BorderStroke(1.dp, contentColor.copy(alpha = if (isInteractive) 0.42f else 0.24f)),
+        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 0.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (loading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(18.dp),
+                    strokeWidth = 2.dp,
+                    color = contentColor,
+                )
+            }
+            Text(
+                text = label,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaListItemCard.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaListItemCard.kt
@@ -1,0 +1,121 @@
+package com.reguerta.user.ui.components.auth
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+private val ReguertaListActionButtonSize = 44.dp
+
+@Composable
+fun ReguertaListItemCard(
+    modifier: Modifier = Modifier,
+    isHighlighted: Boolean = false,
+    content: @Composable BoxScope.() -> Unit,
+) {
+    val shape = RoundedCornerShape(16.dp)
+    val highlightAlpha by animateFloatAsState(
+        targetValue = if (isHighlighted) 0.9f else 0f,
+        label = "listItemHighlightBorderAlpha",
+    )
+    val containerColor by animateColorAsState(
+        targetValue = MaterialTheme.colorScheme.primary.copy(alpha = if (isHighlighted) 0.22f else 0.15f),
+        label = "listItemContainerColor",
+    )
+    val shadowElevation by animateDpAsState(
+        targetValue = if (isHighlighted) 10.dp else 0.dp,
+        label = "listItemShadowElevation",
+    )
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .shadow(shadowElevation, shape = shape, clip = false),
+        shape = shape,
+        colors = CardDefaults.cardColors(containerColor = containerColor),
+        border = BorderStroke(3.dp, MaterialTheme.colorScheme.primary.copy(alpha = highlightAlpha)),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    ) {
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            content = content,
+        )
+    }
+}
+
+@Composable
+fun ReguertaListActionIconButton(
+    icon: ImageVector,
+    contentDescription: String,
+    containerColor: Color,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = modifier
+            .size(ReguertaListActionButtonSize)
+            .clip(RoundedCornerShape(12.dp))
+            .background(containerColor),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = Color.White,
+        )
+    }
+}
+
+@Composable
+fun ReguertaEditListActionButton(
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ReguertaListActionIconButton(
+        icon = Icons.Default.Edit,
+        contentDescription = contentDescription,
+        containerColor = MaterialTheme.colorScheme.primary,
+        onClick = onClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun ReguertaDeleteListActionButton(
+    contentDescription: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ReguertaListActionIconButton(
+        icon = Icons.Default.Delete,
+        contentDescription = contentDescription,
+        containerColor = MaterialTheme.colorScheme.error,
+        onClick = onClick,
+        modifier = modifier,
+    )
+}

--- a/android/Reguerta/app/src/main/res/values-es/strings.xml
+++ b/android/Reguerta/app/src/main/res/values-es/strings.xml
@@ -191,7 +191,7 @@
     <string name="users_list_title">Regüertenses autorizados</string>
     <string name="users_list_action_reload">Recargar</string>
     <string name="users_list_empty_state">Aún no hay usuarios autorizados.</string>
-    <string name="users_create_action">Autorizar nuevo usuario</string>
+    <string name="users_create_action">Autorizar regüertense</string>
     <string name="users_editor_title_create">Autorizar regüertense</string>
     <string name="users_editor_title_edit">Actualizar regüertense</string>
     <string name="users_editor_company_name_label">Nombre de la empresa</string>
@@ -232,6 +232,7 @@
     <string name="products_editor_subtitle">El productor queda fijado a tu cuenta. Aqui se guardan stock, disponibilidad y reglas de ecocesta.</string>
     <string name="products_field_name">Nombre</string>
     <string name="products_field_description">Descripción</string>
+    <string name="products_description_empty">Sin descripción.</string>
     <string name="products_field_image_url">URL de imagen</string>
     <string name="products_pick_image_action">Seleccionar imagen</string>
     <string name="products_clear_image_action">Quitar imagen</string>

--- a/android/Reguerta/app/src/main/res/values/strings.xml
+++ b/android/Reguerta/app/src/main/res/values/strings.xml
@@ -191,7 +191,7 @@
     <string name="users_list_title">Authorized Regüertenses</string>
     <string name="users_list_action_reload">Refresh</string>
     <string name="users_list_empty_state">No authorized users were found yet.</string>
-    <string name="users_create_action">Authorize new user</string>
+    <string name="users_create_action">Authorize Regüertense</string>
     <string name="users_editor_title_create">Authorize Regüertense</string>
     <string name="users_editor_title_edit">Update Regüertense</string>
     <string name="users_editor_company_name_label">Company name</string>
@@ -232,6 +232,7 @@
     <string name="products_editor_subtitle">Vendor is fixed to your producer account. Stock, availability, and eco-basket rules are saved here.</string>
     <string name="products_field_name">Name</string>
     <string name="products_field_description">Description</string>
+    <string name="products_description_empty">No description.</string>
     <string name="products_field_image_url">Image URL</string>
     <string name="products_pick_image_action">Select image</string>
     <string name="products_clear_image_action">Remove image</string>

--- a/docs-es/design-system/components.md
+++ b/docs-es/design-system/components.md
@@ -1,6 +1,6 @@
 # Components
 
-Este catálogo define el contrato actual de componentes y su estado de paridad para auth/onboarding.
+Este catálogo define el contrato actual de componentes y su estado de paridad para UI reutilizable de la app.
 
 ## 1. Leyenda de estado
 
@@ -15,8 +15,10 @@ Este catálogo define el contrato actual de componentes y su estado de paridad p
 |---|---|---|---|---|---|
 | Card/contenedor | `ui/components/auth/ReguertaCard.kt` | `DesignSystem/Components/ReguertaCard.swift` | Agrupar contenido con surface + borde/radio semánticos | stable | Shell principal de splash/welcome/login/register/recover |
 | Button | `ReguertaButton` + `ReguertaButtonVariant` | `ReguertaButton` + `ReguertaButtonVariant` | Modelo unificado primaria/secundaria/texto con loading y disabled | stable | Variantes: `primary`, `secondary`, `text` |
+| Botón flotante | `ReguertaFloatingActionButton` | `ReguertaFloatingActionButton` | Acción inferior persistente sobre contenido con scroll, sin franja opaca de footer | stable | Alineado con el estilo de finalizar pedido; iOS usa Liquid Glass con fallback material |
 | Input/Auth field | `ReguertaInputField` | `ReguertaInputField` | Label, placeholder, helper/error text, trailing action, estados focus/disabled/error | stable | `keyboardType` expuesto en ambas plataformas |
 | Feedback inline | `ReguertaInlineFeedback` + `ReguertaFeedbackKind` | `ReguertaInlineFeedback` + `ReguertaFeedbackKind` | Mensajes reutilizables de info/warning/error | stable | Uso en auth shell y zonas de feedback |
+| Card de lista + botones de acción | `ReguertaListItemCard`, `ReguertaEditListActionButton`, `ReguertaDeleteListActionButton` | `ReguertaListItemCard`, `ReguertaListActionIconButton` | Cards reutilizables para listas con paridad de resaltado y acciones editar/eliminar | stable | Usado por productos y regüertenses autorizados; botones de 44px por defecto |
 
 ## 3. Referencia de uso en Auth
 
@@ -55,6 +57,8 @@ Referencias actuales:
 - Definir APIs por comportamiento y estados explícitos, no por contexto de una pantalla concreta.
 - Mantener `enabled`, `disabled`, `loading`, `focus` y `error` visibles en el contrato del componente.
 - Consumir solo theme/tokens semánticos. Evitar colores y medidas hardcodeadas en vistas de feature.
+- Para acciones inferiores sobre listas con scroll, preferir `ReguertaFloatingActionButton` y dar padding inferior explícito al contenido para que pueda pasar por detrás del botón.
+- Para filas repetidas con acciones de editar/eliminar, preferir `ReguertaListItemCard` y los botones de acción compartidos antes de añadir estilos locales de feature.
 
 ## 6. Exclusiones legacy explícitas
 

--- a/docs/design-system/components.md
+++ b/docs/design-system/components.md
@@ -1,6 +1,6 @@
 # Components
 
-This catalog defines the current component contract and parity status for auth/onboarding.
+This catalog defines the current component contract and parity status for reusable app UI.
 
 ## 1. Status Legend
 
@@ -15,8 +15,10 @@ This catalog defines the current component contract and parity status for auth/o
 |---|---|---|---|---|---|
 | Card/container shell | `ui/components/auth/ReguertaCard.kt` | `DesignSystem/Components/ReguertaCard.swift` | Group related content using semantic surface + border/radius tokens | stable | Main shell for splash/welcome/login/register/recover |
 | Button | `ReguertaButton` + `ReguertaButtonVariant` | `ReguertaButton` + `ReguertaButtonVariant` | Unified primary/secondary/text action model with loading and disabled support | stable | Variants: `primary`, `secondary`, `text` |
+| Floating action button | `ReguertaFloatingActionButton` | `ReguertaFloatingActionButton` | Persistent bottom action over scrollable content without an opaque footer band | stable | Matches the checkout action style; iOS uses Liquid Glass with material fallback |
 | Input/Auth field | `ReguertaInputField` | `ReguertaInputField` | Label, placeholder, helper/error text, trailing action, focus/disabled/error states | stable | Keyboard type exposed in both platforms |
 | Inline feedback | `ReguertaInlineFeedback` + `ReguertaFeedbackKind` | `ReguertaInlineFeedback` + `ReguertaFeedbackKind` | Reusable inline info/warning/error messages | stable | Used in auth shell and generic feedback areas |
+| List item card + action buttons | `ReguertaListItemCard`, `ReguertaEditListActionButton`, `ReguertaDeleteListActionButton` | `ReguertaListItemCard`, `ReguertaListActionIconButton` | Reusable list cards with add/edit/delete highlight parity for operational lists | stable | Used by products and authorized members; 44px action buttons by default |
 
 ## 3. Auth Flow Reference Wiring
 
@@ -55,6 +57,8 @@ Current references:
 - Define component APIs by behavior and explicit state, not by a single screen context.
 - Keep `enabled`, `disabled`, `loading`, `focus`, and `error` visible in the component contract.
 - Consume semantic theme/tokens only. Avoid raw colors and ad-hoc dimensions in feature views.
+- For bottom actions over scrollable lists, prefer `ReguertaFloatingActionButton` and give the scroll content explicit bottom padding so content can pass behind the button.
+- For repeated list rows with edit/delete actions, prefer `ReguertaListItemCard` and the shared action icon buttons before adding feature-local card styles.
 
 ## 6. Explicit Legacy Exclusions
 

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaFloatingActionButton/ReguertaFloatingActionButtonView.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaFloatingActionButton/ReguertaFloatingActionButtonView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+
+@MainActor
+enum ReguertaFloatingActionButtonLayout {
+    static var scrollContentBottomPadding: CGFloat {
+        88.resize + 8.resizeBottomSize
+    }
+}
+
+struct ReguertaFloatingActionButtonView: View {
+    @Environment(\.reguertaTokens) private var tokens
+
+    let title: Text
+    let isEnabled: Bool
+    let accessibilityIdentifier: String?
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            title
+                .font(tokens.typography.body.weight(.semibold))
+                .foregroundStyle(tokens.colors.actionOnPrimary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.78)
+                .frame(maxWidth: .infinity)
+                .frame(height: 52.resize)
+                .background {
+                    ReguertaFloatingActionButtonBackground(isEnabled: isEnabled)
+                }
+                .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1 : 0.55)
+        .padding(.horizontal, tokens.spacing.xl + tokens.spacing.sm)
+        .padding(.bottom, 8.resizeBottomSize)
+        .shadow(color: .black.opacity(0.18), radius: 14.resize, y: 6.resize)
+        .reguertaOptionalAccessibilityIdentifier(accessibilityIdentifier)
+    }
+}
+
+private struct ReguertaFloatingActionButtonBackground: View {
+    @Environment(\.reguertaTokens) private var tokens
+
+    let isEnabled: Bool
+
+    var body: some View {
+        let shape = Capsule()
+        let actionOpacity = isEnabled ? 0.42 : 0.22
+
+        if #available(iOS 26.0, *) {
+            shape
+                .fill(tokens.colors.actionPrimary.opacity(actionOpacity))
+                .glassEffect(
+                    .regular
+                        .tint(tokens.colors.actionPrimary.opacity(isEnabled ? 0.32 : 0.16))
+                        .interactive(isEnabled),
+                    in: shape
+                )
+        } else {
+            shape
+                .fill(.ultraThinMaterial)
+                .background(tokens.colors.actionPrimary.opacity(isEnabled ? 0.72 : 0.34), in: shape)
+        }
+    }
+}
+
+@ViewBuilder
+func reguertaFloatingActionButton(
+    _ title: LocalizedStringKey,
+    isEnabled: Bool = true,
+    accessibilityIdentifier: String? = nil,
+    action: @escaping () -> Void
+) -> some View {
+    ReguertaFloatingActionButtonView(
+        title: Text(title),
+        isEnabled: isEnabled,
+        accessibilityIdentifier: accessibilityIdentifier,
+        action: action
+    )
+}
+
+@ViewBuilder
+func reguertaFloatingActionButton(
+    verbatim title: String,
+    isEnabled: Bool = true,
+    accessibilityIdentifier: String? = nil,
+    action: @escaping () -> Void
+) -> some View {
+    ReguertaFloatingActionButtonView(
+        title: Text(verbatim: title),
+        isEnabled: isEnabled,
+        accessibilityIdentifier: accessibilityIdentifier,
+        action: action
+    )
+}
+
+private extension View {
+    @ViewBuilder
+    func reguertaOptionalAccessibilityIdentifier(_ identifier: String?) -> some View {
+        if let identifier {
+            accessibilityIdentifier(identifier)
+        } else {
+            self
+        }
+    }
+}

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaListItemCard/ReguertaListItemCardView.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaListItemCard/ReguertaListItemCardView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+struct ReguertaListItemCardView<Content: View>: View {
+    @Environment(\.reguertaTokens) private var tokens
+
+    let isHighlighted: Bool
+    let content: () -> Content
+
+    init(
+        isHighlighted: Bool = false,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.isHighlighted = isHighlighted
+        self.content = content
+    }
+
+    var body: some View {
+        content()
+            .frame(width: 358.resize)
+            .background(tokens.colors.actionPrimary.opacity(0.15))
+            .clipShape(RoundedRectangle(cornerRadius: 16.resize))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12.resize)
+                    .stroke(tokens.colors.actionPrimary.opacity(isHighlighted ? 0.9 : 0), lineWidth: 3.resize)
+            )
+            .background(
+                RoundedRectangle(cornerRadius: 12.resize)
+                    .fill(tokens.colors.actionPrimary.opacity(isHighlighted ? 0.22 : 0))
+            )
+            .shadow(
+                color: tokens.colors.actionPrimary.opacity(isHighlighted ? 0.25 : 0),
+                radius: isHighlighted ? 10.resize : 0,
+                x: 0,
+                y: 4
+            )
+            .animation(.easeInOut(duration: 0.25), value: isHighlighted)
+    }
+}
+
+struct ReguertaListActionIconButton: View {
+    let systemImageName: String
+    let accessibilityLabel: String
+    let backgroundColor: Color
+    var size: CGFloat = 44.resize
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImageName)
+                .font(.system(size: size * 0.58, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: size, height: size)
+                .background(backgroundColor)
+                .clipShape(RoundedRectangle(cornerRadius: 12.resize))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(Text(verbatim: accessibilityLabel))
+    }
+}
+
+@ViewBuilder
+func reguertaListItemCard<Content: View>(
+    isHighlighted: Bool = false,
+    @ViewBuilder content: @escaping () -> Content
+) -> some View {
+    ReguertaListItemCardView(
+        isHighlighted: isHighlighted,
+        content: content
+    )
+}

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellViewModel.swift
@@ -293,6 +293,10 @@ private extension AccessRootViewModel {
             return l10n(AccessL10nKey.homeShellNewsTitle)
         case .settings:
             return l10n(AccessL10nKey.settingsTitle)
+        case .products:
+            return l10n(AccessL10nKey.productsListTitle)
+        case .users:
+            return l10n(AccessL10nKey.usersListTitle)
         case .shiftSwapRequest:
             return l10n(AccessL10nKey.shiftSwapRequestScreenTitle)
         case .publishNews:

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteOverlays.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteOverlays.swift
@@ -110,49 +110,15 @@ extension MyOrderRouteView {
     @ViewBuilder
     var cartOverlayCheckoutFooter: some View {
         if !viewModel.isReadOnlyConfirmedView {
-            Button {
+            reguertaFloatingActionButton(
+                verbatim: viewModel.finalizeCheckoutTitle,
+                isEnabled: viewModel.canSubmitCheckout,
+                accessibilityIdentifier: "myOrder.checkoutButton"
+            ) {
                 Task {
                     await viewModel.validateCheckout()
                 }
-            } label: {
-                Text(viewModel.finalizeCheckoutTitle)
-                    .font(tokens.typography.body.weight(.semibold))
-                    .foregroundStyle(tokens.colors.actionOnPrimary)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 52.resize)
-                    .background {
-                        floatingCheckoutButtonBackground(isEnabled: viewModel.canSubmitCheckout)
-                    }
-                    .clipShape(Capsule())
             }
-            .buttonStyle(.plain)
-            .disabled(!viewModel.canSubmitCheckout)
-            .opacity(viewModel.canSubmitCheckout ? 1 : 0.55)
-            .padding(.horizontal, tokens.spacing.xl + tokens.spacing.sm)
-            .padding(.bottom, 8.resizeBottomSize)
-            .shadow(color: .black.opacity(0.18), radius: 14.resize, y: 6.resize)
-            .accessibilityIdentifier("myOrder.checkoutButton")
-        }
-    }
-
-    @ViewBuilder
-    func floatingCheckoutButtonBackground(isEnabled: Bool) -> some View {
-        let shape = Capsule()
-        let actionOpacity = isEnabled ? 0.42 : 0.22
-
-        if #available(iOS 26.0, *) {
-            shape
-                .fill(tokens.colors.actionPrimary.opacity(actionOpacity))
-                .glassEffect(
-                    .regular
-                        .tint(tokens.colors.actionPrimary.opacity(isEnabled ? 0.32 : 0.16))
-                        .interactive(isEnabled),
-                    in: shape
-                )
-        } else {
-            shape
-                .fill(.ultraThinMaterial)
-                .background(tokens.colors.actionPrimary.opacity(isEnabled ? 0.72 : 0.34), in: shape)
         }
     }
 

--- a/ios/Reguerta/Reguerta/Presentation/Products/ContentView+ProductsRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Products/ContentView+ProductsRoute.swift
@@ -17,11 +17,27 @@ struct ProductsRouteView: View {
     }
 
     var body: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            routeContent
-                .padding(.bottom, tokens.spacing.sm)
+        ZStack(alignment: .bottom) {
+            ScrollViewReader { proxy in
+                ScrollView(.vertical, showsIndicators: false) {
+                    routeContent
+                        .padding(.bottom, viewModel.isEditing ? tokens.spacing.sm : ReguertaFloatingActionButtonLayout.scrollContentBottomPadding)
+                }
+                .scrollDismissesKeyboard(.interactively)
+                .onChange(of: viewModel.highlightedProductId) { _, productId in
+                    guard let productId else { return }
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        proxy.scrollTo(productId, anchor: .center)
+                    }
+                }
+            }
+
+            if !viewModel.isEditing {
+                reguertaFloatingActionButton(localizedKey(AccessL10nKey.productsListActionAdd)) {
+                    viewModel.startCreating()
+                }
+            }
         }
-        .scrollDismissesKeyboard(.interactively)
         .alert(
             localizedKey(
                 viewModel.pendingCatalogVisibility == true
@@ -245,65 +261,12 @@ private struct ProductsListRouteView: View {
     let activeProducts: [Product]
     let archivedProducts: [Product]
 
-    private var isProducer: Bool {
-        viewModel.currentMember?.isProducer == true
-    }
-
     private func localizedKey(_ key: String) -> LocalizedStringKey {
         LocalizedStringKey(key)
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: tokens.spacing.lg) {
-            reguertaCard {
-                VStack(alignment: .leading, spacing: tokens.spacing.sm) {
-                    HStack(alignment: .top, spacing: tokens.spacing.md) {
-                        Text(localizedKey(AccessL10nKey.productsListTitle))
-                            .font(tokens.typography.titleCard)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        if isProducer {
-                            Button {
-                                viewModel.requestCatalogVisibilityChange()
-                            } label: {
-                                Group {
-                                    if viewModel.isUpdatingCatalogVisibility {
-                                        ProgressView()
-                                            .tint(tokens.colors.actionOnPrimary)
-                                    } else {
-                                        Text(
-                                            viewModel.currentMember?.producerCatalogEnabled == true
-                                            ? localizedKey(AccessL10nKey.productsListBulkToggleDisableAll)
-                                            : localizedKey(AccessL10nKey.productsListBulkToggleEnableAll)
-                                        )
-                                            .font(tokens.typography.label)
-                                            .multilineTextAlignment(.center)
-                                            .lineSpacing(2)
-                                    }
-                                }
-                                .foregroundStyle(tokens.colors.actionOnPrimary)
-                                .padding(.horizontal, tokens.spacing.md)
-                                .padding(.vertical, tokens.spacing.sm)
-                                .background(
-                                    viewModel.currentMember?.producerCatalogEnabled == true
-                                    ? tokens.colors.feedbackWarning
-                                    : tokens.colors.actionPrimary
-                                )
-                                .clipShape(Capsule())
-                                .overlay(
-                                    Capsule()
-                                        .stroke(tokens.colors.surfacePrimary.opacity(0.85), lineWidth: 2)
-                                )
-                            }
-                            .buttonStyle(.plain)
-                            .disabled(viewModel.isUpdatingCatalogVisibility)
-                        }
-                    }
-                    reguertaButton(localizedKey(AccessL10nKey.productsListActionReload), variant: .text, fullWidth: false) {
-                        Task { await viewModel.refreshCatalog() }
-                    }
-                }
-            }
-
             if viewModel.isLoadingCatalog {
                 reguertaCard {
                     Text(localizedKey(AccessL10nKey.productsListLoading))
@@ -322,9 +285,11 @@ private struct ProductsListRouteView: View {
                             tokens: tokens,
                             product: product,
                             archived: false,
+                            isHighlighted: viewModel.highlightedProductId == product.id,
                             onEdit: { viewModel.startEditing(productId: product.id) },
                             onArchive: { Task { await viewModel.archive(productId: product.id) } }
                         )
+                        .id(product.id)
                     }
                 }
 
@@ -337,17 +302,17 @@ private struct ProductsListRouteView: View {
                             tokens: tokens,
                             product: product,
                             archived: true,
+                            isHighlighted: viewModel.highlightedProductId == product.id,
                             onEdit: { viewModel.startEditing(productId: product.id) },
                             onArchive: {}
                         )
+                        .id(product.id)
                     }
                 }
             }
-
-            reguertaButton(localizedKey(AccessL10nKey.productsListActionAdd)) {
-                viewModel.startCreating()
-            }
         }
+        .animation(.easeInOut(duration: 0.25), value: activeProducts.map(\.id))
+        .animation(.easeInOut(duration: 0.25), value: archivedProducts.map(\.id))
     }
 }
 
@@ -355,81 +320,124 @@ private struct ProductCardRowView: View {
     let tokens: ReguertaDesignTokens
     let product: Product
     let archived: Bool
+    let isHighlighted: Bool
     let onEdit: () -> Void
     let onArchive: () -> Void
+
+    private var descriptionText: String {
+        product.description.isEmpty ? l10n(AccessL10nKey.productsCardDescriptionEmpty) : product.description
+    }
 
     private func decimalText(_ value: Double) -> String {
         value.productUIDecimal
     }
 
-    var body: some View {
-        reguertaCard {
-            VStack(alignment: .leading, spacing: tokens.spacing.md) {
-                HStack(alignment: .top, spacing: tokens.spacing.md) {
-                    RoundedRectangle(cornerRadius: 20.resize)
-                        .fill(tokens.colors.surfaceSecondary)
-                        .frame(width: 96.resize, height: 96.resize)
-                        .overlay {
-                            if let imageURL = URL(string: product.productImageUrl ?? ""), !(product.productImageUrl ?? "").isEmpty {
-                                AsyncImage(url: imageURL) { phase in
-                                    if let image = phase.image {
-                                        image
-                                            .resizable()
-                                            .scaledToFill()
-                                    } else {
-                                        Image(systemName: "photo")
-                                            .font(.system(size: 28.resize))
-                                            .foregroundStyle(tokens.colors.textSecondary)
-                                    }
-                                }
-                                .frame(width: 96.resize, height: 96.resize)
-                                .clipShape(RoundedRectangle(cornerRadius: 20.resize))
-                            } else {
-                                Image(systemName: "photo")
-                                    .font(.system(size: 28.resize))
-                                    .foregroundStyle(tokens.colors.textSecondary)
-                            }
-                        }
-                    VStack(alignment: .leading, spacing: tokens.spacing.sm) {
-                        HStack(alignment: .top) {
-                            VStack(alignment: .leading, spacing: tokens.spacing.xs) {
-                                Text(product.name)
-                                    .font(tokens.typography.titleCard)
-                                Text(product.description.isEmpty ? l10n(AccessL10nKey.productsCardDescriptionEmpty) : product.description)
-                                    .font(tokens.typography.bodySecondary)
-                                    .foregroundStyle(tokens.colors.textSecondary)
-                            }
-                            Spacer(minLength: tokens.spacing.sm)
-                            HStack(spacing: tokens.spacing.xs) {
-                                Button(action: onEdit) {
-                                    Image(systemName: "pencil")
-                                }
-                                .buttonStyle(.plain)
+    private var priceText: String {
+        String(format: "%.2f €", product.price)
+    }
 
-                                if !archived {
-                                    Button(action: onArchive) {
-                                        Image(systemName: "trash")
-                                    }
-                                    .buttonStyle(.plain)
-                                }
-                            }
-                        }
-                        Text("\(decimalText(product.price)) €")
-                            .font(tokens.typography.titleCard)
-                        Text(
-                            archived
-                            ? l10n(AccessL10nKey.productsCardStatusArchived)
-                            : (
-                                product.stockMode == .infinite
-                                ? l10n(AccessL10nKey.productsCardStatusStockUnlimited)
-                                : l10n(AccessL10nKey.productsCardStatusStockValue, decimalText(product.stockQty ?? 0))
-                            )
-                        )
-                        .font(tokens.typography.bodySecondary)
-                        .foregroundStyle(tokens.colors.textSecondary)
+    private var stockText: String {
+        if archived {
+            return l10n(AccessL10nKey.productsCardStatusArchived)
+        }
+        if product.stockMode == .infinite {
+            return l10n(AccessL10nKey.productsCardStatusStockUnlimited)
+        }
+        return l10n(AccessL10nKey.productsCardStatusStockValue, decimalText(product.stockQty ?? 0))
+    }
+
+    var body: some View {
+        reguertaListItemCard(isHighlighted: isHighlighted) {
+            VStack(alignment: .leading, spacing: 0) {
+                Spacer().frame(height: 16.resize)
+                ZStack(alignment: .topTrailing) {
+                    HStack {
+                        Spacer().frame(width: 12.resize)
+                        productImage
+                        Spacer()
                     }
+
+                    HStack(spacing: 8.resize) {
+                        ReguertaListActionIconButton(
+                            systemImageName: "pencil",
+                            accessibilityLabel: "Editar producto",
+                            backgroundColor: tokens.colors.actionPrimary,
+                            action: onEdit
+                        )
+
+                        if !archived {
+                            ReguertaListActionIconButton(
+                                systemImageName: "trash",
+                                accessibilityLabel: "Archivar producto",
+                                backgroundColor: tokens.colors.feedbackError,
+                                action: onArchive
+                            )
+                        }
+                    }
+                    .padding(.trailing, 12.resize)
                 }
+                Spacer().frame(height: 8.resize)
+
+                VStack(alignment: .leading, spacing: 4.resize) {
+                    Text(product.name)
+                        .font(.custom("CabinSketch-Bold", size: 18.resize, relativeTo: .headline))
+                        .foregroundStyle(tokens.colors.textPrimary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 12.resize)
+
+                    Text(descriptionText)
+                        .font(.custom("CabinSketch-Regular", size: 14.resize, relativeTo: .subheadline))
+                        .foregroundStyle(tokens.colors.textPrimary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 12.resize)
+
+                    HStack(alignment: .firstTextBaseline, spacing: 8.resize) {
+                        Text(priceText)
+                            .font(.custom("CabinSketch-Bold", size: 18.resize, relativeTo: .headline))
+                            .foregroundStyle(tokens.colors.textPrimary)
+
+                        Spacer(minLength: 8.resize)
+
+                        Text(stockText)
+                            .font(.custom("CabinSketch-Bold", size: 18.resize, relativeTo: .headline))
+                            .foregroundStyle(tokens.colors.textPrimary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.72)
+                    }
+                    .padding(.horizontal, 12.resize)
+                }
+                Spacer().frame(height: 16.resize)
             }
         }
+    }
+
+    @ViewBuilder
+    private var productImage: some View {
+        RoundedRectangle(cornerRadius: 8.resize)
+            .fill(tokens.colors.surfaceSecondary)
+            .frame(width: 72.resize, height: 72.resize)
+            .overlay {
+                if let imageURL = URL(string: product.productImageUrl ?? ""), !(product.productImageUrl ?? "").isEmpty {
+                    AsyncImage(url: imageURL) { phase in
+                        if let image = phase.image {
+                            image
+                                .resizable()
+                                .scaledToFill()
+                        } else {
+                            Image(systemName: "photo")
+                                .font(.system(size: 24.resize))
+                                .foregroundStyle(tokens.colors.textSecondary)
+                        }
+                    }
+                    .frame(width: 72.resize, height: 72.resize)
+                    .clipShape(RoundedRectangle(cornerRadius: 8.resize))
+                } else {
+                    Image(systemName: "photo")
+                        .font(.system(size: 24.resize))
+                        .foregroundStyle(tokens.colors.textSecondary)
+                }
+            }
+            .clipped()
     }
 }

--- a/ios/Reguerta/Reguerta/Presentation/Products/ProductsRouteViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Products/ProductsRouteViewModel.swift
@@ -26,6 +26,7 @@ final class ProductsRouteViewModel {
     var isUploadingImage = false
     var isUpdatingCatalogVisibility = false
     var pendingCatalogVisibility: Bool?
+    var highlightedProductId: String?
 
     var activeProducts: [Product] {
         catalogProducts.filter { !$0.archived }
@@ -214,13 +215,14 @@ extension ProductsRouteViewModel {
         }
     }
 
-    func save() async {
-        guard let session = authorizedSession else { return }
+    @discardableResult
+    func save() async -> Bool {
+        guard let session = authorizedSession else { return false }
         guard session.member.canManageProductCatalog else {
             showUnableSaveFeedback()
-            return
+            return false
         }
-        guard !isUploadingImage else { return }
+        guard !isUploadingImage else { return false }
         let existing = catalogProducts.first { $0.id == editingProductId }
         guard let input = resolveProductSaveInput(
             draft: draft,
@@ -228,7 +230,7 @@ extension ProductsRouteViewModel {
             nowMillis: nowMillisProvider()
         ) else {
             showUnableSaveFeedback()
-            return
+            return false
         }
 
         isSaving = true
@@ -241,17 +243,19 @@ extension ProductsRouteViewModel {
             existingProduct: input.existing
         ) else {
             showUnableSaveFeedback()
-            return
+            return false
         }
 
         let saved = await productRepository.upsert(
             product: buildProductToSave(sessionMember: session.member, input: input)
         )
         let products = await productRepository.products(vendorId: session.member.id)
-        guard isCurrentSession(session) else { return }
+        guard isCurrentSession(session) else { return false }
         catalogProducts = products
-        draft = saved.toDraft()
-        editingProductId = saved.id
+        draft = ProductDraft()
+        editingProductId = nil
+        highlightProduct(saved.id)
+        return true
     }
 
     func archive(productId: String) async {
@@ -270,6 +274,7 @@ extension ProductsRouteViewModel {
         if editingProductId == productId {
             clearEditor()
         }
+        highlightProduct(productId)
     }
 
     func requestCatalogVisibilityChange() {
@@ -300,6 +305,18 @@ extension ProductsRouteViewModel {
 
     func dismissCatalogVisibilityChange() {
         pendingCatalogVisibility = nil
+    }
+
+    func highlightProduct(_ productId: String) {
+        highlightedProductId = productId
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 1_600_000_000)
+            await MainActor.run {
+                if self?.highlightedProductId == productId {
+                    self?.highlightedProductId = nil
+                }
+            }
+        }
     }
 
     func showUnableSaveFeedback() {
@@ -344,6 +361,7 @@ private extension ProductsRouteViewModel {
         isUploadingImage = false
         isUpdatingCatalogVisibility = false
         pendingCatalogVisibility = nil
+        highlightedProductId = nil
     }
 
     private func syncCurrentSessionFromSessionViewModel() {

--- a/ios/Reguerta/Reguerta/Presentation/Users/ContentView+UsersRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Users/ContentView+UsersRoute.swift
@@ -49,94 +49,117 @@ struct UsersRouteView: View {
     }
 
     private var usersList: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: tokens.spacing.lg) {
-                reguertaCard {
-                    VStack(alignment: .leading, spacing: tokens.spacing.sm) {
-                        Text(LocalizedStringKey(AccessL10nKey.usersListTitle))
-                            .font(tokens.typography.titleCard)
-                        reguertaButton(LocalizedStringKey(AccessL10nKey.usersListActionReload), variant: .text, fullWidth: false) {
-                            Task { await viewModel.refreshMembers() }
+        ZStack(alignment: .bottom) {
+            ScrollViewReader { proxy in
+                ScrollView(.vertical, showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: tokens.spacing.lg) {
+                        if viewModel.sortedMembers.isEmpty {
+                            reguertaCard {
+                                Text(LocalizedStringKey(AccessL10nKey.usersListEmpty))
+                                    .font(tokens.typography.bodySecondary)
+                                    .foregroundStyle(tokens.colors.textSecondary)
+                            }
+                        } else {
+                            ForEach(viewModel.sortedMembers) { member in
+                                userCardRow(member)
+                                    .id(member.id)
+                            }
                         }
                     }
+                    .padding(.bottom, viewModel.canManageMembers ? ReguertaFloatingActionButtonLayout.scrollContentBottomPadding : tokens.spacing.sm)
+                    .animation(.easeInOut(duration: 0.25), value: viewModel.sortedMembers.map(\.id))
                 }
-
-                if viewModel.sortedMembers.isEmpty {
-                    reguertaCard {
-                        Text(LocalizedStringKey(AccessL10nKey.usersListEmpty))
-                            .font(tokens.typography.bodySecondary)
-                            .foregroundStyle(tokens.colors.textSecondary)
-                    }
-                } else {
-                    ForEach(viewModel.sortedMembers) { member in
-                        userCardRow(member)
+                .scrollDismissesKeyboard(.interactively)
+                .onChange(of: viewModel.highlightedMemberId) { _, memberId in
+                    guard let memberId else { return }
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        proxy.scrollTo(memberId, anchor: .center)
                     }
                 }
             }
-            .padding(.bottom, tokens.spacing.sm)
-        }
-        .scrollDismissesKeyboard(.interactively)
-        .safeAreaInset(edge: .bottom, spacing: tokens.spacing.xs) {
+
             if viewModel.canManageMembers {
-                reguertaButton(
+                reguertaFloatingActionButton(
                     LocalizedStringKey(AccessL10nKey.usersListActionAdd),
                     accessibilityIdentifier: "users.addButton"
                 ) {
                     viewModel.startCreating()
                 }
-                .padding(.bottom, tokens.spacing.sm)
-                .background(tokens.colors.surfacePrimary)
             }
         }
     }
 
     private func userCardRow(_ member: Member) -> some View {
-        reguertaCard {
-            VStack(alignment: .leading, spacing: tokens.spacing.sm) {
-                Text(member.displayName)
-                    .font(tokens.typography.titleCard)
-                Text(member.normalizedEmail)
-                    .font(tokens.typography.bodySecondary)
-
-                if member.roles.contains(.producer) {
-                    Text(producerLine(for: member))
-                        .font(tokens.typography.label)
-                        .foregroundStyle(tokens.colors.textSecondary)
-                }
-
-                if member.roles.contains(.admin) {
-                    Text(LocalizedStringKey(AccessL10nKey.usersCardAdminLabel))
-                        .font(tokens.typography.label)
-                        .foregroundStyle(tokens.colors.textSecondary)
-                }
+        reguertaListItemCard(isHighlighted: viewModel.highlightedMemberId == member.id) {
+            VStack(alignment: .leading, spacing: 0) {
+                Spacer().frame(height: 16.resize)
+                userCardTextRows(member)
 
                 if viewModel.canManageMembers {
-                    HStack(spacing: tokens.spacing.sm) {
-                        Spacer()
-                        Button {
-                            viewModel.startEditing(memberId: member.id)
-                        } label: {
-                            Image(systemName: "pencil")
-                                .foregroundStyle(tokens.colors.actionOnPrimary)
-                                .padding(tokens.spacing.sm)
-                                .background(tokens.colors.actionPrimary)
-                                .clipShape(RoundedRectangle(cornerRadius: tokens.radius.sm))
-                        }
-                        .buttonStyle(.plain)
-
-                        Button {
-                            viewModel.requestToggleActive(memberId: member.id)
-                        } label: {
-                            Image(systemName: "trash")
-                                .foregroundStyle(tokens.colors.actionOnPrimary)
-                                .padding(tokens.spacing.sm)
-                                .background(tokens.colors.feedbackError)
-                                .clipShape(RoundedRectangle(cornerRadius: tokens.radius.sm))
-                        }
-                        .buttonStyle(.plain)
-                    }
+                    Spacer().frame(height: 16.resize)
+                    userCardActions(member)
                 }
+                Spacer().frame(height: 16.resize)
             }
+        }
+    }
+
+    @ViewBuilder
+    private func userCardTextRows(_ member: Member) -> some View {
+        Text(member.displayName)
+            .font(.custom("CabinSketch-Bold", size: 18.resize, relativeTo: .body))
+            .foregroundStyle(tokens.colors.textPrimary)
+            .padding(.horizontal, 16.resize)
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+        Spacer().frame(height: 16.resize)
+
+        Text(member.normalizedEmail)
+            .font(.custom("CabinSketch-Regular", size: 18.resize, relativeTo: .body))
+            .foregroundStyle(tokens.colors.textPrimary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.72)
+            .padding(.horizontal, 16.resize)
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+        if member.roles.contains(.producer) {
+            Spacer().frame(height: 16.resize)
+            Text(producerLine(for: member))
+                .font(.custom("CabinSketch-Regular", size: 18.resize, relativeTo: .body))
+                .foregroundStyle(tokens.colors.textPrimary)
+                .lineLimit(2)
+                .minimumScaleFactor(0.72)
+                .padding(.horizontal, 16.resize)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        if member.roles.contains(.admin) {
+            Spacer().frame(height: 16.resize)
+            Text(LocalizedStringKey(AccessL10nKey.usersCardAdminLabel))
+                .font(.custom("CabinSketch-Regular", size: 18.resize, relativeTo: .body))
+                .foregroundStyle(tokens.colors.textPrimary)
+                .padding(.horizontal, 16.resize)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func userCardActions(_ member: Member) -> some View {
+        HStack(spacing: tokens.spacing.sm) {
+            Spacer()
+            ReguertaListActionIconButton(
+                systemImageName: "pencil",
+                accessibilityLabel: "Editar Regüertense",
+                backgroundColor: tokens.colors.actionPrimary,
+                action: { viewModel.startEditing(memberId: member.id) }
+            )
+
+            ReguertaListActionIconButton(
+                systemImageName: "trash",
+                accessibilityLabel: "Desactivar Regüertense",
+                backgroundColor: tokens.colors.feedbackError,
+                action: { viewModel.requestToggleActive(memberId: member.id) }
+            )
+            Spacer().frame(width: 12.resize)
         }
     }
 

--- a/ios/Reguerta/Reguerta/Presentation/Users/UsersFeatureViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Users/UsersFeatureViewModel.swift
@@ -19,6 +19,7 @@ final class UsersFeatureViewModel {
     var isLoadingMembers = false
     var isSavingMember = false
     var isTogglingMember = false
+    var highlightedMemberId: String?
 
     var sortedMembers: [Member] {
         membersFeed.sorted { lhs, rhs in
@@ -272,6 +273,7 @@ final class UsersFeatureViewModel {
             let members = await memberRepository.allMembers()
             sessionViewModel.applyUpdatedAuthorizedMember(updated, members: members)
             syncFromSessionViewModel()
+            highlightMember(updated.id)
             return true
         } catch MemberManagementError.accessDenied {
             feedbackCenter.show(AccessL10nKey.feedbackOnlyAdminManageMembers)
@@ -323,6 +325,7 @@ final class UsersFeatureViewModel {
         isLoadingMembers = false
         isSavingMember = false
         isTogglingMember = false
+        highlightedMemberId = nil
     }
 
     private func isCurrentSession(_ session: AuthorizedSession) -> Bool {
@@ -334,6 +337,18 @@ final class UsersFeatureViewModel {
     private func sortedMembers(from members: [Member]) -> [Member] {
         members.sorted {
             $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
+    }
+
+    private func highlightMember(_ memberId: String) {
+        highlightedMemberId = memberId
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 1_600_000_000)
+            await MainActor.run {
+                if self?.highlightedMemberId == memberId {
+                    self?.highlightedMemberId = nil
+                }
+            }
         }
     }
 }

--- a/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
+++ b/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
@@ -7575,13 +7575,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Authorize new user"
+            "value" : "Authorize Regüertense"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Autorizar nuevo usuario"
+            "value" : "Autorizar regüertense"
           }
         }
       }


### PR DESCRIPTION
## What changed

- Added shared Liquid Glass floating action buttons for checkout, products, and Regüertenses flows.
- Added reusable list item cards and action icon buttons on iOS and Android.
- Aligned product and Regüertense list behavior, sizing, highlights, and scroll overlays across both platforms.
- Documented the reusable UI components in English and Spanish design-system docs.

## Validation

- `git diff --check`
- Android: `./gradlew app:testDebugUnitTest app:lintDebug`
- Android: `./gradlew app:compileDebugKotlin`
- iOS: `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' -parallel-testing-enabled NO -only-testing:ReguertaTests test`

## Notes

- Android connected UI tests were not run because no device or emulator was attached.