### PR TITLE
🐛 fix(order): polish my order cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-05-21 | 🐛 fix(order): polish my order cards
 - 2026-05-15 | 🐛 fix(ios): resolve lint and concurrency errors
 - 2026-05-15 | 🐛 fix(ios-ui): restore drawer route scrolling
 - 2026-05-15 | 🐛 fix(mobile): polish safe area order UI

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrderRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrderRoute.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -18,6 +19,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
@@ -94,6 +96,8 @@ import com.reguerta.user.ui.components.auth.ReguertaDialog
 import com.reguerta.user.ui.components.auth.ReguertaDialogAction
 import com.reguerta.user.ui.components.auth.ReguertaDialogType
 import com.reguerta.user.ui.components.auth.ReguertaFloatingActionButton
+import com.reguerta.user.ui.components.auth.ReguertaListActionIconButton
+import com.reguerta.user.ui.components.auth.ReguertaListItemCard
 import com.reguerta.user.ui.theme.ColorFeedbackWarningDefault
 import com.reguerta.user.ui.theme.ReguertaThemeTokens
 import java.text.Normalizer
@@ -982,7 +986,7 @@ private fun MyOrderConfirmedSummary(
             } else {
                 LazyColumn(
                     modifier = Modifier.weight(1f),
-                    contentPadding = PaddingValues(bottom = 84.dp),
+                    contentPadding = PaddingValues(bottom = 120.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     items(
@@ -995,24 +999,13 @@ private fun MyOrderConfirmedSummary(
             }
         }
 
-        Surface(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth()
-                .padding(horizontal = 8.dp, vertical = 8.dp),
-            shape = RoundedCornerShape(14.dp),
-            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.22f),
-        ) {
-            Text(
-                text = stringResource(
-                    R.string.my_order_confirmed_total_sum_format,
-                    total.toUiDecimal(),
-                ),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
-            )
-        }
+        MyOrderSummaryTotalBar(
+            text = stringResource(
+                R.string.my_order_confirmed_total_sum_format,
+                total.toUiDecimal(),
+            ),
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
     }
 }
 
@@ -1185,7 +1178,7 @@ private fun MyOrderPreviousOrderSummary(
                     )
                     LazyColumn(
                         modifier = Modifier.weight(1f),
-                        contentPadding = PaddingValues(bottom = 84.dp),
+                        contentPadding = PaddingValues(bottom = 120.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
                         items(
@@ -1200,25 +1193,40 @@ private fun MyOrderPreviousOrderSummary(
         }
 
         if (state is MyOrderPreviousOrderState.Loaded) {
-            Surface(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .fillMaxWidth()
-                    .padding(horizontal = 8.dp, vertical = 8.dp),
-                shape = RoundedCornerShape(14.dp),
-                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.22f),
-            ) {
-                Text(
-                    text = stringResource(
-                        R.string.my_order_confirmed_total_sum_format,
-                        state.snapshot.total.toUiDecimal(),
-                    ),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
-                )
-            }
+            MyOrderSummaryTotalBar(
+                text = stringResource(
+                    R.string.my_order_confirmed_total_sum_format,
+                    state.snapshot.total.toUiDecimal(),
+                ),
+                modifier = Modifier.align(Alignment.BottomCenter),
+            )
         }
+    }
+}
+
+@Composable
+private fun MyOrderSummaryTotalBar(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .navigationBarsPadding()
+            .padding(bottom = 12.dp),
+        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.7f),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.32f)),
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+        )
     }
 }
 
@@ -1359,38 +1367,32 @@ private fun MyOrderProductCard(
         commitmentLimit = commitmentLimit,
     )
 
-    Card(modifier = Modifier.fillMaxWidth()) {
+    ReguertaListItemCard {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
+            modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.Top,
-            ) {
-                ProductImage(product = product)
-
-                Column(
-                    modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    QuantityControls(
-                        quantity = quantity,
-                        canIncrease = isEditable && canIncrease,
-                        onIncrease = onIncrease,
-                        onDecrease = onDecrease,
-                        isEditable = isEditable,
-                    )
-                    Text(
-                        text = product.name,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                }
+            Box(modifier = Modifier.fillMaxWidth()) {
+                ProductImage(
+                    product = product,
+                    modifier = Modifier.align(Alignment.TopStart),
+                )
+                QuantityControls(
+                    quantity = quantity,
+                    canIncrease = isEditable && canIncrease,
+                    onIncrease = onIncrease,
+                    onDecrease = onDecrease,
+                    isEditable = isEditable,
+                    modifier = Modifier.align(Alignment.TopEnd),
+                )
             }
+
+            Text(
+                text = product.name,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
 
             if (product.description.isNotBlank()) {
                 Text(
@@ -1433,21 +1435,24 @@ private fun MyOrderProductCard(
 }
 
 @Composable
-private fun ProductImage(product: Product) {
+private fun ProductImage(
+    product: Product,
+    modifier: Modifier = Modifier,
+) {
     if (!product.productImageUrl.isNullOrBlank()) {
         AsyncImage(
             model = product.productImageUrl,
             contentDescription = product.name,
-            modifier = Modifier
+            modifier = modifier
                 .size(72.dp)
-                .clip(RoundedCornerShape(12.dp)),
+                .clip(RoundedCornerShape(8.dp)),
             contentScale = ContentScale.Crop,
         )
     } else {
         Box(
-            modifier = Modifier
+            modifier = modifier
                 .size(72.dp)
-                .clip(RoundedCornerShape(12.dp))
+                .clip(RoundedCornerShape(8.dp))
                 .background(MaterialTheme.colorScheme.surfaceVariant),
             contentAlignment = Alignment.Center,
         ) {
@@ -1468,6 +1473,7 @@ private fun QuantityControls(
     onIncrease: () -> Unit,
     onDecrease: () -> Unit,
     isEditable: Boolean,
+    modifier: Modifier = Modifier,
 ) {
     if (!isEditable) {
         if (quantity > 0) {
@@ -1480,6 +1486,7 @@ private fun QuantityControls(
                 text = quantityText,
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
+                modifier = modifier,
             )
         }
         return
@@ -1488,8 +1495,9 @@ private fun QuantityControls(
         Button(
             onClick = onIncrease,
             enabled = canIncrease,
-            shape = RoundedCornerShape(10.dp),
-            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            modifier = modifier.height(44.dp),
+            shape = RoundedCornerShape(12.dp),
+            contentPadding = PaddingValues(horizontal = 14.dp, vertical = 0.dp),
             colors = ButtonDefaults.buttonColors(
                 containerColor = MaterialTheme.colorScheme.primary,
                 contentColor = MaterialTheme.colorScheme.onPrimary,
@@ -1505,13 +1513,14 @@ private fun QuantityControls(
             Icon(
                 imageVector = Icons.Default.ShoppingCart,
                 contentDescription = null,
-                modifier = Modifier.size(18.dp),
+                modifier = Modifier.size(24.dp),
             )
         }
     } else {
         Row(
+            modifier = modifier,
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             val quantityText = if (quantity == 1) {
                 stringResource(R.string.my_order_quantity_single)
@@ -1549,20 +1558,13 @@ private fun QuantityActionButton(
     containerColor: Color,
     enabled: Boolean = true,
 ) {
-    IconButton(
-        onClick = onClick,
+    ReguertaListActionIconButton(
+        icon = icon,
+        contentDescription = contentDescription,
+        containerColor = containerColor,
         enabled = enabled,
-        modifier = Modifier
-            .size(38.dp)
-            .clip(RoundedCornerShape(9.dp))
-            .background(if (enabled) containerColor else containerColor.copy(alpha = 0.45f)),
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = contentDescription,
-            tint = Color.White,
-        )
-    }
+        onClick = onClick,
+    )
 }
 
 @Composable
@@ -1576,11 +1578,9 @@ private fun SelectedProductCard(
     onDecrease: () -> Unit,
     onEcoBasketOptionChange: (String) -> Unit,
 ) {
-    Card(modifier = Modifier.fillMaxWidth()) {
+    ReguertaListItemCard {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
+            modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             Row(
@@ -1621,6 +1621,7 @@ private fun SelectedProductCard(
                 onIncrease = onIncrease,
                 onDecrease = onDecrease,
                 isEditable = isEditable,
+                modifier = Modifier.align(Alignment.End),
             )
             if (product.isEcoBasket && quantity > 0 && isEditable) {
                 EcoBasketOptionSelector(

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaListItemCard.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaListItemCard.kt
@@ -74,13 +74,15 @@ fun ReguertaListActionIconButton(
     containerColor: Color,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
 ) {
     IconButton(
         onClick = onClick,
+        enabled = enabled,
         modifier = modifier
             .size(ReguertaListActionButtonSize)
             .clip(RoundedCornerShape(12.dp))
-            .background(containerColor),
+            .background(if (enabled) containerColor else containerColor.copy(alpha = 0.45f)),
     ) {
         Icon(
             imageVector = icon,

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaListItemCard/ReguertaListItemCardView.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaListItemCard/ReguertaListItemCardView.swift
@@ -42,6 +42,7 @@ struct ReguertaListActionIconButton: View {
     let accessibilityLabel: String
     let backgroundColor: Color
     var size: CGFloat = 44.resize
+    var isEnabled: Bool = true
     let action: () -> Void
 
     var body: some View {
@@ -50,10 +51,11 @@ struct ReguertaListActionIconButton: View {
                 .font(.system(size: size * 0.58, weight: .semibold))
                 .foregroundStyle(.white)
                 .frame(width: size, height: size)
-                .background(backgroundColor)
+                .background(backgroundColor.opacity(isEnabled ? 1 : 0.45))
                 .clipShape(RoundedRectangle(cornerRadius: 12.resize))
         }
         .buttonStyle(.plain)
+        .disabled(!isEnabled)
         .accessibilityLabel(Text(verbatim: accessibilityLabel))
     }
 }

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteOverlays.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteOverlays.swift
@@ -133,32 +133,45 @@ extension MyOrderRouteView {
         let quantity = viewModel.quantity(for: product)
         let selectedOption = viewModel.selectedEcoBasketOption(for: product)
 
-        reguertaCard {
-            VStack(alignment: .leading, spacing: tokens.spacing.sm) {
+        reguertaListItemCard {
+            VStack(alignment: .leading, spacing: 0) {
+                Spacer().frame(height: 16.resize)
                 HStack(alignment: .top, spacing: tokens.spacing.sm) {
                     productImage(product)
                     VStack(alignment: .leading, spacing: tokens.spacing.xs) {
                         Text(product.name)
                             .font(tokens.typography.body.weight(.semibold))
+                            .foregroundStyle(tokens.colors.textPrimary)
+                            .lineLimit(2)
                         Text("\(product.price.myOrderUiDecimal) € / ud.")
                             .font(tokens.typography.bodySecondary)
                             .foregroundStyle(tokens.colors.textSecondary)
                     }
                     Spacer(minLength: 0)
                 }
+                .padding(.horizontal, 12.resize)
+
+                Spacer().frame(height: 12.resize)
+
                 quantityControls(
                     product: product,
                     quantity: quantity,
                     isEditable: !viewModel.isReadOnlyMode
                 )
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .padding(.horizontal, 12.resize)
+
                 if product.isEcoBasket, quantity > 0, !viewModel.isReadOnlyMode {
+                    Spacer().frame(height: 12.resize)
                     ecoBasketOptionSelector(
                         selectedOption: selectedOption,
                         onOptionSelected: { option in
                             viewModel.selectEcoBasketOption(productId: product.id, option: option)
                         }
                     )
+                    .padding(.horizontal, 12.resize)
                 }
+                Spacer().frame(height: 16.resize)
             }
         }
     }

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteSections.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteSections.swift
@@ -2,41 +2,43 @@ import SwiftUI
 
 extension MyOrderRouteView {
     var confirmedOrderView: some View {
-        VStack(alignment: .leading, spacing: tokens.spacing.md) {
-            HStack(spacing: tokens.spacing.sm) {
-                Text("Pedido confirmado")
-                    .font(tokens.typography.titleCard.weight(.semibold))
-                    .foregroundStyle(tokens.colors.textPrimary)
-                Spacer()
-                Button {
-                    viewModel.editConfirmedOrder()
-                } label: {
-                    HStack(spacing: tokens.spacing.xs) {
-                        Image(systemName: "pencil")
-                        Text("Editar pedido")
-                            .font(tokens.typography.body.weight(.semibold))
+        ZStack(alignment: .bottom) {
+            VStack(alignment: .leading, spacing: tokens.spacing.md) {
+                HStack(spacing: tokens.spacing.sm) {
+                    Text("Pedido confirmado")
+                        .font(tokens.typography.titleCard.weight(.semibold))
+                        .foregroundStyle(tokens.colors.textPrimary)
+                    Spacer()
+                    Button {
+                        viewModel.editConfirmedOrder()
+                    } label: {
+                        HStack(spacing: tokens.spacing.xs) {
+                            Image(systemName: "pencil")
+                            Text("Editar pedido")
+                                .font(tokens.typography.body.weight(.semibold))
+                        }
+                        .foregroundStyle(tokens.colors.actionPrimary)
+                        .padding(.horizontal, tokens.spacing.md)
+                        .padding(.vertical, tokens.spacing.sm)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: tokens.radius.md)
+                                .stroke(tokens.colors.actionPrimary, lineWidth: 1)
+                        )
                     }
-                    .foregroundStyle(tokens.colors.actionPrimary)
-                    .padding(.horizontal, tokens.spacing.md)
-                    .padding(.vertical, tokens.spacing.sm)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: tokens.radius.md)
-                            .stroke(tokens.colors.actionPrimary, lineWidth: 1)
-                    )
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
+
+                ScrollView(.vertical, showsIndicators: false) {
+                    VStack(spacing: tokens.spacing.md) {
+                        ForEach(viewModel.confirmedOrderGroups) { group in
+                            confirmedProducerCard(group)
+                        }
+                    }
+                    .padding(.bottom, orderTotalBarScrollBottomPadding)
+                }
+                .ignoresSafeArea(.container, edges: .bottom)
             }
 
-            ScrollView(.vertical, showsIndicators: false) {
-                VStack(spacing: tokens.spacing.md) {
-                    ForEach(viewModel.confirmedOrderGroups) { group in
-                        confirmedProducerCard(group)
-                    }
-                }
-                .padding(.bottom, tokens.spacing.sm)
-            }
-        }
-        .safeAreaInset(edge: .bottom, spacing: tokens.spacing.xs) {
             orderTotalBar("Suma total pedido: \(viewModel.cartTotal.myOrderUiDecimal) €")
                 .accessibilityIdentifier("myOrder.confirmedTotalBar")
         }
@@ -44,54 +46,56 @@ extension MyOrderRouteView {
 
     @ViewBuilder
     var previousOrderView: some View {
-        VStack(alignment: .leading, spacing: tokens.spacing.md) {
-            switch viewModel.previousOrderState {
-            case .loading:
-                reguertaCard {
-                    HStack(spacing: tokens.spacing.sm) {
-                        ProgressView()
-                            .tint(tokens.colors.actionPrimary)
-                        Text("Cargando pedido de la semana anterior…")
-                            .font(tokens.typography.bodySecondary)
-                            .foregroundStyle(tokens.colors.textSecondary)
+        ZStack(alignment: .bottom) {
+            VStack(alignment: .leading, spacing: tokens.spacing.md) {
+                switch viewModel.previousOrderState {
+                case .loading:
+                    reguertaCard {
+                        HStack(spacing: tokens.spacing.sm) {
+                            ProgressView()
+                                .tint(tokens.colors.actionPrimary)
+                            Text("Cargando pedido de la semana anterior…")
+                                .font(tokens.typography.bodySecondary)
+                                .foregroundStyle(tokens.colors.textSecondary)
+                        }
                     }
-                }
 
-            case .empty:
-                Text("No hay ningún pedido registrado la semana pasada")
-                    .font(tokens.typography.body)
-                    .foregroundStyle(tokens.colors.feedbackError)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.horizontal, tokens.spacing.lg)
-                    .padding(.vertical, tokens.spacing.xl)
+                case .empty:
+                    Text("No hay ningún pedido registrado la semana pasada")
+                        .font(tokens.typography.body)
+                        .foregroundStyle(tokens.colors.feedbackError)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.horizontal, tokens.spacing.lg)
+                        .padding(.vertical, tokens.spacing.xl)
 
-            case .error:
-                reguertaCard {
-                    VStack(alignment: .leading, spacing: tokens.spacing.sm) {
-                        Text("No hemos podido cargar tu pedido anterior.")
-                            .font(tokens.typography.bodySecondary)
-                            .foregroundStyle(tokens.colors.textSecondary)
-                        reguertaButton("Reintentar", variant: .text, fullWidth: false) {
-                            Task {
-                                await viewModel.retryPreviousOrder()
+                case .error:
+                    reguertaCard {
+                        VStack(alignment: .leading, spacing: tokens.spacing.sm) {
+                            Text("No hemos podido cargar tu pedido anterior.")
+                                .font(tokens.typography.bodySecondary)
+                                .foregroundStyle(tokens.colors.textSecondary)
+                            reguertaButton("Reintentar", variant: .text, fullWidth: false) {
+                                Task {
+                                    await viewModel.retryPreviousOrder()
+                                }
                             }
                         }
                     }
-                }
 
-            case .loaded(let snapshot):
-                ScrollView(.vertical, showsIndicators: false) {
-                    VStack(spacing: tokens.spacing.md) {
-                        ForEach(snapshot.groups) { group in
-                            previousProducerCard(group)
+                case .loaded(let snapshot):
+                    ScrollView(.vertical, showsIndicators: false) {
+                        VStack(spacing: tokens.spacing.md) {
+                            ForEach(snapshot.groups) { group in
+                                previousProducerCard(group)
+                            }
                         }
+                        .padding(.bottom, orderTotalBarScrollBottomPadding)
                     }
-                    .padding(.bottom, tokens.spacing.sm)
+                    .ignoresSafeArea(.container, edges: .bottom)
                 }
             }
-        }
-        .safeAreaInset(edge: .bottom, spacing: tokens.spacing.xs) {
+
             if case .loaded(let snapshot) = viewModel.previousOrderState {
                 orderTotalBar("Suma total pedido: \(snapshot.total.myOrderUiDecimal) €")
                     .accessibilityIdentifier("myOrder.previousTotalBar")
@@ -217,19 +221,28 @@ extension MyOrderRouteView {
     }
 
     func orderTotalBar(_ text: String) -> some View {
-        HStack {
+        let shape = RoundedRectangle(cornerRadius: 8.resize, style: .continuous)
+
+        return HStack {
             Text(text)
                 .font(tokens.typography.body.weight(.semibold))
                 .foregroundStyle(tokens.colors.textPrimary)
                 .frame(maxWidth: .infinity)
         }
         .padding(.horizontal, tokens.spacing.md)
-        .padding(.vertical, tokens.spacing.sm)
-        .background(tokens.colors.actionPrimary.opacity(0.62))
-        .clipShape(Capsule())
+        .frame(height: 44.resize)
+        .background(shape.fill(tokens.colors.actionPrimary.opacity(0.7)))
+        .overlay(
+            shape.stroke(tokens.colors.borderSubtle.opacity(0.65), lineWidth: 1.resize)
+        )
+        .clipShape(shape)
         .padding(.horizontal, tokens.spacing.sm)
-        .padding(.bottom, tokens.spacing.sm)
-        .background(tokens.colors.surfacePrimary)
+        .padding(.bottom, 8.resizeBottomSize)
+        .allowsHitTesting(false)
+    }
+
+    var orderTotalBarScrollBottomPadding: CGFloat {
+        72.resize + 8.resizeBottomSize
     }
 
     var loadingState: some View {
@@ -300,46 +313,57 @@ extension MyOrderRouteView {
         let quantity = viewModel.quantity(for: product)
         let stockLabel = stockLabel(for: product)
 
-        reguertaCard {
-            VStack(alignment: .leading, spacing: tokens.spacing.sm) {
-                HStack(alignment: .top, spacing: tokens.spacing.sm) {
-                    productImage(product)
-
-                    VStack(alignment: .leading, spacing: tokens.spacing.xs) {
-                        quantityControls(
-                            product: product,
-                            quantity: quantity,
-                            isEditable: !viewModel.isReadOnlyMode
-                        )
-                        Text(product.name)
-                            .font(tokens.typography.body.weight(.semibold))
-                            .foregroundStyle(tokens.colors.textPrimary)
+        reguertaListItemCard {
+            VStack(alignment: .leading, spacing: 0) {
+                Spacer().frame(height: 16.resize)
+                ZStack(alignment: .topTrailing) {
+                    HStack {
+                        productImage(product)
+                        Spacer(minLength: 0)
                     }
-                    Spacer(minLength: 0)
+                    .padding(.horizontal, 12.resize)
+
+                    quantityControls(
+                        product: product,
+                        quantity: quantity,
+                        isEditable: !viewModel.isReadOnlyMode
+                    )
+                    .padding(.trailing, 12.resize)
                 }
 
-                if product.description.isNotEmpty {
-                    Text(product.description)
-                        .font(tokens.typography.bodySecondary)
-                        .foregroundStyle(tokens.colors.textSecondary)
-                        .lineLimit(2)
-                }
+                Spacer().frame(height: 8.resize)
 
-                Text(viewModel.packContainerLine(for: product))
-                    .font(tokens.typography.bodySecondary)
-                    .foregroundStyle(tokens.colors.textSecondary)
-
-                HStack(alignment: .firstTextBaseline) {
-                    Text("\(product.price.myOrderUiDecimal) € / ud.")
+                VStack(alignment: .leading, spacing: 4.resize) {
+                    Text(product.name)
                         .font(tokens.typography.body.weight(.semibold))
                         .foregroundStyle(tokens.colors.textPrimary)
-                    Spacer()
-                    if let stockLabel {
-                        Text(stockLabel.text)
-                            .font(tokens.typography.bodySecondary.weight(.semibold))
-                            .foregroundStyle(stockLabel.color)
+                        .lineLimit(2)
+
+                    if product.description.isNotEmpty {
+                        Text(product.description)
+                            .font(tokens.typography.bodySecondary)
+                            .foregroundStyle(tokens.colors.textSecondary)
+                            .lineLimit(2)
+                    }
+
+                    Text(viewModel.packContainerLine(for: product))
+                        .font(tokens.typography.bodySecondary)
+                        .foregroundStyle(tokens.colors.textSecondary)
+
+                    HStack(alignment: .firstTextBaseline) {
+                        Text("\(product.price.myOrderUiDecimal) € / ud.")
+                            .font(tokens.typography.body.weight(.semibold))
+                            .foregroundStyle(tokens.colors.textPrimary)
+                        Spacer()
+                        if let stockLabel {
+                            Text(stockLabel.text)
+                                .font(tokens.typography.bodySecondary.weight(.semibold))
+                                .foregroundStyle(stockLabel.color)
+                        }
                     }
                 }
+                .padding(.horizontal, 12.resize)
+                Spacer().frame(height: 16.resize)
             }
         }
     }
@@ -359,13 +383,13 @@ extension MyOrderRouteView {
                 }
             }
             .frame(width: imageSize, height: imageSize)
-            .clipShape(RoundedRectangle(cornerRadius: tokens.radius.sm))
+            .clipShape(RoundedRectangle(cornerRadius: 8.resize))
         } else {
             Image("product_no_available")
                 .resizable()
                 .scaledToFill()
                 .frame(width: imageSize, height: imageSize)
-                .clipShape(RoundedRectangle(cornerRadius: tokens.radius.sm))
+                .clipShape(RoundedRectangle(cornerRadius: 8.resize))
         }
     }
 
@@ -402,13 +426,13 @@ extension MyOrderRouteView {
                 Text("Añadir")
                     .font(tokens.typography.body.weight(.semibold))
                 Image(systemName: "cart.badge.plus")
-                    .font(.system(size: 16.resize, weight: .semibold))
+                    .font(.system(size: 24.resize, weight: .semibold))
             }
             .foregroundStyle(canIncreaseQuantity ? tokens.colors.actionOnPrimary : tokens.colors.textSecondary)
-            .padding(.horizontal, tokens.spacing.md)
-            .padding(.vertical, tokens.spacing.sm)
+            .padding(.horizontal, 14.resize)
+            .frame(height: 44.resize)
             .background(canIncreaseQuantity ? tokens.colors.actionPrimary : Color(.systemGray5))
-            .clipShape(RoundedRectangle(cornerRadius: tokens.radius.sm))
+            .clipShape(RoundedRectangle(cornerRadius: 12.resize))
         }
         .buttonStyle(.plain)
         .disabled(!canIncreaseQuantity)
@@ -421,31 +445,20 @@ extension MyOrderRouteView {
                 .font(tokens.typography.body.weight(.semibold))
                 .foregroundStyle(tokens.colors.textPrimary)
 
-            Button {
-                viewModel.decrease(product)
-            } label: {
-                Image(systemName: quantity == 1 ? "trash" : "minus")
-                    .font(.system(size: 14.resize, weight: .bold))
-                    .foregroundStyle(tokens.colors.actionOnPrimary)
-                    .frame(width: 36.resize, height: 36.resize)
-                    .background(Color(red: 0.74, green: 0.36, blue: 0.35))
-                    .clipShape(RoundedRectangle(cornerRadius: tokens.radius.sm))
-            }
-            .buttonStyle(.plain)
+            ReguertaListActionIconButton(
+                systemImageName: quantity == 1 ? "trash" : "minus",
+                accessibilityLabel: "Quitar producto",
+                backgroundColor: tokens.colors.feedbackError,
+                action: { viewModel.decrease(product) }
+            )
 
-            Button {
-                viewModel.increase(product)
-            } label: {
-                Image(systemName: "plus")
-                    .font(.system(size: 15.resize, weight: .bold))
-                    .foregroundStyle(tokens.colors.actionOnPrimary)
-                    .frame(width: 36.resize, height: 36.resize)
-                    .background(tokens.colors.actionPrimary)
-                    .clipShape(RoundedRectangle(cornerRadius: tokens.radius.sm))
-            }
-            .buttonStyle(.plain)
-            .disabled(!canIncreaseQuantity)
-            .opacity(canIncreaseQuantity ? 1 : 0.55)
+            ReguertaListActionIconButton(
+                systemImageName: "plus",
+                accessibilityLabel: "Añadir producto",
+                backgroundColor: tokens.colors.actionPrimary,
+                isEnabled: canIncreaseQuantity,
+                action: { viewModel.increase(product) }
+            )
         }
     }
 


### PR DESCRIPTION
## Summary
- Refine My Order product and cart cards across Android and iOS.
- Make confirmed and previous order total bars rectangular, translucent, and overlaid above scrolling content.
- Keep the total bar on accent color at 0.7 opacity.

## Validation
- ✅ git diff --check
- ✅ Android: ./gradlew app:testDebugUnitTest
- ✅ Android: ./gradlew app:lintDebug
- ✅ iOS: xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' build
- ⚠️ iOS test run was attempted but the simulator xctrunner launch was denied by the environment.
- ⚠️ Android connected test was attempted after starting an AVD, but adb reported no connected devices.