### PR TITLE
[HU-060] Polish Android drawer and mobile UI spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-07 | 🐛 fix(ui): polish drawer and mobile spacing
 - 2026-07-07 | 🐛 fix(home): align weekly delivery summary
 - 2026-05-22 | 🐛 fix(orders): correct received order prep display
 - 2026-05-21 | 🐛 fix(order): align producer card dividers

--- a/android/Reguerta/app/src/androidTest/java/com/reguerta/user/HomeDrawerContentTest.kt
+++ b/android/Reguerta/app/src/androidTest/java/com/reguerta/user/HomeDrawerContentTest.kt
@@ -1,0 +1,73 @@
+package com.reguerta.user
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
+import com.reguerta.user.domain.access.Member
+import com.reguerta.user.domain.access.MemberRole
+import com.reguerta.user.domain.profiles.SharedProfile
+import com.reguerta.user.presentation.access.HomeDestination
+import com.reguerta.user.presentation.access.HomeDrawerContent
+import com.reguerta.user.ui.theme.ReguertaTheme
+import org.junit.Rule
+import org.junit.Test
+
+class HomeDrawerContentTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun drawerMatchesIosNavigationLabelsAndKeepsRoleBasedActions() {
+        composeRule.setContent {
+            ReguertaTheme {
+                HomeDrawerContent(
+                    member = fullAccessMember(),
+                    sharedProfile = sharedProfile(),
+                    currentDestination = HomeDestination.MY_ORDERS,
+                    installedVersion = "0.3.0.1",
+                    isDevelopBuild = true,
+                    onNavigate = {},
+                    onCloseDrawer = {},
+                    onSignOut = {},
+                )
+            }
+        }
+
+        composeRule.onAllNodesWithText("Home").assertCountEquals(0)
+        composeRule.onAllNodesWithText("My order").assertCountEquals(0)
+        composeRule.onNodeWithText("All my orders").assertIsDisplayed()
+        composeRule.onNodeWithText("Shifts").assertIsDisplayed()
+        composeRule.onNodeWithText("Consult bylaws").assertIsDisplayed()
+        composeRule.onNodeWithText("News").assertIsDisplayed()
+        composeRule.onNodeWithText("Community").assertIsDisplayed()
+        composeRule.onNodeWithText("Settings").assertIsDisplayed()
+        composeRule.onNodeWithText("Products").assertIsDisplayed()
+        composeRule.onNodeWithText("Order history").assertIsDisplayed()
+        composeRule.onNodeWithText("Users").performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("Send notification").performScrollTo().assertIsDisplayed()
+        composeRule.onNodeWithText("Sign out").assertIsDisplayed()
+    }
+
+    private fun fullAccessMember(): Member =
+        Member(
+            id = "member-1",
+            displayName = "Nohemi, Jesus, Iara y Lluvia",
+            normalizedEmail = "ophiura@yahoo.es",
+            authUid = "auth-1",
+            roles = setOf(MemberRole.MEMBER, MemberRole.PRODUCER, MemberRole.ADMIN),
+            isActive = true,
+            producerCatalogEnabled = true,
+        )
+
+    private fun sharedProfile(): SharedProfile =
+        SharedProfile(
+            userId = "member-1",
+            familyNames = "Nohemi, Jesus, Iara y Lluvia",
+            photoUrl = null,
+            about = "",
+            updatedAtMillis = 0L,
+        )
+}

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/HomeDashboardComponents.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/HomeDashboardComponents.kt
@@ -68,6 +68,7 @@ internal fun HomeWeeklySummaryCard(
                 Text(
                     text = display.weekBadgeLabel,
                     style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.Normal,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier
                         .clip(RoundedCornerShape(999.dp))

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRoot.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRoot.kt
@@ -190,7 +190,6 @@ fun ReguertaRoot(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(innerPadding)
             ) {
                 HomeRoute(
                     modifier = Modifier.fillMaxSize(),

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootAuthForms.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootAuthForms.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalFocusManager
 import com.reguerta.user.R
@@ -160,6 +161,7 @@ internal fun SignInCard(
                     label = stringResource(R.string.login_link_forgot_password),
                     onClick = onOpenRecover,
                     variant = ReguertaButtonVariant.TEXT,
+                    textStyle = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Normal),
                     fullWidth = false,
                 )
             }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootAuthRoutes.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootAuthRoutes.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -49,11 +50,11 @@ internal fun WelcomeRoute(
     val controlScale = adaptiveProfile.tokenScale.controls
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
         val compactHeight = maxHeight < 760.dp || maxWidth < 390.dp
-        val logoWidth = if (compactHeight) 0.68f else 0.74f
+        val logoWidth = if (compactHeight) 0.62f else 0.68f
         val buttonWidth = if (compactHeight) maxWidth * 0.84f else maxWidth * 0.88f
-        val topSpacing = if (compactHeight) (8f * controlScale).dp else (44f * controlScale).dp
+        val topSpacing = if (compactHeight) (26f * controlScale).dp else (52f * controlScale).dp
         val bottomSpacing = if (compactHeight) (6f * controlScale).dp else (10f * controlScale).dp
-        val titleToLogoWeight = if (compactHeight) 0.18f else 0.35f
+        val titleToLogoWeight = if (compactHeight) 0.12f else 0.26f
         val middleSectionWeight = if (compactHeight) 0.62f else 0.9f
         val prefixStyle = if (compactHeight) {
             MaterialTheme.typography.headlineSmall.copy(
@@ -171,6 +172,7 @@ internal fun LoginRoute(
     onPasswordChanged: (String) -> Unit,
 ) {
     val spacing = ReguertaThemeTokens.spacing
+    val authTitleStyle = authRouteTitleStyle()
     Column(
         modifier = Modifier.fillMaxSize(),
     ) {
@@ -178,7 +180,7 @@ internal fun LoginRoute(
 
         Text(
             text = stringResource(R.string.login_title),
-            style = MaterialTheme.typography.displayLarge,
+            style = authTitleStyle,
             color = MaterialTheme.colorScheme.primary,
         )
 
@@ -205,13 +207,14 @@ internal fun RegisterRoute(
     onBack: () -> Unit,
 ) {
     val spacing = ReguertaThemeTokens.spacing
+    val authTitleStyle = authRouteTitleStyle()
     Column(
         modifier = Modifier.fillMaxSize(),
     ) {
         AuthBackButton(onBack = onBack)
         Text(
             text = stringResource(R.string.register_title),
-            style = MaterialTheme.typography.displayLarge,
+            style = authTitleStyle,
             color = MaterialTheme.colorScheme.primary,
         )
         Spacer(modifier = Modifier.height(spacing.xl))
@@ -235,15 +238,15 @@ internal fun RecoverPasswordRoute(
     onResetEmailDialogAccepted: () -> Unit,
     onBack: () -> Unit,
 ) {
-    val adaptiveProfile = ReguertaAdaptive.profile
     val spacing = ReguertaThemeTokens.spacing
+    val authTitleStyle = authRouteTitleStyle()
     Column(
         modifier = Modifier.fillMaxSize(),
     ) {
         AuthBackButton(onBack = onBack)
         Text(
             text = stringResource(R.string.recover_title),
-            style = MaterialTheme.typography.displayLarge,
+            style = authTitleStyle,
             color = MaterialTheme.colorScheme.primary,
         )
         Spacer(modifier = Modifier.height(spacing.xl))
@@ -268,6 +271,16 @@ internal fun RecoverPasswordRoute(
             )
         }
     }
+}
+
+@Composable
+private fun authRouteTitleStyle(): TextStyle {
+    val typeScale = ReguertaAdaptive.profile.typographyScale
+    return MaterialTheme.typography.headlineSmall.copy(
+        fontWeight = FontWeight.Normal,
+        fontSize = (26f * typeScale).sp,
+        lineHeight = (32f * typeScale).sp,
+    )
 }
 
 @Composable

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeRoute.kt
@@ -1,17 +1,27 @@
 package com.reguerta.user.presentation.access
 
 import android.net.Uri
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
@@ -20,6 +30,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -28,9 +40,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.zIndex
 import androidx.compose.ui.platform.LocalContext
 import androidx.activity.compose.BackHandler
 import com.reguerta.user.R
@@ -51,6 +67,11 @@ import com.reguerta.user.ui.components.auth.ReguertaDialogAction
 import com.reguerta.user.ui.components.auth.ReguertaDialogType
 import com.reguerta.user.ui.components.auth.ReguertaFlatButton
 import kotlinx.coroutines.delay
+
+private const val HomeDrawerAnimationMillis = 400
+private const val HomeDrawerWidthFraction = 304f / 390f
+private const val HomeDrawerScrimAlpha = 0.15f
+
 @Composable
 internal fun HomeRoute(
     modifier: Modifier = Modifier,
@@ -277,140 +298,163 @@ internal fun HomeRoute(
     }
 
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
-        val drawerWidth = maxWidth * 0.78f
-        val resolvedDrawerWidth = if (drawerWidth > 320.dp) 320.dp else drawerWidth
+        val drawerWidth = maxWidth * HomeDrawerWidthFraction
+        val drawerAnimationSpec = tween<Dp>(
+            durationMillis = HomeDrawerAnimationMillis,
+            easing = FastOutSlowInEasing,
+        )
         val homeOffset by animateDpAsState(
-            targetValue = if (isDrawerOpen) resolvedDrawerWidth else 0.dp,
+            targetValue = if (isDrawerOpen) drawerWidth else 0.dp,
+            animationSpec = drawerAnimationSpec,
             label = "homeDrawerOffset",
         )
         val homeElevation by animateDpAsState(
             targetValue = if (isDrawerOpen) 12.dp else 0.dp,
+            animationSpec = drawerAnimationSpec,
             label = "homeDrawerElevation",
         )
+        val isHomeShifted = isDrawerOpen || homeOffset > 0.dp
 
         Surface(
-            modifier = Modifier
-                .fillMaxSize()
-                .widthIn(max = resolvedDrawerWidth),
+            modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.surface,
         ) {
-            Box(modifier = Modifier.widthIn(max = resolvedDrawerWidth)) {
-                HomeDrawerContent(
-                    member = member,
-                    sharedProfile = currentSharedProfile,
-                    currentDestination = currentDestination,
-                    installedVersion = installedVersion,
-                    isDevelopBuild = isDevelopImpersonationEnabled,
-                    onNavigate = ::handleDrawerNavigation,
-                    onCloseDrawer = ::closeDrawer,
-                    onSignOut = {
-                        closeDrawer()
-                        onSignOut()
-                    },
-                )
+            Row(modifier = Modifier.fillMaxSize()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .width(drawerWidth)
+                        .clipToBounds(),
+                ) {
+                    HomeDrawerContent(
+                        member = member,
+                        sharedProfile = currentSharedProfile,
+                        currentDestination = currentDestination,
+                        installedVersion = installedVersion,
+                        isDevelopBuild = isDevelopImpersonationEnabled,
+                        onNavigate = ::handleDrawerNavigation,
+                        onCloseDrawer = ::closeDrawer,
+                        onSignOut = {
+                            closeDrawer()
+                            onSignOut()
+                        },
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
             }
         }
 
-        Surface(
+        Box(
             modifier = Modifier
                 .fillMaxSize()
                 .offset(x = homeOffset)
-                .shadow(homeElevation),
-            color = MaterialTheme.colorScheme.background,
+                .shadow(homeElevation, clip = false)
+                .zIndex(1f),
         ) {
-        val usesRouteScroll =
-            currentDestination != HomeDestination.MY_ORDER &&
-                currentDestination != HomeDestination.MY_ORDERS &&
-                currentDestination != HomeDestination.RECEIVED_ORDERS &&
-                currentDestination != HomeDestination.RECEIVED_ORDERS_HISTORY &&
-                currentDestination != HomeDestination.PRODUCTS &&
-                currentDestination != HomeDestination.USERS &&
-                currentDestination != HomeDestination.NEWS &&
-                currentDestination != HomeDestination.PUBLISH_NEWS &&
-                currentDestination != HomeDestination.ADMIN_BROADCAST &&
-                currentDestination != HomeDestination.PROFILE &&
-                currentDestination != HomeDestination.SHIFTS
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .fillMaxSize()
-                .imePadding()
-                .padding(start = 16.dp, top = 0.dp, end = 16.dp, bottom = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            val showsMyOrderCartAction = currentDestination == HomeDestination.MY_ORDER && !isMyOrderReadOnlyMode
-            val homeShellTitle = when {
-                currentDestination == HomeDestination.DASHBOARD -> formatHomeTopBarDate(effectiveNowMillis)
-                currentDestination == HomeDestination.MY_ORDER && isMyOrderCartVisible && !isMyOrderReadOnlyMode -> {
-                    stringResource(R.string.my_order_cart_title)
-                }
-                currentDestination == HomeDestination.PUBLISH_NEWS && editingNewsId != null -> {
-                    stringResource(R.string.news_editor_title_edit)
-                }
-                currentDestination == HomeDestination.PROFILE && !sharedProfileTitleOverride.isNullOrBlank() -> {
-                    sharedProfileTitleOverride.orEmpty()
-                }
-                currentDestination == HomeDestination.MY_ORDERS -> {
-                    myOrdersHistoryTitleOverride ?: stringResource(R.string.my_orders_history_title_fallback)
-                }
-                currentDestination == HomeDestination.RECEIVED_ORDERS_HISTORY -> {
-                    receivedOrdersHistoryTitleOverride ?: stringResource(R.string.home_shell_action_received_orders)
-                }
-                else -> stringResource(currentDestination.titleRes())
-            }
-            HomeShellTopBar(
-                title = homeShellTitle,
-                canNavigateBack = currentDestination != HomeDestination.DASHBOARD,
-                showsNotificationsAction = currentDestination == HomeDestination.DASHBOARD,
-                hasNotificationIndicator = hasUnreadNotifications,
-                showsCartAction = showsMyOrderCartAction,
-                cartUnits = myOrderCartUnits,
-                onBack = {
-                    if (currentDestination == HomeDestination.PUBLISH_NEWS) {
-                        onClearNewsEditor()
-                    } else if (currentDestination == HomeDestination.ADMIN_BROADCAST) {
-                        onClearNotificationEditor()
-                    } else if (currentDestination == HomeDestination.PRODUCTS) {
-                        onClearProductEditor()
-                    } else if (currentDestination == HomeDestination.SHIFT_SWAP_REQUEST) {
-                        onClearShiftSwapDraft()
-                    } else if (currentDestination == HomeDestination.MY_ORDER) {
-                        isMyOrderCartVisible = false
-                    }
-                    navigateHome(when (currentDestination) {
-                        HomeDestination.PUBLISH_NEWS -> HomeDestination.NEWS
-                        HomeDestination.ADMIN_BROADCAST -> HomeDestination.NOTIFICATIONS
-                        HomeDestination.SHIFT_SWAP_REQUEST -> HomeDestination.SHIFTS
-                        else -> HomeDestination.DASHBOARD
-                    })
-                },
-                onOpenMenu = {
-                    isDrawerOpen = true
-                },
-                onOpenNotifications = {
-                    navigateHome(HomeDestination.NOTIFICATIONS)
-                },
-                onOpenCart = {
-                    myOrderCartOpenRequests += 1
-                },
-            )
-            Column(
-                modifier = if (usesRouteScroll) {
-                    Modifier
-                        .fillMaxWidth()
-                        .weight(1f)
-                        .verticalScroll(rememberScrollState())
-                } else {
-                    Modifier
-                        .fillMaxWidth()
-                        .weight(1f)
-                },
-                verticalArrangement = if (usesRouteScroll) {
-                    Arrangement.spacedBy(16.dp)
-                } else {
-                    Arrangement.Top
-                },
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                color = MaterialTheme.colorScheme.background,
             ) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                val usesRouteScroll =
+                    currentDestination != HomeDestination.MY_ORDER &&
+                        currentDestination != HomeDestination.MY_ORDERS &&
+                        currentDestination != HomeDestination.RECEIVED_ORDERS &&
+                        currentDestination != HomeDestination.RECEIVED_ORDERS_HISTORY &&
+                        currentDestination != HomeDestination.PRODUCTS &&
+                        currentDestination != HomeDestination.USERS &&
+                        currentDestination != HomeDestination.NEWS &&
+                        currentDestination != HomeDestination.PUBLISH_NEWS &&
+                        currentDestination != HomeDestination.ADMIN_BROADCAST &&
+                        currentDestination != HomeDestination.PROFILE &&
+                        currentDestination != HomeDestination.SHIFTS
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .fillMaxSize()
+                        .windowInsetsPadding(
+                            WindowInsets.safeDrawing.only(
+                                WindowInsetsSides.Horizontal + WindowInsetsSides.Top,
+                            ),
+                        )
+                        .imePadding()
+                        .padding(start = 16.dp, top = 0.dp, end = 16.dp, bottom = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    val showsMyOrderCartAction = currentDestination == HomeDestination.MY_ORDER && !isMyOrderReadOnlyMode
+                    val homeShellTitle = when {
+                        currentDestination == HomeDestination.DASHBOARD -> formatHomeTopBarDate(effectiveNowMillis)
+                        currentDestination == HomeDestination.MY_ORDER && isMyOrderCartVisible && !isMyOrderReadOnlyMode -> {
+                            stringResource(R.string.my_order_cart_title)
+                        }
+                        currentDestination == HomeDestination.PUBLISH_NEWS && editingNewsId != null -> {
+                            stringResource(R.string.news_editor_title_edit)
+                        }
+                        currentDestination == HomeDestination.NOTIFICATIONS -> ""
+                        currentDestination == HomeDestination.PROFILE && !sharedProfileTitleOverride.isNullOrBlank() -> {
+                            sharedProfileTitleOverride.orEmpty()
+                        }
+                        currentDestination == HomeDestination.MY_ORDERS -> {
+                            myOrdersHistoryTitleOverride ?: stringResource(R.string.my_orders_history_title_fallback)
+                        }
+                        currentDestination == HomeDestination.RECEIVED_ORDERS_HISTORY -> {
+                            receivedOrdersHistoryTitleOverride ?: stringResource(R.string.home_shell_action_received_orders)
+                        }
+                        else -> stringResource(currentDestination.titleRes())
+                    }
+                    HomeShellTopBar(
+                        title = homeShellTitle,
+                        canNavigateBack = currentDestination != HomeDestination.DASHBOARD,
+                        showsNotificationsAction = currentDestination == HomeDestination.DASHBOARD,
+                        hasNotificationIndicator = hasUnreadNotifications,
+                        showsCartAction = showsMyOrderCartAction,
+                        cartUnits = myOrderCartUnits,
+                        onBack = {
+                            if (currentDestination == HomeDestination.PUBLISH_NEWS) {
+                                onClearNewsEditor()
+                            } else if (currentDestination == HomeDestination.ADMIN_BROADCAST) {
+                                onClearNotificationEditor()
+                            } else if (currentDestination == HomeDestination.PRODUCTS) {
+                                onClearProductEditor()
+                            } else if (currentDestination == HomeDestination.SHIFT_SWAP_REQUEST) {
+                                onClearShiftSwapDraft()
+                            } else if (currentDestination == HomeDestination.MY_ORDER) {
+                                isMyOrderCartVisible = false
+                            }
+                            navigateHome(when (currentDestination) {
+                                HomeDestination.PUBLISH_NEWS -> HomeDestination.NEWS
+                                HomeDestination.ADMIN_BROADCAST -> HomeDestination.NOTIFICATIONS
+                                HomeDestination.SHIFT_SWAP_REQUEST -> HomeDestination.SHIFTS
+                                else -> HomeDestination.DASHBOARD
+                            })
+                        },
+                        onOpenMenu = {
+                            isDrawerOpen = true
+                        },
+                        onOpenNotifications = {
+                            navigateHome(HomeDestination.NOTIFICATIONS)
+                        },
+                        onOpenCart = {
+                            myOrderCartOpenRequests += 1
+                        },
+                    )
+                    Column(
+                        modifier = if (usesRouteScroll) {
+                            Modifier
+                                .fillMaxWidth()
+                                .weight(1f)
+                                .verticalScroll(rememberScrollState())
+                        } else {
+                            Modifier
+                                .fillMaxWidth()
+                                .weight(1f)
+                        },
+                        verticalArrangement = if (usesRouteScroll) {
+                            Arrangement.spacedBy(16.dp)
+                        } else {
+                            Arrangement.Top
+                        },
+                    ) {
                 when (currentDestination) {
                     HomeDestination.DASHBOARD -> {
                     when (mode) {
@@ -469,6 +513,12 @@ internal fun HomeRoute(
                             navigateHome(HomeDestination.NEWS)
                         },
                         modifier = Modifier.padding(bottom = 16.dp),
+                    )
+                    Spacer(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .navigationBarsPadding()
+                            .padding(bottom = 16.dp),
                     )
                     }
 
@@ -701,17 +751,22 @@ internal fun HomeRoute(
                         onClear = onClearBylawsResult,
                     )
 
+                    }
                 }
-            }
-            if (isDrawerOpen) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .clickable(onClick = ::closeDrawer),
-                )
+                }
+
+                if (isHomeShifted) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color.Black.copy(alpha = HomeDrawerScrimAlpha))
+                            .clickable(onClick = ::closeDrawer),
+                    )
+                }
+
             }
         }
-    }
+
     }
 
     pendingSavedNewsId?.let {
@@ -798,4 +853,5 @@ internal fun HomeRoute(
             onDismissRequest = onDismissPushNotificationPermissionDialog,
         )
     }
+}
 }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeShellComponents.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeShellComponents.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -25,7 +26,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Campaign
 import androidx.compose.material.icons.filled.Group
-import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Inbox
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Notifications
@@ -180,7 +180,8 @@ fun HomeDrawerContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp, vertical = 20.dp),
+            .safeDrawingPadding()
+            .padding(start = 16.dp, top = 0.dp, end = 16.dp, bottom = 20.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Row(
@@ -189,7 +190,7 @@ fun HomeDrawerContent(
         ) {
             IconButton(
                 onClick = onCloseDrawer,
-                modifier = Modifier.size(36.dp),
+                modifier = Modifier.size(48.dp),
             ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
@@ -227,18 +228,6 @@ fun HomeDrawerContent(
                 .verticalScroll(drawerScrollState),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            HomeDrawerItem(
-                icon = Icons.Filled.Home,
-                label = stringResource(R.string.home_title),
-                selected = currentDestination == HomeDestination.DASHBOARD,
-                onClick = { onNavigate(HomeDestination.DASHBOARD) },
-            )
-            HomeDrawerItem(
-                icon = Icons.Filled.ShoppingCart,
-                label = stringResource(R.string.module_my_order),
-                selected = currentDestination == HomeDestination.MY_ORDER,
-                onClick = { onNavigate(HomeDestination.MY_ORDER) },
-            )
             HomeDrawerItem(
                 icon = Icons.AutoMirrored.Filled.Article,
                 label = stringResource(R.string.module_my_orders),
@@ -438,6 +427,8 @@ private fun HomeDrawerItem(
             text = label,
             style = MaterialTheme.typography.bodyLarge,
             modifier = Modifier.weight(1f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }
@@ -532,7 +523,7 @@ fun LatestNewsCard(
         Text(
             text = stringResource(R.string.home_shell_news_title),
             modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.titleMedium,
+            style = MaterialTheme.typography.headlineSmall,
             fontWeight = FontWeight.SemiBold,
             textAlign = TextAlign.Center,
         )

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootNewsNotificationsRoutes.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootNewsNotificationsRoutes.kt
@@ -347,7 +347,17 @@ fun NotificationsFeedRoute(
     notificationItems: List<NotificationFeedItem>,
     isLoading: Boolean,
 ) {
-    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.home_shell_notifications),
+            modifier = Modifier.fillMaxWidth(),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
         if (isLoading) {
             Text(
                 text = stringResource(R.string.notifications_loading),
@@ -362,14 +372,20 @@ fun NotificationsFeedRoute(
             )
         } else {
             notificationItems.forEach { item ->
-                NotificationFeedItemCard(item = item)
+                NotificationFeedItemCard(
+                    item = item,
+                    modifier = Modifier.fillMaxWidth(),
+                )
             }
         }
     }
 }
 
 @Composable
-private fun NotificationFeedItemCard(item: NotificationFeedItem) {
+private fun NotificationFeedItemCard(
+    item: NotificationFeedItem,
+    modifier: Modifier = Modifier,
+) {
     val event = item.notification
     val containerColor = if (item.isRead) {
         MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)
@@ -377,9 +393,13 @@ private fun NotificationFeedItemCard(item: NotificationFeedItem) {
         ColorFeedbackWarningDefault.copy(alpha = 0.15f)
     }
 
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
         Text(
             text = event.sentAtMillis.toNotificationDateLabel(),
+            modifier = Modifier.fillMaxWidth(),
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Type.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Type.kt
@@ -70,5 +70,17 @@ internal fun reguertaTypography(scale: Float = 1f): Typography {
             fontSize = (14f * safeScale).sp,
             lineHeight = (18f * safeScale).sp,
         ),
+        labelMedium = TextStyle(
+            fontFamily = CabinSketch,
+            fontWeight = FontWeight.Normal,
+            fontSize = (14f * safeScale).sp,
+            lineHeight = (18f * safeScale).sp,
+        ),
+        labelSmall = TextStyle(
+            fontFamily = CabinSketch,
+            fontWeight = FontWeight.Normal,
+            fontSize = (12f * safeScale).sp,
+            lineHeight = (16f * safeScale).sp,
+        ),
     )
 }

--- a/android/Reguerta/app/src/main/res/values-es/strings.xml
+++ b/android/Reguerta/app/src/main/res/values-es/strings.xml
@@ -68,14 +68,14 @@
     <string name="home_shell_section_common">Común</string>
     <string name="home_shell_section_producer">Productor</string>
     <string name="home_shell_section_admin">Admin</string>
-    <string name="module_my_orders">Ver mis pedidos</string>
+    <string name="module_my_orders">Todos mis pedidos</string>
     <string name="home_shell_action_products">Productos</string>
     <string name="home_shell_action_received_orders">Pedidos recibidos</string>
     <string name="home_shell_action_received_orders_history">Histórico de pedidos</string>
     <string name="home_shell_action_users">Usuarios</string>
     <string name="home_shell_action_profile">Comunidad</string>
     <string name="home_shell_action_settings">Ajustes</string>
-    <string name="home_shell_action_bylaws">IA estatutos</string>
+    <string name="home_shell_action_bylaws">Consultar estatutos</string>
     <string name="home_shell_action_news">Noticias</string>
     <string name="home_shell_action_publish_news">Nueva noticia</string>
     <string name="home_shell_action_admin_broadcast">Mandar notificación</string>

--- a/android/Reguerta/app/src/main/res/values/strings.xml
+++ b/android/Reguerta/app/src/main/res/values/strings.xml
@@ -68,14 +68,14 @@
     <string name="home_shell_section_common">Common</string>
     <string name="home_shell_section_producer">Producer</string>
     <string name="home_shell_section_admin">Admin</string>
-    <string name="module_my_orders">View my orders</string>
+    <string name="module_my_orders">All my orders</string>
     <string name="home_shell_action_products">Products</string>
     <string name="home_shell_action_received_orders">Received orders</string>
     <string name="home_shell_action_received_orders_history">Order history</string>
     <string name="home_shell_action_users">Users</string>
     <string name="home_shell_action_profile">Community</string>
     <string name="home_shell_action_settings">Settings</string>
-    <string name="home_shell_action_bylaws">Bylaws AI</string>
+    <string name="home_shell_action_bylaws">Consult bylaws</string>
     <string name="home_shell_action_news">News</string>
     <string name="home_shell_action_publish_news">New news</string>
     <string name="home_shell_action_admin_broadcast">Send notification</string>

--- a/ios/Reguerta/Reguerta/Presentation/Auth/ContentView+AuthRoutes.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/ContentView+AuthRoutes.swift
@@ -20,6 +20,7 @@ extension AccessRootRoutingView {
     var welcomeRoute: some View {
         VStack(spacing: tokens.spacing.md) {
             Spacer(minLength: tokens.spacing.md)
+                .frame(maxHeight: 112.resize)
 
             Text(localizedKey(AccessL10nKey.welcomeTitlePrefix))
                 .font(.custom("CabinSketch-Regular", size: 22.resize, relativeTo: .headline))

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellComponents.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellComponents.swift
@@ -97,7 +97,7 @@ struct HomeWeeklySummaryCardView: View {
                     .minimumScaleFactor(0.78)
                 Spacer(minLength: tokens.spacing.sm)
                 Text(display.weekBadgeLabel)
-                    .font(tokens.typography.label)
+                    .font(tokens.typography.labelRegular)
                     .foregroundStyle(tokens.colors.actionPrimary)
                     .padding(.horizontal, tokens.spacing.sm)
                     .padding(.vertical, tokens.spacing.xs)

--- a/spec/app/hu-060-android-drawer-notifications-ui/plan.md
+++ b/spec/app/hu-060-android-drawer-notifications-ui/plan.md
@@ -1,0 +1,26 @@
+# Plan - HU-060 (Android/iOS UI spacing and text polish)
+
+## Approach
+
+Keep this as a focused UI polish pass. Reuse the existing drawer, auth, home, welcome, and notifications routes; do not introduce new navigation state or domain behavior.
+
+## Implementation steps
+
+1. Inspect iOS drawer labels and Android string resources for equivalent route names.
+2. Update Android drawer labels/localization to match iOS semantics.
+3. Adjust Android drawer width and animation timing in the home shell.
+4. Verify the drawer still respects current role-based visibility.
+5. Inspect Android notifications route layout and align title/date headers with the notification card content column.
+6. Tune welcome, auth, home week badge, and latest news typography/spacing from the Android/iOS screenshot comparison.
+7. Run focused Android validation, Android instrumented validation, and iOS build validation for SwiftUI changes.
+
+## Validation
+
+- Android: `./gradlew app:testDebugUnitTest`
+- Android: `./gradlew app:lintDebug`
+- Android: `./gradlew app:connectedDebugAndroidTest` when an emulator/device is available because drawer/notificaciones are UI-facing.
+- iOS: `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' build` for SwiftUI changes.
+
+## Notes
+
+- iOS is the primary reference for copy and visual rhythm, but small iOS spacing/typography corrections are allowed when the comparison shows Android is closer to the intended balance.

--- a/spec/app/hu-060-android-drawer-notifications-ui/spec.md
+++ b/spec/app/hu-060-android-drawer-notifications-ui/spec.md
@@ -1,0 +1,72 @@
+# HU-060 - Android/iOS UI spacing and text polish
+
+## Metadata
+- issue_id: 157
+- priority: P2
+- platform: android, ios
+- status: in-progress
+
+## Context and problem
+
+Several Android screens diverge from the iOS visual reference used during review, while a few iOS details also need small spacing or typography corrections.
+
+The Android drawer currently exposes route names that do not match the iOS route semantics, opens too quickly, and visually extends too far across the screen. The notifications feed also places date headers too far from the left alignment used by the notification cards; iOS keeps those dates under the screen title and aligned with the content column. Follow-up screenshot review also identified spacing and typography differences in welcome, auth, home week badges, latest news headings, and notification hierarchy.
+
+## User story
+
+As a member I want the app's main entry, home, drawer, and notifications screens to use coherent spacing, route names, and typography across Android and iOS.
+
+## Scope
+
+### In Scope
+- Align Android drawer item labels with the iOS labels for equivalent routes.
+- Tune Android drawer open/close animation to feel less abrupt.
+- Adjust Android drawer width/placement so it remains visually contained while preserving the menu button state.
+- Align Android notification date headers with the notification cards and title hierarchy.
+- Adjust Android welcome/auth/home typography and spacing where it clearly diverges from the iOS reference.
+- Apply small iOS welcome/home typography adjustments when the cross-platform comparison shows Android is closer to the intended balance.
+- Consult iOS source and screenshots as the reference for copy and layout intent.
+
+### Out of Scope
+- Changing role/capability rules for drawer visibility.
+- Changing notification read-state behavior.
+- Backend, Firestore, or Cloud Functions changes.
+- Pixel-perfect iOS rewrites.
+- Final redesign of home order buttons after light/dark review.
+
+## Acceptance criteria
+
+- Android drawer labels match iOS route semantics:
+  - all personal orders/history routes use the same conceptual names as iOS,
+  - shifts/bylaws/news/community/settings/products/order-history/users/sign-out remain distinguishable and consistent.
+- Android drawer width leaves the home content visible like the iOS reference instead of covering nearly the full screen.
+- Android drawer animation is slower and smoother than the current abrupt transition.
+- Android notifications date headers are placed below the `Notifications` title and aligned with notification cards.
+- Android welcome logo/title spacing is calmer and the auth title is less oversized.
+- The week badge uses the app font and a regular weight on both platforms.
+- Latest news heading hierarchy is closer between platforms.
+- No route loses its existing role-based visibility.
+- Android validation passes for the touched app area and iOS builds after the small SwiftUI adjustments.
+
+## Dependencies
+
+- Existing HU-039/HU-040 home shell and drawer navigation.
+- Existing HU-056 notifications feed.
+- iOS drawer and notification layouts as visual reference.
+
+## Risks
+
+- Risk: renaming drawer items changes expected tests or localization strings.
+  - Mitigation: update only labels for existing destinations and keep destination identifiers unchanged.
+- Risk: slowing drawer animation makes navigation feel laggy.
+  - Mitigation: use a modest duration increase and keep gestures/taps responsive.
+- Risk: width changes hide drawer content on narrow Android screens.
+  - Mitigation: use responsive width constraints and keep text truncation.
+
+## Definition of Done (DoD)
+
+- [x] Acceptance criteria validated on Android.
+- [x] iOS reference checked where labels or spacing are ambiguous.
+- [x] Android tests/lint run according to AGENTS.md.
+- [x] iOS build run after SwiftUI changes.
+- [x] Documentation/tasks updated with validation evidence.

--- a/spec/app/hu-060-android-drawer-notifications-ui/tasks.md
+++ b/spec/app/hu-060-android-drawer-notifications-ui/tasks.md
@@ -1,0 +1,41 @@
+# Tasks - HU-060 (Android/iOS UI spacing and text polish)
+
+GitHub tracking:
+
+- #157 - Pulir espacios y textos UI Android/iOS.
+
+## 1. Bootstrap
+- [x] Create GitHub issue.
+- [x] Create branch `codex/hu-060-android-drawer-notifications-ui`.
+- [x] Add issue mirror, spec, plan, and tasks.
+
+## 2. Drawer
+- [x] Compare iOS drawer labels against Android drawer labels.
+- [x] Update Android drawer copy/localization for equivalent routes.
+- [x] Tune Android drawer open/close animation duration.
+- [x] Adjust Android drawer width/containment.
+- [x] Verify role-based visibility remains unchanged.
+
+## 3. Notifications
+- [x] Compare iOS notifications date/title/card alignment.
+- [x] Align Android notification date headers with the notification cards.
+- [x] Verify empty/loading states still look acceptable.
+
+## 4. Validation
+- [x] Run Android unit tests.
+- [x] Run Android lint.
+- [x] Run Android instrumented tests or document why unavailable.
+- [x] Run iOS build after SwiftUI adjustments.
+- [x] Record manual visual checks.
+
+Validation evidence:
+
+- `./gradlew app:testDebugUnitTest app:lintDebug` passed.
+- `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest` passed on Pixel_4_A12_API29 AVD.
+- `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' build` passed.
+- `xcodebuild ... test` was attempted first; the app compiled but the simulator refused to launch `com.plusprojects.ReguertaUITests.xctrunner` with `FBSOpenApplicationServiceErrorDomain Code=1 RequestDenied`, so build-only was used to validate the SwiftUI changes.
+- Manual source check: iOS drawer, welcome, home, and notifications SwiftUI routes were used as copy/alignment references.
+
+## 5. Closure
+- [x] Update task status and validation evidence.
+- [ ] Open PR linked to #157.

--- a/spec/issues/hu-060-android-drawer-notifications-ui-issue.md
+++ b/spec/issues/hu-060-android-drawer-notifications-ui-issue.md
@@ -1,0 +1,52 @@
+# [HU-060] Pulir espacios y textos UI Android/iOS
+
+## Summary
+
+Pulir espacios, jerarquía tipográfica y textos en pantallas clave de Android/iOS, tomando iOS como referencia cuando ya esté mejor resuelto y ajustando ambos lados cuando convenga mantener coherencia visual.
+
+## Links
+- GitHub Issue: #157
+- URL: https://github.com/JFrancoG/ReguertaPlus/issues/157
+- Spec: spec/app/hu-060-android-drawer-notifications-ui/spec.md
+- Plan: spec/app/hu-060-android-drawer-notifications-ui/plan.md
+- Tasks: spec/app/hu-060-android-drawer-notifications-ui/tasks.md
+
+## Acceptance criteria
+
+- El menú lateral Android usa nombres equivalentes a los de iOS para las mismas rutas funcionales.
+- El drawer Android abre con una animación más pausada y natural.
+- El drawer Android queda dentro de la composición visible, manteniendo el botón de menú/estado esperado.
+- La pantalla Android de Notificaciones coloca la fecha debajo del título y alineada con las cards.
+- La bienvenida, login/registro y home ajustan tamaños/posiciones/fuentes donde las capturas muestran diferencias claras.
+- Se consulta la implementación iOS cuando la captura no sea suficiente para igualar estructura o textos.
+- La validación Android relevante pasa antes de cerrar la PR y los cambios iOS compilan.
+
+## Scope
+
+### In Scope
+- Android side drawer copy, width, and open/close animation.
+- Android notifications feed title/date alignment.
+- Android welcome/auth/home spacing and typography polish.
+- Small iOS welcome/home typography adjustments where Android/iOS comparison showed imbalance.
+- iOS as reference for naming, spacing, and hierarchy where appropriate.
+- Focused documentation and validation evidence.
+
+### Out of Scope
+- Backend or Firestore changes.
+- New notification behavior.
+- Broad iOS redesign.
+- Final redesign of home order buttons after light/dark review.
+
+## Implementation checklist
+- [x] Android drawer
+- [x] Android notifications
+- [x] iOS reference review
+- [x] Testing
+- [x] Documentation
+
+## Suggested labels
+- type:feature
+- area:app
+- area:notifications
+- platform:android
+- priority:P2


### PR DESCRIPTION
## Summary
- Polish Android drawer structure, animation, scrim, labels, and alignment against the iOS baseline.
- Tune Android home/auth/notifications typography and spacing, plus small iOS welcome/week-badge parity tweaks.
- Add HU-060 docs and an Android instrumentation check for the drawer labels.

## Validation
- ✅ `git diff --check`
- ✅ Android: `./gradlew app:testDebugUnitTest app:lintDebug`
- ✅ Android: `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest`
- ✅ iOS: `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination "platform=iOS Simulator,name=iPhone 17" build`
- ⚠️ iOS full test: `ReguertaUITests.testMyOrderSearchBarStaysAboveBottomSafeArea()` fails and also fails when run alone; this is outside the HU-060 touched surfaces.

Closes #157