### PR TITLE
fix(home): align weekly delivery summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-07 | 🐛 fix(home): align weekly delivery summary
 - 2026-05-22 | 🐛 fix(orders): correct received order prep display
 - 2026-05-21 | 🐛 fix(order): align producer card dividers
 - 2026-05-21 | 🐛 fix(prices): localize euro formatting

--- a/android/Reguerta/app/src/main/AndroidManifest.xml
+++ b/android/Reguerta/app/src/main/AndroidManifest.xml
@@ -21,7 +21,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/LaunchTheme">
+            android:theme="@style/LaunchTheme"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/MainActivity.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/MainActivity.kt
@@ -11,8 +11,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
 import com.reguerta.user.presentation.access.ReguertaRoot
 import com.reguerta.user.ui.theme.ReguertaTheme
@@ -24,9 +22,7 @@ class MainActivity : ComponentActivity() {
         requestNotificationsPermissionIfNeeded()
         setContent {
             ReguertaTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    ReguertaRoot(modifier = Modifier.padding(innerPadding))
-                }
+                ReguertaRoot(modifier = Modifier.fillMaxSize())
             }
         }
     }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/HomeDashboardComponents.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/HomeDashboardComponents.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -35,6 +34,8 @@ import com.reguerta.user.R
 import com.reguerta.user.ui.theme.ColorFeedbackWarningDefault
 import com.reguerta.user.ui.theme.ReguertaThemeTokens
 
+private val HomeSummaryGridRowHeight = 76.dp
+
 @Composable
 internal fun HomeWeeklySummaryCard(
     display: HomeWeeklySummaryDisplay,
@@ -49,7 +50,7 @@ internal fun HomeWeeklySummaryCard(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(spacing.lg),
+                .padding(vertical = spacing.lg),
             verticalArrangement = Arrangement.spacedBy(spacing.md),
         ) {
             Row(
@@ -86,6 +87,7 @@ internal fun HomeWeeklySummaryCard(
                     .border(1.dp, MaterialTheme.colorScheme.outlineVariant, MaterialTheme.shapes.medium),
             ) {
                 HomeSummaryGridRow(
+                    modifier = Modifier.height(HomeSummaryGridRowHeight),
                     leftContent = {
                         HomeSummaryPrimaryCell(
                             label = stringResource(R.string.home_dashboard_state),
@@ -103,6 +105,7 @@ internal fun HomeWeeklySummaryCard(
                 )
                 HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
                 HomeSummaryGridRow(
+                    modifier = Modifier.height(HomeSummaryGridRowHeight),
                     leftContent = {
                         HomeSummaryPrimaryCell(
                             label = stringResource(R.string.home_dashboard_delivery),
@@ -119,6 +122,7 @@ internal fun HomeWeeklySummaryCard(
                 )
                 HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
                 HomeSummaryGridRow(
+                    modifier = Modifier.height(HomeSummaryGridRowHeight),
                     leftContent = {
                         HomeSummaryPrimaryCell(
                             label = stringResource(R.string.home_dashboard_market),
@@ -139,13 +143,12 @@ internal fun HomeWeeklySummaryCard(
 
 @Composable
 private fun HomeSummaryGridRow(
+    modifier: Modifier = Modifier,
     leftContent: @Composable () -> Unit,
     rightContent: @Composable () -> Unit,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(IntrinsicSize.Min),
+        modifier = modifier.fillMaxWidth(),
     ) {
         Box(
             modifier = Modifier
@@ -392,6 +395,7 @@ private fun HomeDashboardAction(
 }
 
 private fun HomeOrderStateDisplay.labelRes(): Int = when (this) {
+    HomeOrderStateDisplay.CONSULTATION -> R.string.home_dashboard_order_state_consultation
     HomeOrderStateDisplay.NOT_STARTED -> R.string.home_dashboard_order_state_not_started
     HomeOrderStateDisplay.UNCONFIRMED -> R.string.home_dashboard_order_state_unconfirmed
     HomeOrderStateDisplay.COMPLETED -> R.string.home_dashboard_order_state_completed
@@ -399,6 +403,7 @@ private fun HomeOrderStateDisplay.labelRes(): Int = when (this) {
 
 private fun HomeOrderStateDisplay.myOrderSubtitleRes(isConsultaPhase: Boolean): Int = when {
     isConsultaPhase -> R.string.home_dashboard_my_order_subtitle_last_order
+    this == HomeOrderStateDisplay.CONSULTATION -> R.string.home_dashboard_my_order_subtitle_last_order
     this == HomeOrderStateDisplay.NOT_STARTED -> R.string.home_dashboard_my_order_subtitle_edit
     this == HomeOrderStateDisplay.UNCONFIRMED -> R.string.home_dashboard_my_order_subtitle_review
     else -> R.string.home_dashboard_my_order_subtitle_completed
@@ -406,6 +411,7 @@ private fun HomeOrderStateDisplay.myOrderSubtitleRes(isConsultaPhase: Boolean): 
 
 @Composable
 private fun HomeOrderStateDisplay.color(): Color = when (this) {
+    HomeOrderStateDisplay.CONSULTATION -> MaterialTheme.colorScheme.onSurface
     HomeOrderStateDisplay.NOT_STARTED -> MaterialTheme.colorScheme.error
     HomeOrderStateDisplay.UNCONFIRMED -> ColorFeedbackWarningDefault
     HomeOrderStateDisplay.COMPLETED -> MaterialTheme.colorScheme.primary

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/HomeWeeklySummaryDisplay.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/HomeWeeklySummaryDisplay.kt
@@ -23,6 +23,7 @@ private const val HomeOrderCartQuantitiesSuffix = ".quantities"
 private const val HomeOrderConfirmedQuantitiesSuffix = ".confirmed_quantities"
 
 internal enum class HomeOrderStateDisplay {
+    CONSULTATION,
     NOT_STARTED,
     UNCONFIRMED,
     COMPLETED,
@@ -55,15 +56,10 @@ internal fun resolveHomeWeeklySummaryDisplay(
     locale: Locale = Locale.forLanguageTag("es-ES"),
 ): HomeWeeklySummaryDisplay {
     val today = Instant.ofEpochMilli(nowMillis).atZone(zoneId).toLocalDate()
-    val deliveryDay = defaultDeliveryDayOfWeek?.toDayOfWeek() ?: DayOfWeek.WEDNESDAY
     val currentWeekStart = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
-    val currentWeekKey = currentWeekStart.toIsoWeekKey()
     val currentDeliveryDate = resolveEffectiveHomeDeliveryDate(
-        weekKey = currentWeekKey,
         weekStart = currentWeekStart,
-        deliveryDay = deliveryDay,
-        overrides = deliveryCalendarOverrides,
-        shifts = shifts,
+        deliveryCalendarOverrides = deliveryCalendarOverrides,
         zoneId = zoneId,
     )
     val targetWeekStart = if (today.isAfter(currentDeliveryDate)) {
@@ -77,20 +73,16 @@ internal fun resolveHomeWeeklySummaryDisplay(
     val isConsultaPhase = !today.isBefore(currentWeekStart) && !today.isAfter(currentDeliveryDate)
     val targetShift = shifts
         .filter { it.type == ShiftType.DELIVERY }
-        .firstOrNull { it.effectiveDateMillis(deliveryCalendarOverrides).toLocalDate(zoneId).toIsoWeekKey() == targetWeekKey }
+        .firstOrNull { it.dateMillis.toLocalDate(zoneId).toIsoWeekKey() == targetWeekKey }
     val targetMarketShift = shifts
         .filter { it.type == ShiftType.MARKET }
         .filter { !it.dateMillis.toLocalDate(zoneId).isBefore(today) }
         .minByOrNull { it.dateMillis }
-    val targetDeliveryDate = targetShift
-        ?.effectiveDateMillis(deliveryCalendarOverrides)
-        ?.toLocalDate(zoneId)
-        ?: resolveDeliveryDate(
-            weekStart = targetWeekStart,
-            deliveryDay = deliveryDay,
-            overrides = deliveryCalendarOverrides,
-            zoneId = zoneId,
-        )
+    val targetDeliveryDate = resolveHomeCalendarDeliveryDate(
+        weekStart = targetWeekStart,
+        deliveryCalendarOverrides = deliveryCalendarOverrides,
+        zoneId = zoneId,
+    )
     val fallbackMarketDate = orderWeekStart.plusDays(5)
     val targetMarketDate = targetMarketShift
         ?.dateMillis
@@ -134,6 +126,12 @@ internal fun resolveHomeOrderState(
     }
 }
 
+internal fun resolveHomeDisplayedOrderState(
+    isConsultaPhase: Boolean,
+    orderState: HomeOrderStateDisplay,
+): HomeOrderStateDisplay =
+    if (isConsultaPhase) HomeOrderStateDisplay.CONSULTATION else orderState
+
 internal fun formatHomeTopBarDate(
     nowMillis: Long,
     zoneId: ZoneId = ZoneId.systemDefault(),
@@ -156,41 +154,25 @@ private fun android.content.SharedPreferences.hasPositiveQuantity(key: String): 
         }
     }.getOrDefault(false)
 
-private fun resolveDeliveryDate(
+private fun resolveEffectiveHomeDeliveryDate(
     weekStart: LocalDate,
-    deliveryDay: DayOfWeek,
-    overrides: List<DeliveryCalendarOverride>,
+    deliveryCalendarOverrides: List<DeliveryCalendarOverride>,
+    zoneId: ZoneId,
+): LocalDate = resolveHomeCalendarDeliveryDate(
+    weekStart = weekStart,
+    deliveryCalendarOverrides = deliveryCalendarOverrides,
+    zoneId = zoneId,
+)
+
+private fun resolveHomeCalendarDeliveryDate(
+    weekStart: LocalDate,
+    deliveryCalendarOverrides: List<DeliveryCalendarOverride>,
     zoneId: ZoneId,
 ): LocalDate {
     val weekKey = weekStart.toIsoWeekKey()
-    return overrides.firstOrNull { it.weekKey == weekKey }
-        ?.deliveryDateMillis
-        ?.toLocalDate(zoneId)
-        ?: weekStart.plusDays(deliveryDay.value.toLong() - 1L)
-}
-
-private fun resolveEffectiveHomeDeliveryDate(
-    weekKey: String,
-    weekStart: LocalDate,
-    deliveryDay: DayOfWeek,
-    overrides: List<DeliveryCalendarOverride>,
-    shifts: List<ShiftAssignment>,
-    zoneId: ZoneId,
-): LocalDate {
-    val overrideDate = overrides.firstOrNull { it.weekKey == weekKey }
-        ?.deliveryDateMillis
-        ?.toLocalDate(zoneId)
-    if (overrideDate != null) {
-        return overrideDate
-    }
-    val weekEnd = weekStart.plusDays(6)
-    return shifts
-        .asSequence()
-        .filter { it.type == ShiftType.DELIVERY }
-        .map { it.effectiveDateMillis(overrides).toLocalDate(zoneId) }
-        .filter { !it.isBefore(weekStart) && !it.isAfter(weekEnd) }
-        .minOrNull()
-        ?: weekStart.plusDays(deliveryDay.value.toLong() - 1L)
+    val override = deliveryCalendarOverrides.firstOrNull { it.weekKey == weekKey }
+    return override?.deliveryDateMillis?.toLocalDate(zoneId)
+        ?: weekStart.plusDays(DayOfWeek.WEDNESDAY.value.toLong() - 1L)
 }
 
 private fun resolveProducerName(weekStart: LocalDate, members: List<Member>): String {

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReceivedOrdersViewModel.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReceivedOrdersViewModel.kt
@@ -12,7 +12,6 @@ import com.reguerta.user.domain.orders.ReceivedOrdersSnapshot
 import com.reguerta.user.domain.orders.toIsoWeekStartDate
 import com.reguerta.user.domain.orders.toIsoWeekKey
 import com.reguerta.user.domain.shifts.ShiftAssignment
-import com.reguerta.user.domain.shifts.ShiftType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -245,17 +244,5 @@ private fun resolveReceivedOrdersDeliveryDate(
         return Instant.ofEpochMilli(override.deliveryDateMillis).atZone(zoneId).toLocalDate()
     }
     val weekStart = currentWeekKey.toIsoWeekStartDate() ?: fallbackWeekStart
-    val weekEnd = weekStart.plusDays(6)
-    val shiftDeliveryDate = shifts
-        .asSequence()
-        .filter { shift -> shift.type == ShiftType.DELIVERY }
-        .map { shift -> Instant.ofEpochMilli(shift.dateMillis).atZone(zoneId).toLocalDate() }
-        .filter { shiftDate -> !shiftDate.isBefore(weekStart) && !shiftDate.isAfter(weekEnd) }
-        .sorted()
-        .firstOrNull()
-    if (shiftDeliveryDate != null) {
-        return shiftDeliveryDate
-    }
-    val deliveryDay = defaultDeliveryDayOfWeek?.toDayOfWeek() ?: DayOfWeek.WEDNESDAY
-    return weekStart.plusDays((deliveryDay.value - DayOfWeek.MONDAY.value).toLong())
+    return weekStart.plusDays((DayOfWeek.WEDNESDAY.value - DayOfWeek.MONDAY.value).toLong())
 }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootAuthRoutes.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootAuthRoutes.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -171,12 +170,9 @@ internal fun LoginRoute(
     onEmailChanged: (String) -> Unit,
     onPasswordChanged: (String) -> Unit,
 ) {
-    val adaptiveProfile = ReguertaAdaptive.profile
     val spacing = ReguertaThemeTokens.spacing
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .offset(y = (-20f * adaptiveProfile.tokenScale.controls).dp),
+        modifier = Modifier.fillMaxSize(),
     ) {
         AuthBackButton(onBack = onBack)
 
@@ -208,12 +204,9 @@ internal fun RegisterRoute(
     onRepeatPasswordChanged: (String) -> Unit,
     onBack: () -> Unit,
 ) {
-    val adaptiveProfile = ReguertaAdaptive.profile
     val spacing = ReguertaThemeTokens.spacing
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .offset(y = (-20f * adaptiveProfile.tokenScale.controls).dp),
+        modifier = Modifier.fillMaxSize(),
     ) {
         AuthBackButton(onBack = onBack)
         Text(
@@ -245,9 +238,7 @@ internal fun RecoverPasswordRoute(
     val adaptiveProfile = ReguertaAdaptive.profile
     val spacing = ReguertaThemeTokens.spacing
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .offset(y = (-20f * adaptiveProfile.tokenScale.controls).dp),
+        modifier = Modifier.fillMaxSize(),
     ) {
         AuthBackButton(onBack = onBack)
         Text(
@@ -283,7 +274,9 @@ internal fun RecoverPasswordRoute(
 private fun AuthBackButton(onBack: () -> Unit) {
     val controlScale = ReguertaAdaptive.profile.tokenScale.controls
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = (4f * controlScale).dp),
         horizontalArrangement = Arrangement.Start,
     ) {
         Icon(
@@ -291,7 +284,6 @@ private fun AuthBackButton(onBack: () -> Unit) {
             contentDescription = stringResource(R.string.common_action_back),
             tint = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier
-                .offset(x = (-2f * controlScale).dp)
                 .size((24f * controlScale).dp)
                 .clickable(onClick = onBack),
         )

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeRoute.kt
@@ -6,31 +6,25 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.material3.Surface
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.DrawerValue
-import androidx.compose.material3.ModalDrawerSheet
-import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberDrawerState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -57,7 +51,6 @@ import com.reguerta.user.ui.components.auth.ReguertaDialogAction
 import com.reguerta.user.ui.components.auth.ReguertaDialogType
 import com.reguerta.user.ui.components.auth.ReguertaFlatButton
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 @Composable
 internal fun HomeRoute(
     modifier: Modifier = Modifier,
@@ -253,8 +246,6 @@ internal fun HomeRoute(
             onRefreshMembers()
         } else if (destination == HomeDestination.SHIFTS) {
             onRefreshShifts()
-        } else if (destination == HomeDestination.BYLAWS) {
-            Unit
         } else if (destination == HomeDestination.SHIFT_SWAP_REQUEST) {
             onRefreshShifts()
         } else if (destination == HomeDestination.ADMIN_BROADCAST) {
@@ -344,8 +335,8 @@ internal fun HomeRoute(
                 .fillMaxWidth()
                 .fillMaxSize()
                 .imePadding()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+                .padding(start = 16.dp, top = 0.dp, end = 16.dp, bottom = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             val showsMyOrderCartAction = currentDestination == HomeDestination.MY_ORDER && !isMyOrderReadOnlyMode
             val homeShellTitle = when {
@@ -436,10 +427,13 @@ internal fun HomeRoute(
                                 orderState = HomeOrderStateDisplay.NOT_STARTED,
                             )
                             val weeklySummary = baselineSummary.copy(
-                                orderState = resolveHomeOrderState(
-                                    context = context,
-                                    memberId = mode.member.id,
-                                    weekKey = baselineSummary.orderWeekKey,
+                                orderState = resolveHomeDisplayedOrderState(
+                                    isConsultaPhase = baselineSummary.isConsultaPhase,
+                                    orderState = resolveHomeOrderState(
+                                        context = context,
+                                        memberId = mode.member.id,
+                                        weekKey = baselineSummary.orderWeekKey,
+                                    ),
                                 ),
                             )
                             AuthorizedHome(

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeShellComponents.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeShellComponents.kt
@@ -81,87 +81,83 @@ fun HomeShellTopBar(
     onOpenNotifications: () -> Unit,
     onOpenCart: () -> Unit,
 ) {
-    Card {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 10.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            IconButton(onClick = if (canNavigateBack) onBack else onOpenMenu) {
-                Icon(
-                    imageVector = if (canNavigateBack) Icons.AutoMirrored.Filled.ArrowBack else Icons.Filled.Menu,
-                    contentDescription = if (canNavigateBack) {
-                        stringResource(R.string.common_action_back)
-                    } else {
-                        stringResource(R.string.home_shell_menu)
-                    },
-                )
-            }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = if (canNavigateBack) onBack else onOpenMenu) {
+            Icon(
+                imageVector = if (canNavigateBack) Icons.AutoMirrored.Filled.ArrowBack else Icons.Filled.Menu,
+                contentDescription = if (canNavigateBack) {
+                    stringResource(R.string.common_action_back)
+                } else {
+                    stringResource(R.string.home_shell_menu)
+                },
+            )
+        }
 
-            if (title.isNotBlank()) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.weight(1f),
-                )
-            } else {
-                Spacer(modifier = Modifier.weight(1f))
-            }
+        if (title.isNotBlank()) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.weight(1f),
+            )
+        } else {
+            Spacer(modifier = Modifier.weight(1f))
+        }
 
-            if (showsNotificationsAction) {
-                Box(contentAlignment = Alignment.TopEnd) {
-                    IconButton(onClick = onOpenNotifications) {
-                        Icon(
-                            imageVector = Icons.Filled.Notifications,
-                            contentDescription = stringResource(R.string.home_shell_notifications),
-                        )
-                    }
-                    if (hasNotificationIndicator) {
-                        Box(
-                            modifier = Modifier
-                                .padding(top = 9.dp, end = 9.dp)
-                                .size(9.dp)
-                                .clip(CircleShape)
-                                .background(MaterialTheme.colorScheme.error),
-                        )
-                    }
+        if (showsNotificationsAction) {
+            Box(contentAlignment = Alignment.TopEnd) {
+                IconButton(onClick = onOpenNotifications) {
+                    Icon(
+                        imageVector = Icons.Filled.Notifications,
+                        contentDescription = stringResource(R.string.home_shell_notifications),
+                    )
                 }
-            } else if (showsCartAction) {
-                Box(contentAlignment = Alignment.TopEnd) {
-                    IconButton(
-                        onClick = onOpenCart,
-                        enabled = cartUnits > 0,
+                if (hasNotificationIndicator) {
+                    Box(
+                        modifier = Modifier
+                            .padding(top = 9.dp, end = 9.dp)
+                            .size(9.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.error),
+                    )
+                }
+            }
+        } else if (showsCartAction) {
+            Box(contentAlignment = Alignment.TopEnd) {
+                IconButton(
+                    onClick = onOpenCart,
+                    enabled = cartUnits > 0,
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.ShoppingCart,
+                        contentDescription = stringResource(R.string.my_order_view_cart_action),
+                    )
+                }
+                if (cartUnits > 0) {
+                    Box(
+                        modifier = Modifier
+                            .padding(top = 8.dp, end = 8.dp)
+                            .size(18.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.error),
+                        contentAlignment = Alignment.Center,
                     ) {
-                        Icon(
-                            imageVector = Icons.Filled.ShoppingCart,
-                            contentDescription = stringResource(R.string.my_order_view_cart_action),
+                        Text(
+                            text = cartUnits.coerceAtMost(99).toString(),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onError,
+                            fontWeight = FontWeight.Normal,
                         )
                     }
-                    if (cartUnits > 0) {
-                        Box(
-                            modifier = Modifier
-                                .padding(top = 8.dp, end = 8.dp)
-                                .size(18.dp)
-                                .clip(CircleShape)
-                                .background(MaterialTheme.colorScheme.error),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Text(
-                                text = cartUnits.coerceAtMost(99).toString(),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onError,
-                                fontWeight = FontWeight.Normal,
-                            )
-                        }
-                    }
                 }
-            } else {
-                Spacer(modifier = Modifier.size(48.dp))
             }
+        } else {
+            Spacer(modifier = Modifier.size(48.dp))
         }
     }
 }
@@ -529,31 +525,29 @@ fun LatestNewsCard(
     onViewAll: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Card(modifier = modifier) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.home_shell_news_title),
+            modifier = Modifier.fillMaxWidth(),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+        )
+        if (news.isEmpty()) {
             Text(
-                text = stringResource(R.string.home_shell_news_title),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
+                text = stringResource(R.string.news_empty_state),
+                style = MaterialTheme.typography.bodyMedium,
             )
-            if (news.isEmpty()) {
-                Text(
-                    text = stringResource(R.string.news_empty_state),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-            } else {
-                LatestNewsSummaryRows(news = news)
-            }
-            ReguertaFlatButton(
-                label = stringResource(R.string.news_view_all),
-                onClick = onViewAll,
-                modifier = Modifier.fillMaxWidth(),
-            )
+        } else {
+            LatestNewsSummaryRows(news = news)
         }
+        ReguertaFlatButton(
+            label = stringResource(R.string.news_view_all),
+            onClick = onViewAll,
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrderRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrderRoute.kt
@@ -91,7 +91,6 @@ import com.reguerta.user.domain.products.Product
 import com.reguerta.user.domain.products.ProductPricingMode
 import com.reguerta.user.domain.products.ProductStockMode
 import com.reguerta.user.domain.shifts.ShiftAssignment
-import com.reguerta.user.domain.shifts.ShiftType
 import com.reguerta.user.ui.components.auth.ReguertaDialog
 import com.reguerta.user.ui.components.auth.ReguertaDialogAction
 import com.reguerta.user.ui.components.auth.ReguertaDialogType
@@ -2103,19 +2102,7 @@ private fun resolveEffectiveDeliveryDate(
         return Instant.ofEpochMilli(override.deliveryDateMillis).atZone(zoneId).toLocalDate()
     }
     val weekStart = currentWeekKey.toIsoWeekStartDate() ?: fallbackWeekStart
-    val weekEnd = weekStart.plusDays(6)
-    val shiftDeliveryDate = shifts
-        .asSequence()
-        .filter { shift -> shift.type == ShiftType.DELIVERY }
-        .map { shift -> Instant.ofEpochMilli(shift.dateMillis).atZone(zoneId).toLocalDate() }
-        .filter { shiftDate -> !shiftDate.isBefore(weekStart) && !shiftDate.isAfter(weekEnd) }
-        .sorted()
-        .firstOrNull()
-    if (shiftDeliveryDate != null) {
-        return shiftDeliveryDate
-    }
-    val deliveryDay = defaultDeliveryDayOfWeek?.toDayOfWeek() ?: DayOfWeek.WEDNESDAY
-    return weekStart.plusDays((deliveryDay.value - DayOfWeek.MONDAY.value).toLong())
+    return weekStart.plusDays((DayOfWeek.WEDNESDAY.value - DayOfWeek.MONDAY.value).toLong())
 }
 
 private suspend fun fetchPreviousWeekOrderSnapshot(

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionAuthActions.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/SessionAuthActions.kt
@@ -81,45 +81,11 @@ internal class SessionAuthActions(
 
             when (val authResult = authSessionProvider.signIn(email = email, password = password)) {
                 is AuthSignInResult.Success -> {
-                    when (val result = resolveAuthorizedSession(authResult.principal)) {
-                        is AccessResolutionResult.Authorized -> {
-                            val members = memberRepository.getAllMembers()
-                            val allNotifications = notificationRepository.getAllNotifications()
-                            val readNotificationIds = notificationRepository.getReadNotificationIds(result.member.id)
-                            uiState.update {
-                                it.copy(
-                                    isAuthenticating = false,
-                                    mode = SessionMode.Authorized(
-                                        principal = authResult.principal,
-                                        authenticatedMember = result.member,
-                                        member = result.member,
-                                        members = members,
-                                    ),
-                                    myOrderFreshnessState = MyOrderFreshnessUiState.Checking,
-                                    notificationsFeed = allNotifications.filter { event -> event.isVisibleTo(result.member) },
-                                    readNotificationIds = readNotificationIds,
-                                )
-                            }
-                            registerAuthorizedDevice(result.member)
-                            refreshMyOrderFreshness()
-                        }
-
-                        is AccessResolutionResult.Unauthorized -> {
-                            val showUnauthorizedDialog = shouldShowUnauthorizedDialog(
-                                currentMode = uiState.value.mode,
-                                email = authResult.principal.email,
-                                reason = result.reason,
-                            )
-                            uiState.update { state ->
-                                state.toUnauthorizedAfterAuthAttemptState(
-                                    email = authResult.principal.email,
-                                    reason = result.reason,
-                                    showUnauthorizedDialog = showUnauthorizedDialog,
-                                    clearRegisterInputs = false,
-                                )
-                            }
-                        }
-                    }
+                    applyAuthorizedSession(
+                        principal = authResult.principal,
+                        shouldRefreshCriticalData = true,
+                    )
+                    uiState.update { it.copy(isAuthenticating = false) }
                 }
 
                 is AuthSignInResult.Failure -> {
@@ -191,47 +157,17 @@ internal class SessionAuthActions(
 
             when (val authResult = authSessionProvider.signUp(email = email, password = password)) {
                 is AuthSignInResult.Success -> {
-                    when (val result = resolveAuthorizedSession(authResult.principal)) {
-                        is AccessResolutionResult.Authorized -> {
-                            val members = memberRepository.getAllMembers()
-                            val allNotifications = notificationRepository.getAllNotifications()
-                            val readNotificationIds = notificationRepository.getReadNotificationIds(result.member.id)
-                            uiState.update {
-                                it.copy(
-                                    isRegistering = false,
-                                    registerEmailInput = "",
-                                    registerPasswordInput = "",
-                                    registerRepeatPasswordInput = "",
-                                    mode = SessionMode.Authorized(
-                                        principal = authResult.principal,
-                                        authenticatedMember = result.member,
-                                        member = result.member,
-                                        members = members,
-                                    ),
-                                    myOrderFreshnessState = MyOrderFreshnessUiState.Checking,
-                                    notificationsFeed = allNotifications.filter { event -> event.isVisibleTo(result.member) },
-                                    readNotificationIds = readNotificationIds,
-                                )
-                            }
-                            registerAuthorizedDevice(result.member)
-                            refreshMyOrderFreshness()
-                        }
-
-                        is AccessResolutionResult.Unauthorized -> {
-                            val showUnauthorizedDialog = shouldShowUnauthorizedDialog(
-                                currentMode = uiState.value.mode,
-                                email = authResult.principal.email,
-                                reason = result.reason,
-                            )
-                            uiState.update { state ->
-                                state.toUnauthorizedAfterAuthAttemptState(
-                                    email = authResult.principal.email,
-                                    reason = result.reason,
-                                    showUnauthorizedDialog = showUnauthorizedDialog,
-                                    clearRegisterInputs = true,
-                                )
-                            }
-                        }
+                    applyAuthorizedSession(
+                        principal = authResult.principal,
+                        shouldRefreshCriticalData = true,
+                    )
+                    uiState.update {
+                        it.copy(
+                            isRegistering = false,
+                            registerEmailInput = "",
+                            registerPasswordInput = "",
+                            registerRepeatPasswordInput = "",
+                        )
                     }
                 }
 
@@ -402,6 +338,8 @@ internal class SessionAuthActions(
                 val ownSharedProfile = sharedProfiles.firstOrNull { it.userId == result.member.id }
                 uiState.update {
                     it.copy(
+                        isAuthenticating = false,
+                        isRegistering = false,
                         mode = SessionMode.Authorized(
                             principal = principal,
                             authenticatedMember = result.member,

--- a/android/Reguerta/app/src/main/res/values-es/strings.xml
+++ b/android/Reguerta/app/src/main/res/values-es/strings.xml
@@ -95,6 +95,7 @@
     <string name="home_dashboard_market_responsibles">Responsables mercado</string>
     <string name="home_dashboard_helper_format">%1$s</string>
     <string name="home_dashboard_state">Pedido</string>
+    <string name="home_dashboard_order_state_consultation">Último pedido</string>
     <string name="home_dashboard_order_state_not_started">Sin hacer</string>
     <string name="home_dashboard_order_state_unconfirmed">Sin confirmar</string>
     <string name="home_dashboard_order_state_completed">Hecho</string>

--- a/android/Reguerta/app/src/main/res/values/strings.xml
+++ b/android/Reguerta/app/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="home_dashboard_market_responsibles">Market responsibles</string>
     <string name="home_dashboard_helper_format">%1$s</string>
     <string name="home_dashboard_state">Order</string>
+    <string name="home_dashboard_order_state_consultation">Last order</string>
     <string name="home_dashboard_order_state_not_started">Not started</string>
     <string name="home_dashboard_order_state_unconfirmed">Unconfirmed</string>
     <string name="home_dashboard_order_state_completed">Done</string>

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/access/HomeWeeklySummaryDisplayTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/access/HomeWeeklySummaryDisplayTest.kt
@@ -3,6 +3,7 @@ package com.reguerta.user.presentation.access
 import com.reguerta.user.domain.access.Member
 import com.reguerta.user.domain.access.MemberRole
 import com.reguerta.user.domain.access.ProducerParity
+import com.reguerta.user.domain.calendar.DeliveryCalendarOverride
 import com.reguerta.user.domain.calendar.DeliveryWeekday
 import com.reguerta.user.domain.shifts.ShiftAssignment
 import com.reguerta.user.domain.shifts.ShiftStatus
@@ -130,10 +131,79 @@ class HomeWeeklySummaryDisplayTest {
     }
 
     @Test
+    fun weeklySummary_usesWednesdayWhenNoDeliveryCalendarOverrideEvenIfShiftIsLater() {
+        val display = resolveHomeWeeklySummaryDisplay(
+            nowMillis = LocalDate.of(2026, 7, 7).atStartOfDay(zone).toInstant().toEpochMilli(),
+            defaultDeliveryDayOfWeek = DeliveryWeekday.WEDNESDAY,
+            deliveryCalendarOverrides = emptyList(),
+            shifts = listOf(deliveryShift("delivery_2026w28", LocalDate.of(2026, 7, 9))),
+            members = members,
+            currentMemberId = "member_1",
+            orderState = HomeOrderStateDisplay.NOT_STARTED,
+            zoneId = zone,
+        )
+
+        assertEquals("2026-W28", display.weekKey)
+        assertEquals("Mié 8", display.deliveryLabel)
+        assertEquals("Carmen", display.responsibleName)
+        assertEquals("Javier", display.helperName)
+    }
+
+    @Test
+    fun weeklySummary_usesDeliveryCalendarOverrideWhenPresent() {
+        val display = resolveHomeWeeklySummaryDisplay(
+            nowMillis = LocalDate.of(2026, 7, 7).atStartOfDay(zone).toInstant().toEpochMilli(),
+            defaultDeliveryDayOfWeek = DeliveryWeekday.WEDNESDAY,
+            deliveryCalendarOverrides = listOf(
+                deliveryOverride(
+                    weekKey = "2026-W28",
+                    deliveryDate = LocalDate.of(2026, 7, 9),
+                ),
+            ),
+            shifts = listOf(deliveryShift("delivery_2026w28", LocalDate.of(2026, 7, 9))),
+            members = members,
+            currentMemberId = "member_1",
+            orderState = HomeOrderStateDisplay.NOT_STARTED,
+            zoneId = zone,
+        )
+
+        assertEquals("2026-W28", display.weekKey)
+        assertEquals("Jue 9", display.deliveryLabel)
+        assertEquals("Carmen", display.responsibleName)
+        assertEquals("Javier", display.helperName)
+    }
+
+    @Test
     fun orderStateLabelsPreserveRequiredMapping() {
+        assertEquals(HomeOrderStateDisplay.CONSULTATION, HomeOrderStateDisplay.CONSULTATION)
         assertEquals(HomeOrderStateDisplay.NOT_STARTED, HomeOrderStateDisplay.NOT_STARTED)
         assertEquals(HomeOrderStateDisplay.UNCONFIRMED, HomeOrderStateDisplay.UNCONFIRMED)
         assertEquals(HomeOrderStateDisplay.COMPLETED, HomeOrderStateDisplay.COMPLETED)
+    }
+
+    @Test
+    fun displayedOrderState_usesConsultationStateBeforeDelivery() {
+        assertEquals(
+            HomeOrderStateDisplay.CONSULTATION,
+            resolveHomeDisplayedOrderState(
+                isConsultaPhase = true,
+                orderState = HomeOrderStateDisplay.NOT_STARTED,
+            ),
+        )
+        assertEquals(
+            HomeOrderStateDisplay.CONSULTATION,
+            resolveHomeDisplayedOrderState(
+                isConsultaPhase = true,
+                orderState = HomeOrderStateDisplay.UNCONFIRMED,
+            ),
+        )
+        assertEquals(
+            HomeOrderStateDisplay.NOT_STARTED,
+            resolveHomeDisplayedOrderState(
+                isConsultaPhase = false,
+                orderState = HomeOrderStateDisplay.NOT_STARTED,
+            ),
+        )
     }
 
     private fun deliveryShift(
@@ -170,6 +240,22 @@ class HomeWeeklySummaryDisplayTest {
             createdAtMillis = 0,
             updatedAtMillis = 0,
         )
+
+    private fun deliveryOverride(
+        weekKey: String,
+        deliveryDate: LocalDate,
+    ): DeliveryCalendarOverride {
+        val deliveryMillis = deliveryDate.atStartOfDay(zone).toInstant().toEpochMilli()
+        return DeliveryCalendarOverride(
+            weekKey = weekKey,
+            deliveryDateMillis = deliveryMillis,
+            ordersBlockedDateMillis = deliveryMillis,
+            ordersOpenAtMillis = deliveryMillis,
+            ordersCloseAtMillis = deliveryMillis,
+            updatedBy = "test",
+            updatedAtMillis = 0,
+        )
+    }
 
     private val members = listOf(
         Member(

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/access/ReceivedOrdersWindowTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/access/ReceivedOrdersWindowTest.kt
@@ -1,0 +1,78 @@
+package com.reguerta.user.presentation.access
+
+import com.reguerta.user.domain.calendar.DeliveryCalendarOverride
+import com.reguerta.user.domain.calendar.DeliveryWeekday
+import com.reguerta.user.domain.shifts.ShiftAssignment
+import com.reguerta.user.domain.shifts.ShiftStatus
+import com.reguerta.user.domain.shifts.ShiftType
+import java.time.LocalDate
+import java.time.ZoneId
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReceivedOrdersWindowTest {
+    private val zone = ZoneId.of("Europe/Madrid")
+
+    @Test
+    fun window_usesWednesdayWhenNoDeliveryCalendarOverrideEvenIfShiftIsLater() {
+        val window = resolveReceivedOrdersWindow(
+            nowMillis = LocalDate.of(2026, 7, 9).toMillis(),
+            defaultDeliveryDayOfWeek = DeliveryWeekday.WEDNESDAY,
+            deliveryCalendarOverrides = emptyList(),
+            shifts = listOf(deliveryShift("delivery_2026w28", LocalDate.of(2026, 7, 9))),
+        )
+
+        assertEquals(false, window.isEnabled)
+        assertEquals("2026-W28", window.targetWeekKey)
+    }
+
+    @Test
+    fun window_usesDeliveryCalendarOverrideWhenPresent() {
+        val window = resolveReceivedOrdersWindow(
+            nowMillis = LocalDate.of(2026, 7, 9).toMillis(),
+            defaultDeliveryDayOfWeek = DeliveryWeekday.WEDNESDAY,
+            deliveryCalendarOverrides = listOf(
+                deliveryOverride(
+                    weekKey = "2026-W28",
+                    deliveryDate = LocalDate.of(2026, 7, 9),
+                ),
+            ),
+            shifts = listOf(deliveryShift("delivery_2026w28", LocalDate.of(2026, 7, 9))),
+        )
+
+        assertEquals(true, window.isEnabled)
+        assertEquals("2026-W27", window.targetWeekKey)
+    }
+
+    private fun deliveryShift(id: String, date: LocalDate): ShiftAssignment =
+        ShiftAssignment(
+            id = id,
+            type = ShiftType.DELIVERY,
+            dateMillis = date.toMillis(),
+            assignedUserIds = listOf("member_1"),
+            helperUserId = "member_2",
+            status = ShiftStatus.CONFIRMED,
+            source = "test",
+            createdAtMillis = 0,
+            updatedAtMillis = 0,
+        )
+
+    private fun deliveryOverride(
+        weekKey: String,
+        deliveryDate: LocalDate,
+    ): DeliveryCalendarOverride {
+        val deliveryMillis = deliveryDate.toMillis()
+        return DeliveryCalendarOverride(
+            weekKey = weekKey,
+            deliveryDateMillis = deliveryMillis,
+            ordersBlockedDateMillis = deliveryMillis,
+            ordersOpenAtMillis = deliveryMillis,
+            ordersCloseAtMillis = deliveryMillis,
+            updatedBy = "test",
+            updatedAtMillis = 0,
+        )
+    }
+
+    private fun LocalDate.toMillis(): Long =
+        atStartOfDay(zone).toInstant().toEpochMilli()
+}

--- a/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderPreviousOrder.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderPreviousOrder.swift
@@ -2,9 +2,9 @@ import FirebaseFirestore
 import Foundation
 
 func resolveMyOrderConsultaWindow(
-    defaultDeliveryDayOfWeek: DeliveryWeekday?,
+    defaultDeliveryDayOfWeek _: DeliveryWeekday?,
     deliveryCalendarOverrides: [DeliveryCalendarOverride],
-    shifts: [ShiftAssignment],
+    shifts _: [ShiftAssignment],
     now: Date = Date(),
     timeZone: TimeZone = TimeZone(identifier: "Europe/Madrid") ?? .current
 ) -> MyOrderConsultaWindow {
@@ -14,7 +14,6 @@ func resolveMyOrderConsultaWindow(
     let weekStartDay = calendar.startOfDay(
         for: calendar.dateInterval(of: .weekOfYear, for: now)?.start ?? now
     )
-    let weekEndDay = calendar.date(byAdding: .day, value: 6, to: weekStartDay) ?? weekStartDay
     let today = calendar.startOfDay(for: now)
     let currentWeekKey = String(
         format: "%04d-W%02d",
@@ -27,16 +26,8 @@ func resolveMyOrderConsultaWindow(
         effectiveDeliveryDate = calendar.startOfDay(
             for: Date(timeIntervalSince1970: TimeInterval(override.deliveryDateMillis) / 1_000)
         )
-    } else if let currentWeekDeliveryShiftDate = shifts
-        .filter({ $0.type == .delivery })
-        .map({ calendar.startOfDay(for: Date(timeIntervalSince1970: TimeInterval($0.dateMillis) / 1_000)) })
-        .filter({ $0 >= weekStartDay && $0 <= weekEndDay })
-        .sorted(by: <)
-        .first {
-        effectiveDeliveryDate = currentWeekDeliveryShiftDate
     } else {
-        let dayOffset = (defaultDeliveryDayOfWeek ?? .wednesday).myOrderDayOffset
-        effectiveDeliveryDate = calendar.date(byAdding: .day, value: dayOffset, to: weekStartDay) ?? weekStartDay
+        effectiveDeliveryDate = calendar.date(byAdding: .day, value: 2, to: weekStartDay) ?? weekStartDay
     }
 
     let previousWeekDate = calendar.date(byAdding: .day, value: -7, to: weekStartDay) ?? weekStartDay

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaScreenHeader/ReguertaScreenHeaderView.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaScreenHeader/ReguertaScreenHeaderView.swift
@@ -82,6 +82,8 @@ struct ReguertaGlassIconButton: View {
     @Environment(\.reguertaTokens) private var tokens
 
     let iconAction: ReguertaHeaderAction
+    private var buttonSize: CGFloat { 52.resize }
+    private var effectPadding: CGFloat { 6.resize }
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
@@ -89,7 +91,7 @@ struct ReguertaGlassIconButton: View {
                 Image(systemName: iconAction.systemImageName)
                     .font(.system(size: 20.resize, weight: .semibold))
                     .foregroundStyle(iconAction.iconColor(tokens: tokens))
-                    .frame(width: 52.resize, height: 52.resize)
+                    .frame(width: buttonSize, height: buttonSize)
                     .contentShape(Circle())
             }
             .buttonStyle(.plain)
@@ -99,13 +101,15 @@ struct ReguertaGlassIconButton: View {
                 isEnabled: iconAction.isEnabled,
                 colorScheme: colorScheme
             )
+            .padding(effectPadding)
             .accessibilityLabel(iconAction.accessibilityLabel.viewText)
             .reguertaHeaderAccessibilityIdentifier(iconAction.accessibilityIdentifier)
 
             ReguertaHeaderBadgeView(badge: iconAction.badge)
+                .padding(effectPadding)
                 .allowsHitTesting(false)
         }
-        .frame(width: 52.resize, height: 52.resize)
+        .frame(width: buttonSize + effectPadding * 2, height: buttonSize + effectPadding * 2)
     }
 }
 

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeDashboardRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeDashboardRoute.swift
@@ -1,15 +1,17 @@
 import SwiftUI
 
 enum HomeOrderStateDisplay: Equatable {
+    case consultation
     case notStarted
     case unconfirmed
     case completed
 
     func myOrderSubtitleKey(isConsultaPhase: Bool) -> String {
-        if isConsultaPhase {
+        if isConsultaPhase || self == .consultation {
             return AccessL10nKey.homeDashboardMyOrderSubtitleLastOrder
         }
         return switch self {
+        case .consultation: AccessL10nKey.homeDashboardMyOrderSubtitleLastOrder
         case .notStarted: AccessL10nKey.homeDashboardMyOrderSubtitleEdit
         case .unconfirmed: AccessL10nKey.homeDashboardMyOrderSubtitleReview
         case .completed: AccessL10nKey.homeDashboardMyOrderSubtitleCompleted
@@ -18,6 +20,7 @@ enum HomeOrderStateDisplay: Equatable {
 
     var titleKey: String {
         switch self {
+        case .consultation: AccessL10nKey.homeDashboardOrderStateConsultation
         case .notStarted: AccessL10nKey.homeDashboardOrderStateNotStarted
         case .unconfirmed: AccessL10nKey.homeDashboardOrderStateUnconfirmed
         case .completed: AccessL10nKey.homeDashboardOrderStateCompleted

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellComponents.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellComponents.swift
@@ -377,6 +377,8 @@ private extension View {
 private extension HomeOrderStateDisplay {
     func color(tokens: ReguertaDesignTokens) -> Color {
         switch self {
+        case .consultation:
+            return tokens.colors.textPrimary
         case .notStarted:
             return tokens.colors.feedbackError
         case .unconfirmed:

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellViewModel.swift
@@ -219,6 +219,7 @@ extension AccessRootViewModel {
             shifts: shiftsViewModel.shiftsFeed,
             members: session.members
         )
+        let storedOrderState = resolveHomeOrderState(memberId: session.member.id, weekKey: baseline.orderWeekKey)
         return HomeWeeklySummaryDisplay(
             weekKey: baseline.weekKey,
             orderWeekKey: baseline.orderWeekKey,
@@ -230,7 +231,10 @@ extension AccessRootViewModel {
             helperName: baseline.helperName,
             marketLabel: baseline.marketLabel,
             marketResponsibleNames: baseline.marketResponsibleNames,
-            orderState: resolveHomeOrderState(memberId: session.member.id, weekKey: baseline.orderWeekKey),
+            orderState: resolveHomeDisplayedOrderState(
+                isConsultaPhase: baseline.isConsultaPhase,
+                orderState: storedOrderState
+            ),
             isConsultaPhase: baseline.isConsultaPhase
         )
     }

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeWeeklySummaryResolution.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeWeeklySummaryResolution.swift
@@ -5,9 +5,8 @@ private let homeOrderCartQuantitiesSuffix = ".quantities"
 private let homeOrderConfirmedQuantitiesSuffix = ".confirmed_quantities"
 
 private struct HomeWeeklySummaryResolutionContext {
-    let deliveryWeekday: DeliveryWeekday
+    let deliveryCalendarOverrides: [DeliveryCalendarOverride]
     let shifts: [ShiftAssignment]
-    let overrides: [DeliveryCalendarOverride]
     let calendar: Calendar
 }
 
@@ -25,7 +24,7 @@ private struct HomeWeeklySummaryTarget {
 
 func resolveHomeWeeklySummaryDisplay(
     nowMillis: Int64,
-    defaultDeliveryDayOfWeek: DeliveryWeekday?,
+    defaultDeliveryDayOfWeek _: DeliveryWeekday?,
     deliveryCalendarOverrides: [DeliveryCalendarOverride],
     shifts: [ShiftAssignment],
     members: [Member],
@@ -36,24 +35,16 @@ func resolveHomeWeeklySummaryDisplay(
     let locale = Locale(identifier: "es_ES")
     let today = calendar.startOfDay(for: Date(timeIntervalSince1970: TimeInterval(nowMillis) / 1_000))
     let currentWeekStart = calendar.dateInterval(of: .weekOfYear, for: today)?.start ?? today
-    let isConsultaPhase = resolveHomeConsultaPhase(
-        nowMillis: nowMillis,
-        defaultDeliveryDayOfWeek: defaultDeliveryDayOfWeek,
-        deliveryCalendarOverrides: deliveryCalendarOverrides,
-        shifts: shifts
-    )
-    let deliveryWeekday = defaultDeliveryDayOfWeek ?? .wednesday
     let context = HomeWeeklySummaryResolutionContext(
-        deliveryWeekday: deliveryWeekday,
+        deliveryCalendarOverrides: deliveryCalendarOverrides,
         shifts: shifts,
-        overrides: deliveryCalendarOverrides,
         calendar: calendar
     )
     let currentDeliveryDate = resolveHomeEffectiveDeliveryDate(
-        weekKey: currentWeekStart.homeIsoWeekKey(calendar: calendar),
         weekStart: currentWeekStart,
         context: context
     )
+    let isConsultaPhase = today >= currentWeekStart && today <= currentDeliveryDate
     let target = resolveHomeWeeklySummaryTarget(
         today: today,
         currentWeekStart: currentWeekStart,
@@ -87,8 +78,7 @@ private func resolveHomeWeeklySummaryTarget(
     let orderWeekKey = orderWeekStart.homeIsoWeekKey(calendar: context.calendar)
     let targetShift = resolveHomeTargetDeliveryShift(
         shifts: context.shifts,
-        targetWeekKey: targetWeekKey,
-        overrides: context.overrides
+        targetWeekKey: targetWeekKey
     )
     let targetMarketShift = resolveHomeTargetMarketShift(
         shifts: context.shifts,
@@ -96,10 +86,8 @@ private func resolveHomeWeeklySummaryTarget(
         calendar: context.calendar
     )
     let deliveryDate = resolveHomeTargetDeliveryDate(
-        targetShift: targetShift,
         weekStart: targetWeekStart,
-        deliveryWeekday: context.deliveryWeekday,
-        overrides: context.overrides,
+        deliveryCalendarOverrides: context.deliveryCalendarOverrides,
         calendar: context.calendar
     )
     let fallbackMarketDate = context.calendar.date(byAdding: .day, value: 5, to: orderWeekStart) ?? orderWeekStart
@@ -160,29 +148,14 @@ private func resolveHomeTargetWeekStart(
         : currentWeekStart
 }
 
-private func resolveHomeConsultaPhase(
-    nowMillis: Int64,
-    defaultDeliveryDayOfWeek: DeliveryWeekday?,
-    deliveryCalendarOverrides: [DeliveryCalendarOverride],
-    shifts: [ShiftAssignment]
-) -> Bool {
-    resolveMyOrderConsultaWindow(
-        defaultDeliveryDayOfWeek: defaultDeliveryDayOfWeek,
-        deliveryCalendarOverrides: deliveryCalendarOverrides,
-        shifts: shifts,
-        now: Date(timeIntervalSince1970: TimeInterval(nowMillis) / 1_000)
-    ).isConsultaPhase
-}
-
 private func resolveHomeTargetDeliveryShift(
     shifts: [ShiftAssignment],
-    targetWeekKey: String,
-    overrides: [DeliveryCalendarOverride]
+    targetWeekKey: String
 ) -> ShiftAssignment? {
     shifts
         .filter { $0.type == .delivery }
         .first { shift in
-            effectiveHomeDeliveryMillis(for: shift, overrides: overrides).homeIsoWeekKey == targetWeekKey
+            shift.dateMillis.homeIsoWeekKey == targetWeekKey
         }
 }
 
@@ -203,18 +176,13 @@ private func resolveHomeTargetMarketShift(
 }
 
 private func resolveHomeTargetDeliveryDate(
-    targetShift: ShiftAssignment?,
     weekStart: Date,
-    deliveryWeekday: DeliveryWeekday,
-    overrides: [DeliveryCalendarOverride],
+    deliveryCalendarOverrides: [DeliveryCalendarOverride],
     calendar: Calendar
 ) -> Date {
-    targetShift.map {
-        Date(timeIntervalSince1970: TimeInterval(effectiveHomeDeliveryMillis(for: $0, overrides: overrides)) / 1_000)
-    } ?? resolveHomeDeliveryDate(
+    resolveHomeCalendarDeliveryDate(
         weekStart: weekStart,
-        deliveryWeekday: deliveryWeekday,
-        overrides: overrides,
+        deliveryCalendarOverrides: deliveryCalendarOverrides,
         calendar: calendar
     )
 }
@@ -243,6 +211,13 @@ func resolveHomeOrderState(
     return .notStarted
 }
 
+func resolveHomeDisplayedOrderState(
+    isConsultaPhase: Bool,
+    orderState: HomeOrderStateDisplay
+) -> HomeOrderStateDisplay {
+    isConsultaPhase ? .consultation : orderState
+}
+
 func formatHomeTopBarDate(
     nowMillis: Int64,
     locale: Locale = Locale(identifier: "es_ES")
@@ -254,59 +229,29 @@ func formatHomeTopBarDate(
     return formatter.string(from: date).lowercased()
 }
 
-private func effectiveHomeDeliveryMillis(
-    for shift: ShiftAssignment,
-    overrides: [DeliveryCalendarOverride]
-) -> Int64 {
-    guard shift.type == .delivery else { return shift.dateMillis }
-    return overrides.first(where: { $0.weekKey == shift.weekKey })?.deliveryDateMillis ?? shift.dateMillis
-}
-
-private func resolveHomeDeliveryDate(
+private func resolveHomeCalendarDeliveryDate(
     weekStart: Date,
-    deliveryWeekday: DeliveryWeekday,
-    overrides: [DeliveryCalendarOverride],
+    deliveryCalendarOverrides: [DeliveryCalendarOverride],
     calendar: Calendar
 ) -> Date {
     let weekKey = weekStart.homeIsoWeekKey(calendar: calendar)
-    if let override = overrides.first(where: { $0.weekKey == weekKey }) {
-        return calendar.startOfDay(for: Date(timeIntervalSince1970: TimeInterval(override.deliveryDateMillis) / 1_000))
-    }
-    return calendar.date(byAdding: .day, value: deliveryWeekday.homeDayOffset, to: weekStart) ?? weekStart
-}
-
-private func resolveHomeEffectiveDeliveryDate(
-    weekKey: String,
-    weekStart: Date,
-    context: HomeWeeklySummaryResolutionContext
-) -> Date {
-    if let override = context.overrides.first(where: { $0.weekKey == weekKey }) {
-        return context.calendar.startOfDay(
+    if let override = deliveryCalendarOverrides.first(where: { $0.weekKey == weekKey }) {
+        return calendar.startOfDay(
             for: Date(timeIntervalSince1970: TimeInterval(override.deliveryDateMillis) / 1_000)
         )
     }
-    let weekEnd = context.calendar.date(byAdding: .day, value: 6, to: weekStart) ?? weekStart
-    if let deliveryShiftDate = context.shifts
-        .filter({ $0.type == .delivery })
-        .map({
-            context.calendar.startOfDay(
-                for: Date(
-                    timeIntervalSince1970: TimeInterval(
-                        effectiveHomeDeliveryMillis(for: $0, overrides: context.overrides)
-                    ) / 1_000
-                )
-            )
-        })
-        .filter({ $0 >= weekStart && $0 <= weekEnd })
-        .sorted(by: <)
-        .first {
-        return deliveryShiftDate
-    }
-    return context.calendar.date(
-        byAdding: .day,
-        value: context.deliveryWeekday.homeDayOffset,
-        to: weekStart
-    ) ?? weekStart
+    return calendar.date(byAdding: .day, value: 2, to: weekStart) ?? weekStart
+}
+
+private func resolveHomeEffectiveDeliveryDate(
+    weekStart: Date,
+    context: HomeWeeklySummaryResolutionContext
+) -> Date {
+    resolveHomeCalendarDeliveryDate(
+        weekStart: weekStart,
+        deliveryCalendarOverrides: context.deliveryCalendarOverrides,
+        calendar: context.calendar
+    )
 }
 
 private func resolveHomeProducerName(
@@ -369,19 +314,5 @@ private extension Date {
         formatter.locale = locale
         formatter.dateFormat = "EEE d"
         return formatter.string(from: self).replacingOccurrences(of: ".", with: "").capitalized
-    }
-}
-
-private extension DeliveryWeekday {
-    var homeDayOffset: Int {
-        switch self {
-        case .monday: 0
-        case .tuesday: 1
-        case .wednesday: 2
-        case .thursday: 3
-        case .friday: 4
-        case .saturday: 5
-        case .sunday: 6
-        }
     }
 }

--- a/ios/Reguerta/Reguerta/Presentation/Localization/AccessLocalization.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Localization/AccessLocalization.swift
@@ -99,6 +99,7 @@ enum AccessL10nKey {
     static let homeDashboardMarketResponsibles = "home.dashboard.market_responsibles"
     static let homeDashboardHelperFormat = "home.dashboard.helper.format"
     static let homeDashboardState = "home.dashboard.state"
+    static let homeDashboardOrderStateConsultation = "home.dashboard.order_state.consultation"
     static let homeDashboardOrderStateNotStarted = "home.dashboard.order_state.not_started"
     static let homeDashboardOrderStateUnconfirmed = "home.dashboard.order_state.unconfirmed"
     static let homeDashboardOrderStateCompleted = "home.dashboard.order_state.completed"

--- a/ios/Reguerta/Reguerta/Presentation/Root/ContentView.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Root/ContentView.swift
@@ -229,6 +229,7 @@ struct AuthShellView: AccessRootRoutingView {
                 .padding(.bottom, tokens.spacing.md)
             }
             .scrollDismissesKeyboard(.interactively)
+            .scrollClipDisabled()
         }
     }
 }

--- a/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
+++ b/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
@@ -2243,6 +2243,23 @@
         }
       }
     },
+    "home.dashboard.order_state.consultation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last order"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Último pedido"
+          }
+        }
+      }
+    },
     "home.dashboard.order_state.not_started" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/ios/Reguerta/ReguertaTests/ReguertaHomeSummaryTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaHomeSummaryTests.swift
@@ -118,6 +118,47 @@ struct ReguertaHomeSummaryTests {
     }
 
     @Test
+    func homeWeeklySummaryUsesWednesdayWhenNoDeliveryCalendarOverrideEvenIfShiftIsLater() {
+        let display = resolveHomeWeeklySummaryDisplay(
+            nowMillis: testMillis(year: 2026, month: 7, day: 7),
+            defaultDeliveryDayOfWeek: .wednesday,
+            deliveryCalendarOverrides: [],
+            shifts: [testDeliveryShift(id: "delivery_w28", year: 2026, month: 7, day: 9)],
+            members: homeSummaryMembers
+        )
+
+        #expect(display.weekKey == "2026-W28")
+        #expect(display.deliveryLabel == "Mié 8")
+        #expect(display.responsibleName == "Carmen")
+        #expect(display.helperName == "Javier")
+    }
+
+    @Test
+    func homeWeeklySummaryUsesDeliveryCalendarOverrideWhenPresent() {
+        let override = DeliveryCalendarOverride(
+            weekKey: "2026-W28",
+            deliveryDateMillis: testMillis(year: 2026, month: 7, day: 9),
+            ordersBlockedDateMillis: testMillis(year: 2026, month: 7, day: 9),
+            ordersOpenAtMillis: testMillis(year: 2026, month: 7, day: 9),
+            ordersCloseAtMillis: testMillis(year: 2026, month: 7, day: 9),
+            updatedBy: "test",
+            updatedAtMillis: 0
+        )
+        let display = resolveHomeWeeklySummaryDisplay(
+            nowMillis: testMillis(year: 2026, month: 7, day: 7),
+            defaultDeliveryDayOfWeek: .wednesday,
+            deliveryCalendarOverrides: [override],
+            shifts: [testDeliveryShift(id: "delivery_w28", year: 2026, month: 7, day: 9)],
+            members: homeSummaryMembers
+        )
+
+        #expect(display.weekKey == "2026-W28")
+        #expect(display.deliveryLabel == "Jue 9")
+        #expect(display.responsibleName == "Carmen")
+        #expect(display.helperName == "Javier")
+    }
+
+    @Test
     func homeOrderStateMappingUsesConfirmedBeforeDraft() {
         let suiteName = "home-order-state-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -132,5 +173,12 @@ struct ReguertaHomeSummaryTests {
         #expect(resolveHomeOrderState(userDefaults: defaults, memberId: "member_1", weekKey: "2026-W19") == .unconfirmed)
         defaults.set(["product_1": 2], forKey: confirmedKey)
         #expect(resolveHomeOrderState(userDefaults: defaults, memberId: "member_1", weekKey: "2026-W19") == .completed)
+    }
+
+    @Test
+    func homeDisplayedOrderStateUsesConsultationBeforeDelivery() {
+        #expect(resolveHomeDisplayedOrderState(isConsultaPhase: true, orderState: .notStarted) == .consultation)
+        #expect(resolveHomeDisplayedOrderState(isConsultaPhase: true, orderState: .unconfirmed) == .consultation)
+        #expect(resolveHomeDisplayedOrderState(isConsultaPhase: false, orderState: .notStarted) == .notStarted)
     }
 }

--- a/ios/Reguerta/ReguertaTests/ReguertaOrdersViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaOrdersViewModelTests.swift
@@ -221,6 +221,41 @@ struct ReguertaOrdersViewModelTests {
     }
 
     @Test
+    func myOrderConsultaWindowUsesWednesdayWhenNoDeliveryCalendarOverrideEvenIfShiftIsLater() {
+        let window = resolveMyOrderConsultaWindow(
+            defaultDeliveryDayOfWeek: .wednesday,
+            deliveryCalendarOverrides: [],
+            shifts: [testDeliveryShift(id: "delivery_w28", year: 2026, month: 7, day: 9)],
+            now: Date(timeIntervalSince1970: TimeInterval(testMillis(year: 2026, month: 7, day: 9)) / 1_000)
+        )
+
+        #expect(!window.isConsultaPhase)
+        #expect(window.previousWeekKey == "2026-W27")
+    }
+
+    @Test
+    func myOrderConsultaWindowUsesDeliveryCalendarOverrideWhenPresent() {
+        let override = DeliveryCalendarOverride(
+            weekKey: "2026-W28",
+            deliveryDateMillis: testMillis(year: 2026, month: 7, day: 9),
+            ordersBlockedDateMillis: testMillis(year: 2026, month: 7, day: 9),
+            ordersOpenAtMillis: testMillis(year: 2026, month: 7, day: 9),
+            ordersCloseAtMillis: testMillis(year: 2026, month: 7, day: 9),
+            updatedBy: "test",
+            updatedAtMillis: 0
+        )
+        let window = resolveMyOrderConsultaWindow(
+            defaultDeliveryDayOfWeek: .wednesday,
+            deliveryCalendarOverrides: [override],
+            shifts: [testDeliveryShift(id: "delivery_w28", year: 2026, month: 7, day: 9)],
+            now: Date(timeIntervalSince1970: TimeInterval(testMillis(year: 2026, month: 7, day: 9)) / 1_000)
+        )
+
+        #expect(window.isConsultaPhase)
+        #expect(window.previousWeekKey == "2026-W27")
+    }
+
+    @Test
     func receivedOrdersViewModelDoesNotLoadForNonProducerOrOutsideWindow() async {
         let repository = InMemoryOrdersRepository()
         let nonProducerViewModel = makeReceivedOrdersViewModel(repository: repository)


### PR DESCRIPTION
## Summary
- Use deliveryCalendar overrides as the delivery date source, with Wednesday fallback when no override exists.
- Keep Android and iOS home/order windows aligned before delivery and show the last order during the consultation phase.
- Polish Android home/auth spacing, summary table alignment, latest news title alignment, and IME resize behavior.
- Adjust iOS drawer-launched auth header shadow clipping and related safe-area handling.

## Validation
- Android: ./gradlew app:testDebugUnitTest app:lintDebug
- Android: ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest
- iOS focused: xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' test -only-testing:ReguertaTests/ReguertaHomeSummaryTests -only-testing:ReguertaTests/ReguertaOrdersViewModelTests
- git diff --staged --check

## Issue
- No linked issue; this PR documents the retrospective fix. Next work should start from an issue first.