### PR TITLE
🐛 fix(order): align producer card dividers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-05-21 | 🐛 fix(order): align producer card dividers
 - 2026-05-21 | 🐛 fix(prices): localize euro formatting
 - 2026-05-21 | 🐛 fix(order): polish my order cards
 - 2026-05-15 | 🐛 fix(ios): resolve lint and concurrency errors

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrderRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrderRoute.kt
@@ -1042,7 +1042,9 @@ private fun MyOrderConfirmedProducerCard(group: MyOrderConfirmedGroup) {
                 )
             }
 
-            group.lines.forEachIndexed { index, line ->
+            MyOrderProducerDivider()
+
+            group.lines.forEach { line ->
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.Top,
@@ -1074,16 +1076,9 @@ private fun MyOrderConfirmedProducerCard(group: MyOrderConfirmedGroup) {
                         fontWeight = FontWeight.SemiBold,
                     )
                 }
-                if (index != group.lines.lastIndex) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 6.dp)
-                            .background(MaterialTheme.colorScheme.outline.copy(alpha = 0.24f))
-                            .height(1.dp),
-                    )
-                }
             }
+
+            MyOrderProducerDivider()
 
             Row(modifier = Modifier.fillMaxWidth()) {
                 Spacer(modifier = Modifier.weight(1f))
@@ -1246,7 +1241,9 @@ private fun MyOrderPreviousProducerCard(group: MyOrderPreviousOrderGroup) {
                 color = MaterialTheme.colorScheme.primary,
             )
 
-            group.lines.forEachIndexed { index, line ->
+            MyOrderProducerDivider()
+
+            group.lines.forEach { line ->
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.Top,
@@ -1278,16 +1275,9 @@ private fun MyOrderPreviousProducerCard(group: MyOrderPreviousOrderGroup) {
                         fontWeight = FontWeight.SemiBold,
                     )
                 }
-                if (index != group.lines.lastIndex) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 6.dp)
-                            .background(MaterialTheme.colorScheme.outline.copy(alpha = 0.24f))
-                            .height(1.dp),
-                    )
-                }
             }
+
+            MyOrderProducerDivider()
 
             Row(modifier = Modifier.fillMaxWidth()) {
                 Spacer(modifier = Modifier.weight(1f))
@@ -1303,6 +1293,16 @@ private fun MyOrderPreviousProducerCard(group: MyOrderPreviousOrderGroup) {
             }
         }
     }
+}
+
+@Composable
+private fun MyOrderProducerDivider() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.outline.copy(alpha = 0.24f))
+            .height(1.dp),
+    )
 }
 
 @Composable

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteSections.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteSections.swift
@@ -117,6 +117,9 @@ extension MyOrderRouteView {
                     .foregroundStyle(tokens.colors.textSecondary)
             }
 
+            Divider()
+                .overlay(tokens.colors.borderSubtle)
+
             confirmedProducerLinesSection(group)
         }
         .padding(tokens.spacing.lg)
@@ -135,6 +138,9 @@ extension MyOrderRouteView {
             ForEach(group.lines) { line in
                 confirmedProducerLineRow(line)
             }
+
+            Divider()
+                .overlay(tokens.colors.borderSubtle)
 
             HStack {
                 Spacer()
@@ -165,8 +171,6 @@ extension MyOrderRouteView {
                     .font(tokens.typography.body.weight(.semibold))
                     .foregroundStyle(tokens.colors.textPrimary)
             }
-            Divider()
-                .overlay(tokens.colors.borderSubtle)
         }
     }
 
@@ -177,6 +181,9 @@ extension MyOrderRouteView {
                 Text(group.companyName)
                     .font(tokens.typography.titleCard.weight(.semibold))
                     .foregroundStyle(tokens.colors.actionPrimary)
+
+                Divider()
+                    .overlay(tokens.colors.borderSubtle)
 
                 ForEach(group.lines) { line in
                     VStack(alignment: .leading, spacing: tokens.spacing.xs) {
@@ -197,10 +204,11 @@ extension MyOrderRouteView {
                                 .font(tokens.typography.body.weight(.semibold))
                                 .foregroundStyle(tokens.colors.textPrimary)
                         }
-                        Divider()
-                            .overlay(tokens.colors.borderSubtle)
                     }
                 }
+
+                Divider()
+                    .overlay(tokens.colors.borderSubtle)
 
                 HStack {
                     Spacer()


### PR DESCRIPTION
## Summary
- Add the requested producer-name divider in confirmed and previous order cards.
- Remove internal product-row dividers so each card reads as: producer, divider, products, divider, total.
- Keep Android and iOS order card layouts aligned.

## Validation
- `./gradlew app:compileDebugKotlin`
- `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

Note: the iOS build still reports the existing SwiftLint warning in `UsersFeatureViewModel.swift` for type body length; this change does not touch that file.