### PR TITLE
HU-061: Confirm drawer sign-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- 2026-07-08 | ✨ feat(access): confirm drawer sign-out
 - 2026-05-27 | ✨ feat(shifts): redesign shifts screen
 - 2026-05-26 | ✨ feat(orders): add received order history
 - 2026-05-25 | ✨ feat(orders): add weekly order history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - 2026-07-10 | 🐛 fix(shifts): align helper assignments
+- 2026-07-08 | 🐛 fix(ios-ui): refine welcome layout
 - 2026-07-08 | 🐛 fix(android-orders): polish order cards
 - 2026-07-07 | 🐛 fix(ui): polish drawer and mobile spacing
 - 2026-07-07 | 🐛 fix(home): align weekly delivery summary

--- a/android/Reguerta/app/src/androidTest/java/com/reguerta/user/HomeDrawerContentTest.kt
+++ b/android/Reguerta/app/src/androidTest/java/com/reguerta/user/HomeDrawerContentTest.kt
@@ -5,13 +5,16 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.reguerta.user.domain.access.Member
 import com.reguerta.user.domain.access.MemberRole
 import com.reguerta.user.domain.profiles.SharedProfile
 import com.reguerta.user.presentation.access.HomeDestination
 import com.reguerta.user.presentation.access.HomeDrawerContent
+import com.reguerta.user.presentation.access.HomeDrawerContentWithLogoutConfirmation
 import com.reguerta.user.ui.theme.ReguertaTheme
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 
@@ -49,6 +52,102 @@ class HomeDrawerContentTest {
         composeRule.onNodeWithText("Users").performScrollTo().assertIsDisplayed()
         composeRule.onNodeWithText("Send notification").performScrollTo().assertIsDisplayed()
         composeRule.onNodeWithText("Sign out").assertIsDisplayed()
+    }
+
+    @Test
+    fun drawerSignOutClickShowsConfirmationBeforeSigningOut() {
+        var confirmCount = 0
+
+        composeRule.setContent {
+            ReguertaTheme {
+                HomeDrawerContentWithLogoutConfirmation(
+                    member = fullAccessMember(),
+                    sharedProfile = sharedProfile(),
+                    currentDestination = HomeDestination.DASHBOARD,
+                    installedVersion = "0.3.0.1",
+                    isDevelopBuild = true,
+                    onNavigate = {},
+                    onCloseDrawer = {},
+                    onSignOut = { confirmCount += 1 },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Sign out").performClick()
+        composeRule.waitUntil(timeoutMillis = 1_000) {
+            runCatching {
+                composeRule.onNodeWithText("Are you sure you want to sign out?").assertIsDisplayed()
+            }.isSuccess
+        }
+
+        composeRule.onNodeWithText("Are you sure you want to sign out?").assertIsDisplayed()
+        composeRule.runOnIdle {
+            assertEquals(0, confirmCount)
+        }
+    }
+
+    @Test
+    fun logoutConfirmationCancelKeepsSessionActive() {
+        var confirmCount = 0
+
+        composeRule.setContent {
+            ReguertaTheme {
+                HomeDrawerContentWithLogoutConfirmation(
+                    member = fullAccessMember(),
+                    sharedProfile = sharedProfile(),
+                    currentDestination = HomeDestination.DASHBOARD,
+                    installedVersion = "0.3.0.1",
+                    isDevelopBuild = true,
+                    onNavigate = {},
+                    onCloseDrawer = {},
+                    onSignOut = { confirmCount += 1 },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Sign out").performClick()
+        composeRule.waitUntil(timeoutMillis = 1_000) {
+            runCatching {
+                composeRule.onNodeWithText("Are you sure you want to sign out?").assertIsDisplayed()
+            }.isSuccess
+        }
+        composeRule.onNodeWithText("Back").performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(0, confirmCount)
+        }
+    }
+
+    @Test
+    fun logoutConfirmationConfirmInvokesSignOutOnce() {
+        var confirmCount = 0
+
+        composeRule.setContent {
+            ReguertaTheme {
+                HomeDrawerContentWithLogoutConfirmation(
+                    member = fullAccessMember(),
+                    sharedProfile = sharedProfile(),
+                    currentDestination = HomeDestination.DASHBOARD,
+                    installedVersion = "0.3.0.1",
+                    isDevelopBuild = true,
+                    onNavigate = {},
+                    onCloseDrawer = {},
+                    onSignOut = { confirmCount += 1 },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Sign out").performClick()
+        composeRule.waitUntil(timeoutMillis = 1_000) {
+            runCatching {
+                composeRule.onNodeWithText("Are you sure you want to sign out?").assertIsDisplayed()
+            }.isSuccess
+        }
+        composeRule.onNodeWithText("Confirm").performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(1, confirmCount)
+        }
     }
 
     private fun fullAccessMember(): Member =

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeRoute.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.zIndex
@@ -71,6 +72,7 @@ import kotlinx.coroutines.delay
 private const val HomeDrawerAnimationMillis = 400
 private const val HomeDrawerWidthFraction = 304f / 390f
 private const val HomeDrawerScrimAlpha = 0.15f
+private const val HomeLogoutConfirmationDelayMillis = 80L
 
 @Composable
 internal fun HomeRoute(
@@ -322,7 +324,7 @@ internal fun HomeRoute(
                         .width(drawerWidth)
                         .clipToBounds(),
                 ) {
-                    HomeDrawerContent(
+                    HomeDrawerContentWithLogoutConfirmation(
                         member = member,
                         sharedProfile = currentSharedProfile,
                         currentDestination = currentDestination,
@@ -330,10 +332,7 @@ internal fun HomeRoute(
                         isDevelopBuild = isDevelopImpersonationEnabled,
                         onNavigate = ::handleDrawerNavigation,
                         onCloseDrawer = ::closeDrawer,
-                        onSignOut = {
-                            closeDrawer()
-                            onSignOut()
-                        },
+                        onSignOut = onSignOut,
                     )
                 }
                 Spacer(modifier = Modifier.weight(1f))
@@ -343,7 +342,7 @@ internal fun HomeRoute(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .offset(x = homeOffset)
+                .offset { IntOffset(homeOffset.roundToPx(), 0) }
                 .shadow(homeElevation, clip = false)
                 .zIndex(1f),
         ) {
@@ -761,7 +760,6 @@ internal fun HomeRoute(
         }
 
     }
-
     pendingSavedNewsId?.let {
         ReguertaDialog(
             type = ReguertaDialogType.INFO,
@@ -847,4 +845,77 @@ internal fun HomeRoute(
         )
     }
 }
+}
+
+@Composable
+fun HomeDrawerContentWithLogoutConfirmation(
+    member: Member?,
+    sharedProfile: SharedProfile?,
+    currentDestination: HomeDestination,
+    installedVersion: String,
+    isDevelopBuild: Boolean,
+    onNavigate: (HomeDestination) -> Unit,
+    onCloseDrawer: () -> Unit,
+    onSignOut: () -> Unit,
+) {
+    var showLogoutConfirmationDialog by rememberSaveable { mutableStateOf(false) }
+    var logoutConfirmationRequestCount by rememberSaveable { mutableIntStateOf(0) }
+
+    LaunchedEffect(logoutConfirmationRequestCount) {
+        if (logoutConfirmationRequestCount == 0) {
+            return@LaunchedEffect
+        }
+        delay(HomeLogoutConfirmationDelayMillis)
+        showLogoutConfirmationDialog = true
+    }
+
+    fun dismissLogoutConfirmation() {
+        showLogoutConfirmationDialog = false
+    }
+
+    HomeDrawerContent(
+        member = member,
+        sharedProfile = sharedProfile,
+        currentDestination = currentDestination,
+        installedVersion = installedVersion,
+        isDevelopBuild = isDevelopBuild,
+        onNavigate = onNavigate,
+        onCloseDrawer = onCloseDrawer,
+        onSignOut = {
+            onCloseDrawer()
+            showLogoutConfirmationDialog = false
+            logoutConfirmationRequestCount += 1
+        },
+    )
+
+    if (showLogoutConfirmationDialog) {
+        HomeLogoutConfirmationDialog(
+            onConfirmSignOut = {
+                showLogoutConfirmationDialog = false
+                onSignOut()
+            },
+            onDismiss = ::dismissLogoutConfirmation,
+        )
+    }
+}
+
+@Composable
+private fun HomeLogoutConfirmationDialog(
+    onConfirmSignOut: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ReguertaDialog(
+        type = ReguertaDialogType.INFO,
+        title = stringResource(R.string.access_action_sign_out),
+        message = stringResource(R.string.access_action_sign_out_confirm_message),
+        primaryAction = ReguertaDialogAction(
+            label = stringResource(R.string.common_action_confirm),
+            onClick = onConfirmSignOut,
+        ),
+        secondaryAction = ReguertaDialogAction(
+            label = stringResource(R.string.common_action_back),
+            onClick = onDismiss,
+        ),
+        onDismissRequest = onDismiss,
+    )
 }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaDialog.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/auth/ReguertaDialog.kt
@@ -1,22 +1,27 @@
 package com.reguerta.user.ui.components.auth
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -51,21 +56,26 @@ fun ReguertaDialog(
     onDismissRequest: () -> Unit = {},
 ) {
     val spacing = ReguertaThemeTokens.spacing
-    val radius = ReguertaThemeTokens.radius
-    val buttonTokens = ReguertaThemeTokens.button
     val dialogTitleStyle = MaterialTheme.typography.headlineMedium.copy(
-        fontSize = 20.sp,
-        lineHeight = 26.sp,
+        fontSize = 24.sp,
+        lineHeight = 30.sp,
     )
     val dialogBodyStyle = MaterialTheme.typography.bodyMedium.copy(
-        fontSize = 13.sp,
-        lineHeight = 18.sp,
+        fontSize = 17.sp,
+        lineHeight = 24.sp,
     )
     val accentColor = if (type == ReguertaDialogType.ERROR) {
         MaterialTheme.colorScheme.error
     } else {
         MaterialTheme.colorScheme.primary
     }
+    val primaryActionTextColor = if (type == ReguertaDialogType.ERROR) {
+        MaterialTheme.colorScheme.onError
+    } else {
+        MaterialTheme.colorScheme.onPrimary
+    }
+    val dialogShape = RoundedCornerShape(26.dp)
+    val dialogTextSecondary = MaterialTheme.colorScheme.onSurfaceVariant
 
     Dialog(
         onDismissRequest = onDismissRequest,
@@ -77,18 +87,20 @@ fun ReguertaDialog(
     ) {
         Surface(
             modifier = Modifier
-                .fillMaxWidth(0.92f)
-                .widthIn(max = 360.dp),
-            shape = RoundedCornerShape(radius.lg),
+                .fillMaxWidth(0.86f)
+                .widthIn(max = 336.dp),
+            shape = dialogShape,
             color = MaterialTheme.colorScheme.surface,
-            tonalElevation = 2.dp,
+            border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.65f)),
+            tonalElevation = 0.dp,
+            shadowElevation = 8.dp,
         ) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(spacing.lg),
+                    .padding(horizontal = spacing.xxl, vertical = 28.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(spacing.md),
+                verticalArrangement = Arrangement.spacedBy(spacing.lg),
             ) {
                 DialogIcon(type = type, accentColor = accentColor)
 
@@ -102,8 +114,8 @@ fun ReguertaDialog(
                 Text(
                     text = message,
                     style = dialogBodyStyle,
-                    modifier = Modifier.padding(top = 4.dp, bottom = 8.dp),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = spacing.sm),
+                    color = dialogTextSecondary,
                     textAlign = TextAlign.Center,
                 )
 
@@ -111,46 +123,93 @@ fun ReguertaDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(top = 8.dp),
-                        horizontalArrangement = Arrangement.spacedBy(spacing.sm, Alignment.CenterHorizontally),
+                            .padding(top = spacing.xs),
+                        horizontalArrangement = Arrangement.spacedBy(spacing.md, Alignment.CenterHorizontally),
                     ) {
-                        ReguertaButton(
+                        DialogActionButton(
                             label = secondaryAction.label,
                             onClick = secondaryAction.onClick,
-                            variant = ReguertaButtonVariant.SECONDARY,
-                            fullWidth = false,
-                            modifier = Modifier.width(buttonTokens.dialogTwoButtonsWidth),
+                            accentColor = accentColor,
+                            primaryContentColor = primaryActionTextColor,
+                            isPrimary = false,
+                            modifier = Modifier.weight(1f),
                         )
 
-                        ReguertaButton(
+                        DialogActionButton(
                             label = primaryAction.label,
                             onClick = primaryAction.onClick,
-                            variant = if (type == ReguertaDialogType.ERROR) {
-                                ReguertaButtonVariant.DESTRUCTIVE
-                            } else {
-                                ReguertaButtonVariant.PRIMARY
-                            },
-                            fullWidth = false,
-                            modifier = Modifier.width(buttonTokens.dialogTwoButtonsWidth),
+                            accentColor = accentColor,
+                            primaryContentColor = primaryActionTextColor,
+                            isPrimary = true,
+                            modifier = Modifier.weight(1f),
                         )
                     }
                 } else {
-                    ReguertaButton(
+                    DialogActionButton(
                         label = primaryAction.label,
                         onClick = primaryAction.onClick,
-                        variant = if (type == ReguertaDialogType.ERROR) {
-                            ReguertaButtonVariant.DESTRUCTIVE
-                        } else {
-                            ReguertaButtonVariant.PRIMARY
-                        },
                         modifier = Modifier.padding(top = 8.dp),
-                        fullWidth = true,
+                        accentColor = accentColor,
+                        primaryContentColor = primaryActionTextColor,
+                        isPrimary = true,
                     )
                 }
             }
         }
     }
 }
+
+@Composable
+private fun DialogActionButton(
+    label: String,
+    onClick: () -> Unit,
+    accentColor: Color,
+    primaryContentColor: Color,
+    isPrimary: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val secondaryContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.65f)
+    val shape = RoundedCornerShape(999.dp)
+    val textStyle = MaterialTheme.typography.titleLarge.copy(
+        fontSize = 22.sp,
+        lineHeight = 28.sp,
+    )
+    val buttonModifier = modifier
+        .fillMaxWidth()
+        .defaultMinSize(minHeight = 58.dp)
+
+    if (isPrimary) {
+        Button(
+            onClick = onClick,
+            modifier = buttonModifier,
+            shape = shape,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = accentColor,
+                contentColor = primaryContentColor,
+            ),
+            contentPadding = dialogButtonPadding(),
+        ) {
+            Text(text = label, style = textStyle, textAlign = TextAlign.Center)
+        }
+    } else {
+        OutlinedButton(
+            onClick = onClick,
+            modifier = buttonModifier,
+            shape = shape,
+            border = BorderStroke(1.5.dp, accentColor),
+            colors = ButtonDefaults.outlinedButtonColors(
+                containerColor = secondaryContainerColor,
+                contentColor = accentColor,
+            ),
+            contentPadding = dialogButtonPadding(),
+        ) {
+            Text(text = label, style = textStyle, textAlign = TextAlign.Center)
+        }
+    }
+}
+
+private fun dialogButtonPadding() =
+    PaddingValues(horizontal = 16.dp, vertical = 10.dp)
 
 @Composable
 private fun DialogIcon(
@@ -166,14 +225,14 @@ private fun DialogIcon(
 
     Box(
         modifier = Modifier
-            .size(88.dp)
+            .size(104.dp)
             .background(accentColor.copy(alpha = 0.22f), CircleShape),
         contentAlignment = Alignment.Center,
     ) {
         Icon(
             imageVector = icon,
             contentDescription = contentDescription,
-            modifier = Modifier.size(38.dp),
+            modifier = Modifier.size(48.dp),
             tint = accentColor,
         )
     }

--- a/android/Reguerta/app/src/main/res/values-es/strings.xml
+++ b/android/Reguerta/app/src/main/res/values-es/strings.xml
@@ -11,6 +11,7 @@
     <string name="access_action_signing_in">Iniciando sesión…</string>
     <string name="access_action_sign_in">Iniciar sesión</string>
     <string name="access_action_sign_out">Cerrar sesión</string>
+    <string name="access_action_sign_out_confirm_message">¿Estás seguro que quieres cerrar la sesión?</string>
     <string name="access_action_dismiss_message">Cerrar mensaje</string>
     <string name="auth_shell_splash_loading">Preparando experiencia…</string>
     <string name="startup_update_forced_title">Actualización obligatoria</string>

--- a/android/Reguerta/app/src/main/res/values/strings.xml
+++ b/android/Reguerta/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="access_action_signing_in">Signing in…</string>
     <string name="access_action_sign_in">Sign in</string>
     <string name="access_action_sign_out">Sign out</string>
+    <string name="access_action_sign_out_confirm_message">Are you sure you want to sign out?</string>
     <string name="access_action_dismiss_message">Dismiss message</string>
     <string name="auth_shell_splash_loading">Preparing experience…</string>
     <string name="startup_update_forced_title">Update required</string>

--- a/ios/Reguerta/Reguerta/Presentation/Auth/ContentView+AuthRoutes.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/ContentView+AuthRoutes.swift
@@ -19,8 +19,7 @@ extension AccessRootRoutingView {
 
     var welcomeRoute: some View {
         VStack(spacing: tokens.spacing.md) {
-            Spacer(minLength: tokens.spacing.md)
-                .frame(maxHeight: 112.resize)
+            Spacer().frame(height: 32.resize)
 
             Text(localizedKey(AccessL10nKey.welcomeTitlePrefix))
                 .font(.custom("CabinSketch-Regular", size: 22.resize, relativeTo: .headline))
@@ -28,11 +27,11 @@ extension AccessRootRoutingView {
                 .frame(maxWidth: .infinity)
 
             Text(localizedKey(AccessL10nKey.welcomeTitleBrand))
-                .font(.custom("CabinSketch-Bold", size: 40.resize, relativeTo: .title))
+                .font(.custom("CabinSketch-Bold", size: 36.resize, relativeTo: .title))
                 .foregroundStyle(tokens.colors.actionPrimary)
                 .frame(maxWidth: .infinity)
 
-            Spacer().frame(height: 24.resize)
+            Spacer()
 
             Image("brand_logo")
                 .resizable()
@@ -40,7 +39,7 @@ extension AccessRootRoutingView {
                 .frame(width: 214.resize, height: 214.resize)
                 .frame(maxWidth: .infinity)
 
-            Spacer(minLength: 0)
+            Spacer()
 
             reguertaButton(
                 localizedKey(AccessL10nKey.welcomeCtaEnter),
@@ -52,7 +51,7 @@ extension AccessRootRoutingView {
             .frame(maxWidth: 320.resize)
             .frame(maxWidth: .infinity)
 
-            Spacer(minLength: 0)
+            Spacer()
 
             HStack(spacing: tokens.spacing.xs) {
                 Text(localizedKey(AccessL10nKey.welcomeNotRegistered))

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellRoute.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 
+private enum HomeSignOutDialogL10n {
+    static let confirm = "common.action.confirm"
+    static let message = "access.action.sign_out.confirm.message"
+}
+
 extension AccessRootRoutingView {
     @ViewBuilder
     var homeRoute: some View {
@@ -36,6 +41,9 @@ extension AccessRootRoutingView {
             .overlay {
                 homeSharedProfileSavedDialogOverlay
             }
+            .overlay {
+                homeSignOutConfirmationDialogOverlay
+            }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .offset(x: rootViewModel.homeLayerOffset)
             .zIndex(2)
@@ -66,6 +74,26 @@ extension AccessRootRoutingView {
                     action: rootViewModel.dismissSharedProfileSavedDialog
                 ),
                 onDismiss: rootViewModel.dismissSharedProfileSavedDialog
+            )
+        }
+    }
+
+    @ViewBuilder
+    var homeSignOutConfirmationDialogOverlay: some View {
+        if rootViewModel.showsHomeSignOutDialog {
+            reguertaDialog(
+                type: .info,
+                title: l10n(AccessL10nKey.signOut),
+                message: l10n(HomeSignOutDialogL10n.message),
+                primaryAction: ReguertaDialogAction(
+                    title: l10n(HomeSignOutDialogL10n.confirm),
+                    action: rootViewModel.confirmHomeDrawerSignOut
+                ),
+                secondaryAction: ReguertaDialogAction(
+                    title: l10n(AccessL10nKey.commonBack),
+                    action: rootViewModel.dismissHomeDrawerSignOutDialog
+                ),
+                onDismiss: rootViewModel.dismissHomeDrawerSignOutDialog
             )
         }
     }

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellViewModel.swift
@@ -148,6 +148,15 @@ extension AccessRootViewModel {
 
     func handleHomeDrawerSignOut() {
         closeHomeDrawer()
+        showsHomeSignOutDialog = true
+    }
+
+    func dismissHomeDrawerSignOutDialog() {
+        showsHomeSignOutDialog = false
+    }
+
+    func confirmHomeDrawerSignOut() {
+        showsHomeSignOutDialog = false
         homeDestination = .dashboard
         sessionViewModel.signOut()
         dispatchShell(.signedOut)

--- a/ios/Reguerta/Reguerta/Presentation/Root/AccessRootViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Root/AccessRootViewModel.swift
@@ -70,8 +70,8 @@ final class AccessRootViewModel {
     var myOrdersHistoryTitleOverride: String?
     var receivedOrdersHistoryTitleOverride: String?
     var showsSharedProfileSavedDialog = false
+    var showsHomeSignOutDialog = false
     var nowOverrideMillis: Int64?
-
     var shouldSkipSplash: Bool {
         shouldSkipSplashProvider()
     }

--- a/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
+++ b/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
@@ -109,13 +109,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Do you want to sign out now? You can stay here if you tapped it by mistake."
+            "value" : "Are you sure you want to sign out?"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿Seguro que quieres cerrar sesión ahora? Puedes quedarte aquí si lo has pulsado por error."
+            "value" : "¿Estás seguro que quieres cerrar la sesión?"
           }
         }
       }
@@ -126,13 +126,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sign out?"
+            "value" : "Sign out"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "¿Cerrar sesión?"
+            "value" : "Cerrar sesión"
           }
         }
       }

--- a/ios/Reguerta/ReguertaTests/ReguertaRootDependencyTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaRootDependencyTests.swift
@@ -93,6 +93,48 @@ struct ReguertaRootDependencyTests {
         #expect(rootViewModel.shellState.canGoBack == false)
     }
 
+    @Test
+    func homeDrawerSignOutRequestsConfirmationWithoutEndingSession() {
+        let rootViewModel = makeRootViewModel()
+        rootViewModel.shellState = AuthShellState(backStack: [.home])
+        rootViewModel.sessionViewModel.mode = .authorized(makeAuthorizedSession())
+        rootViewModel.isHomeDrawerOpen = true
+
+        rootViewModel.handleHomeDrawerSignOut()
+
+        #expect(rootViewModel.showsHomeSignOutDialog)
+        #expect(rootViewModel.isHomeDrawerOpen == false)
+        #expect(rootViewModel.shellState.currentRoute == .home)
+        guard case .authorized = rootViewModel.sessionViewModel.mode else {
+            Issue.record("Drawer sign-out should wait for explicit confirmation")
+            return
+        }
+
+        rootViewModel.dismissHomeDrawerSignOutDialog()
+
+        #expect(rootViewModel.showsHomeSignOutDialog == false)
+        guard case .authorized = rootViewModel.sessionViewModel.mode else {
+            Issue.record("Dismissing the dialog should keep the session active")
+            return
+        }
+    }
+
+    @Test
+    func homeDrawerSignOutConfirmationSignsOutAndRoutesWelcome() {
+        let rootViewModel = makeRootViewModel()
+        rootViewModel.shellState = AuthShellState(backStack: [.home])
+        rootViewModel.sessionViewModel.mode = .authorized(makeAuthorizedSession())
+        rootViewModel.showsHomeSignOutDialog = true
+
+        rootViewModel.confirmHomeDrawerSignOut()
+
+        #expect(rootViewModel.showsHomeSignOutDialog == false)
+        #expect(rootViewModel.homeDestination == .dashboard)
+        #expect(rootViewModel.sessionViewModel.mode == .signedOut)
+        #expect(rootViewModel.shellState.currentRoute == .welcome)
+        #expect(rootViewModel.shellState.canGoBack == false)
+    }
+
     private func makeRootViewModel(
         startupPolicy: StartupVersionPolicy? = nil,
         shouldSkipSplash: Bool = false,
@@ -105,6 +147,24 @@ struct ReguertaRootDependencyTests {
             ),
             shouldSkipSplashProvider: { shouldSkipSplash },
             installedVersionProvider: { installedVersion }
+        )
+    }
+
+    private func makeAuthorizedSession() -> AuthorizedSession {
+        let member = Member(
+            id: "member_root",
+            displayName: "Root Member",
+            normalizedEmail: "root@reguerta.test",
+            authUid: "auth_root",
+            roles: [.member],
+            isActive: true,
+            producerCatalogEnabled: true
+        )
+        return AuthorizedSession(
+            principal: AuthPrincipal(uid: "auth_root", email: "root@reguerta.test"),
+            authenticatedMember: member,
+            member: member,
+            members: [member]
         )
     }
 }

--- a/spec/app/hu-061-logout-confirmation-dialog/plan.md
+++ b/spec/app/hu-061-logout-confirmation-dialog/plan.md
@@ -1,0 +1,67 @@
+# Plan - HU-061 (Logout confirmation dialog)
+
+## Approach
+
+Keep the change in the drawer/session UI layer. The logout callback already knows how to sign out and transition to the unauthenticated state; this story only adds an explicit confirmation step before that callback is invoked.
+
+## Implementation steps
+
+1. Locate Android drawer/footer sign-out wiring and existing `ReguertaDialog` API.
+2. Locate iOS drawer/footer sign-out wiring and existing `ReguertaDialog` API.
+3. Add local confirmation state to Android drawer/home shell and show the dialog from `Cerrar sesión`.
+4. Add local confirmation state to iOS drawer/home shell and show the dialog from `Cerrar sesión`.
+5. Ensure cancel/back/dismiss clears confirmation state without invoking sign-out.
+6. Ensure confirm clears or consumes the dialog state and invokes the existing sign-out once.
+7. Update focused UI/session tests where the current expectation is immediate logout.
+8. Run relevant Android and iOS validation.
+
+## Layer impact
+
+- UI: drawer footer action and `ReguertaDialog` presentation on Android/iOS.
+- Domain: no expected changes.
+- Data: no expected changes.
+- Backend: no expected changes.
+- Docs: HU-061 spec, plan, tasks, and issue mirror.
+
+## Platform-specific changes
+
+### Android
+
+- Reuse the existing Compose `ReguertaDialog` component.
+- Add `showLogoutConfirmation` state in the composable that owns drawer sign-out interaction.
+- Replace immediate sign-out with opening the confirmation dialog.
+- Invoke the existing logout callback only from `Confirmar`.
+
+### iOS
+
+- Reuse the existing SwiftUI `ReguertaDialog` component.
+- Add a local state flag in the view/shell that owns drawer sign-out interaction.
+- Replace immediate sign-out with opening the confirmation dialog.
+- Invoke the existing logout action only from `Confirmar`.
+
+### Functions/Backend
+
+- No changes expected.
+
+## Test strategy
+
+- Unit: keep existing auth/session unit tests unchanged unless UI callback ownership requires a small focused test.
+- UI/component: validate that tapping `Cerrar sesión` opens the dialog instead of calling sign-out.
+- UI/component: validate that `Volver`/dismiss does not sign out.
+- UI/component: validate that `Confirmar` calls sign-out once.
+- Manual: inspect Android and iOS drawer flows if automated UI coverage is limited.
+
+## Validation
+
+- Android: `./gradlew app:testDebugUnitTest`
+- Android: `./gradlew app:lintDebug`
+- Android: `./gradlew app:connectedDebugAndroidTest` when an emulator/device is available because drawer behavior changed.
+- iOS: `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' test`
+- If the named simulator is unavailable, use a valid local simulator and record it.
+
+## Technical risks and mitigation
+
+- Risk: the confirmation dialog competes with drawer close animation.
+  - Mitigation: let existing drawer state remain unchanged unless current architecture already closes it on footer actions; the visible confirmation is the source of truth.
+- Risk: platform dialog APIs expose different dismissal behavior.
+  - Mitigation: map all non-confirm dismissals to cancel semantics.

--- a/spec/app/hu-061-logout-confirmation-dialog/spec.md
+++ b/spec/app/hu-061-logout-confirmation-dialog/spec.md
@@ -1,0 +1,83 @@
+# HU-061 - Confirmar cierre de sesión desde el menú lateral
+
+## Metadata
+
+- issue_id: 159
+- priority: P2
+- platform: both
+- status: implemented
+
+## Context and problem
+
+El menú lateral de Android e iOS expone `Cerrar sesión` como acción de footer. Actualmente el toque ejecuta el cierre de sesión sin confirmación, lo que hace fácil salir por accidente al navegar por el drawer.
+
+Reguerta ya cuenta con un patrón visual de `ReguertaDialog` para confirmaciones e información. Esta historia debe reutilizar ese patrón en ambas plataformas y mantener intacto el flujo de autenticación existente detrás de la acción confirmada.
+
+## User story
+
+Como persona usuaria autenticada, quiero que la opción `Cerrar sesión` del menú lateral me pida confirmación antes de salir para no perder la sesión por un toque accidental.
+
+## Scope
+
+### In Scope
+
+- Interceptar la acción `Cerrar sesión` del menú lateral en Android e iOS.
+- Mostrar un `ReguertaDialog` de confirmación con el copy aprobado:
+  - título: `Cerrar sesión`,
+  - mensaje: `¿Estás seguro que quieres cerrar la sesión?`,
+  - secundaria: `Volver`,
+  - primaria: `Confirmar`.
+- Reutilizar estilos, iconografía y comportamiento de `ReguertaDialog` ya existentes en cada plataforma.
+- Ejecutar el sign-out actual solo al confirmar.
+- Mantener la sesión activa y cerrar solo el diálogo al cancelar o volver.
+- Mantener paridad funcional Android/iOS.
+
+### Out of Scope
+
+- Cambiar Firebase Auth, refresh de sesión, repositorios de autenticación o estado de usuario.
+- Rediseñar el drawer completo.
+- Modificar reglas de roles/capacidades del menú.
+- Crear un nuevo sistema de diálogos.
+- Cambiar la navegación posterior al sign-out más allá del comportamiento actual.
+
+## Linked functional requirements
+
+- RF-ROL-03
+- RF-ROL-04
+- RF-AUT-01
+
+## Acceptance criteria
+
+- Al tocar `Cerrar sesión` en el menú lateral de Android, no se ejecuta el cierre inmediatamente.
+- Al tocar `Cerrar sesión` en el menú lateral de iOS, no se ejecuta el cierre inmediatamente.
+- Ambas plataformas muestran un `ReguertaDialog` con icono informativo, título `Cerrar sesión`, mensaje `¿Estás seguro que quieres cerrar la sesión?`, botón `Volver` y botón `Confirmar`.
+- `Volver` cierra el diálogo y mantiene la sesión activa.
+- El dismissal/back del diálogo, cuando la plataforma lo permita, equivale a cancelar y mantiene la sesión activa.
+- `Confirmar` invoca el flujo de cierre de sesión existente una sola vez.
+- Tras confirmar, la app navega al estado actual de usuario no autenticado.
+- El drawer conserva sus reglas de visibilidad por rol y no pierde destinos existentes.
+- Android e iOS exponen comportamiento, copy y jerarquía visual equivalentes.
+
+## Dependencies
+
+- HU-039 para el Home shell y drawer base.
+- HU-040 para mapa de navegación del drawer.
+- HU-023 para comportamiento de ciclo de sesión.
+- Componentes `ReguertaDialog` existentes en Android e iOS.
+
+## Risks
+
+- Risk: el sign-out actual está acoplado directamente al botón del drawer.
+  - Mitigation: introducir un estado local de confirmación en la capa UI y delegar en el callback existente solo desde la acción primaria.
+- Risk: Android e iOS usan APIs de diálogo diferentes.
+  - Mitigation: reutilizar los componentes del sistema de diseño de cada plataforma y fijar como contrato el copy/semántica, no una implementación idéntica.
+- Risk: tests existentes esperan logout inmediato.
+  - Mitigation: actualizar solo los tests de comportamiento del drawer/session para validar cancelación y confirmación explícita.
+
+## Definition of Done (DoD)
+
+- [x] Acceptance criteria validated on Android and iOS.
+- [x] Agreed test coverage executed.
+- [x] Android/iOS parity reviewed.
+- [x] Issue mirror, spec, plan, and tasks updated with validation evidence.
+- [x] Known parity gaps, if any, documented in handoff.

--- a/spec/app/hu-061-logout-confirmation-dialog/tasks.md
+++ b/spec/app/hu-061-logout-confirmation-dialog/tasks.md
@@ -1,0 +1,56 @@
+# Tasks - HU-061 (Logout confirmation dialog)
+
+GitHub tracking:
+
+- #159 - Confirmar cierre de sesión desde el menú lateral.
+
+## 1. Bootstrap
+
+- [x] Create GitHub issue.
+- [x] Create branch `codex/hu-061-logout-confirmation-dialog`.
+- [x] Add issue mirror, spec, plan, and tasks.
+
+## 2. Android implementation
+
+- [x] Locate current drawer sign-out callback.
+- [x] Locate existing `ReguertaDialog` API and usage examples.
+- [x] Show confirmation dialog before sign-out.
+- [x] Wire `Volver`/dismiss to keep session active.
+- [x] Wire `Confirmar` to invoke existing sign-out once.
+- [x] Update focused Android tests if existing coverage asserts immediate sign-out.
+
+## 3. iOS implementation
+
+- [x] Locate current drawer sign-out callback.
+- [x] Locate existing `ReguertaDialog` API and usage examples.
+- [x] Show confirmation dialog before sign-out.
+- [x] Wire `Volver`/dismiss to keep session active.
+- [x] Wire `Confirmar` to invoke existing sign-out once.
+- [x] Update focused iOS tests if existing coverage asserts immediate sign-out.
+
+## 4. Validation
+
+- [x] Run Android unit tests.
+- [x] Run Android lint.
+- [x] Run Android instrumented tests or document why unavailable.
+- [x] Run iOS test command from `AGENTS.md` or document simulator fallback.
+- [x] Record manual parity check.
+
+Validation evidence:
+
+- Android manual follow-up: iOS worked, but Android did not surface the dialog from the real drawer footer. Fixed by deferring the confirmation display after closing the drawer and adding a drawer-click instrumented test.
+- Android visual follow-up: adjusted the shared `ReguertaDialog` treatment to keep the new proportions while using the active `MaterialTheme` colors, so light devices render the light Reguerta dialog and dark devices render the dark version.
+- Android icon follow-up: aligned the icon with the current Android `ReguertaAlertDialog` pattern: translucent outer badge plus the Material `Info`/`Error` icon tinted with the accent, without an extra inner circle.
+- Android lint follow-up: cleared the `ReguertaRootHomeRoute.kt` warnings by using the state-backed `Modifier.offset { ... }` overload and keeping the logout dialog helper private.
+- Android: `./gradlew app:compileDebugKotlin app:lintDebug` passed, and the lint report no longer lists `ReguertaRootHomeRoute.kt`.
+- Android: `./gradlew app:testDebugUnitTest app:lintDebug` passed.
+- Android: `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.reguerta.user.HomeDrawerContentTest` passed 4 focused tests on `Pixel_4_A12_API29`.
+- Android: `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest` passed 7 tests on `Pixel_4_A12_API29`.
+- iOS: full `xcodebuild ... test` for `iPhone 17` was attempted; unit tests started, then the UI test runner failed to launch with `FBSOpenApplicationServiceErrorDomain Code=1` / `RequestDenied`.
+- iOS: `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' test -only-testing:ReguertaTests -quiet` passed.
+- Parity: Android and iOS both intercept drawer sign-out, show the info `ReguertaDialog`, cancel without signing out, and invoke the existing sign-out flow only from `Confirmar`.
+
+## 5. Closure
+
+- [x] Update validation evidence.
+- [ ] Prepare PR linked to #159.

--- a/spec/issues/hu-061-logout-confirmation-dialog-issue.md
+++ b/spec/issues/hu-061-logout-confirmation-dialog-issue.md
@@ -1,0 +1,80 @@
+# [HU-061] Confirmar cierre de sesión desde el menú lateral
+
+GitHub issue: https://github.com/JFrancoG/ReguertaPlus/issues/159
+
+## Summary
+
+Al pulsar `Cerrar sesión` desde el menú lateral en iOS y Android, la app cierra sesión inmediatamente. La salida debe pasar por un `ReguertaDialog` de confirmación con el estilo visual existente de Reguerta para evitar cierres accidentales.
+
+## Links
+
+- Spec: `spec/app/hu-061-logout-confirmation-dialog/spec.md`
+- Plan: `spec/app/hu-061-logout-confirmation-dialog/plan.md`
+- Tasks: `spec/app/hu-061-logout-confirmation-dialog/tasks.md`
+
+## User story
+
+Como persona usuaria autenticada, quiero que la opción `Cerrar sesión` del menú lateral me pida confirmación antes de salir para no perder la sesión por un toque accidental.
+
+## Acceptance criteria
+
+- Al tocar `Cerrar sesión` en el menú lateral de Android, no se ejecuta el cierre inmediatamente.
+- Al tocar `Cerrar sesión` en el menú lateral de iOS, no se ejecuta el cierre inmediatamente.
+- Ambas plataformas muestran un `ReguertaDialog` de confirmación con:
+  - icono informativo,
+  - título `Cerrar sesión`,
+  - mensaje `¿Estás seguro que quieres cerrar la sesión?`,
+  - acción secundaria `Volver`,
+  - acción primaria `Confirmar`.
+- `Volver` cierra el diálogo y mantiene la sesión activa.
+- `Confirmar` ejecuta el cierre de sesión existente una sola vez y navega al estado actual de usuario no autenticado.
+- El diálogo respeta el estilo visual ya usado por `ReguertaDialog` en cada plataforma y no introduce un componente paralelo.
+- La interacción es equivalente entre iOS y Android, incluyendo back/dismiss cuando aplique.
+
+## Scope
+
+### In Scope
+
+- Reutilizar los componentes `ReguertaDialog` existentes en iOS y Android.
+- Conectar la acción de drawer/footer `Cerrar sesión` a un estado de confirmación.
+- Mantener el flujo de sign-out/auth actual detrás de la confirmación.
+- Añadir o ajustar cobertura donde ya existan tests de drawer/session.
+- Documentar validación y cualquier brecha temporal de paridad.
+
+### Out of Scope
+
+- Cambiar autenticación, Firebase Auth, token refresh o permisos.
+- Rediseñar el menú lateral completo.
+- Cambiar navegación de login/onboarding fuera del resultado actual de cerrar sesión.
+- Crear un nuevo sistema de diálogos.
+
+## Implementation checklist
+
+- [x] Localizar el flujo actual de `Cerrar sesión` en Android.
+- [x] Localizar el flujo actual de `Cerrar sesión` en iOS.
+- [x] Android: mostrar `ReguertaDialog` antes de invocar el sign-out existente.
+- [x] iOS: mostrar `ReguertaDialog` antes de invocar el sign-out existente.
+- [x] Verificar que cancelar/dismiss mantiene sesión y drawer estable.
+- [x] Verificar que confirmar cierra sesión una sola vez.
+- [x] Ejecutar validación Android relevante.
+- [x] Ejecutar validación iOS relevante.
+
+## Validation evidence
+
+- Android manual follow-up: iOS worked, but Android did not surface the dialog from the real drawer footer. Fixed by deferring the confirmation display after closing the drawer and adding a drawer-click instrumented test.
+- Android visual follow-up: adjusted the shared `ReguertaDialog` treatment to keep the new proportions while using the active `MaterialTheme` colors, so light devices render the light Reguerta dialog and dark devices render the dark version.
+- Android icon follow-up: aligned the icon with the current Android `ReguertaAlertDialog` pattern: translucent outer badge plus the Material `Info`/`Error` icon tinted with the accent, without an extra inner circle.
+- Android lint follow-up: cleared the `ReguertaRootHomeRoute.kt` warnings by using the state-backed `Modifier.offset { ... }` overload and keeping the logout dialog helper private.
+- Android: `./gradlew app:compileDebugKotlin app:lintDebug` passed, and the lint report no longer lists `ReguertaRootHomeRoute.kt`.
+- Android: `./gradlew app:testDebugUnitTest app:lintDebug` passed.
+- Android: `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.reguerta.user.HomeDrawerContentTest` passed 4 focused tests on `Pixel_4_A12_API29`.
+- Android: `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest` passed 7 tests on `Pixel_4_A12_API29`.
+- iOS: full `xcodebuild ... test` for `iPhone 17` was attempted; the UI test runner failed to launch with `FBSOpenApplicationServiceErrorDomain Code=1` / `RequestDenied`.
+- iOS: `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' test -only-testing:ReguertaTests -quiet` passed.
+
+## Labels
+
+- `type:feature`
+- `area:app`
+- `platform:cross`
+- `priority:P2`


### PR DESCRIPTION
## Summary
- Add cross-platform confirmation before drawer sign-out.
- Align Android ReguertaDialog visuals with light/dark theme and existing info icon treatment.
- Keep the iOS welcome layout polish as a separate final commit.

## Validation
- Android: ./gradlew app:compileDebugKotlin app:lintDebug
- Android: ./gradlew app:testDebugUnitTest app:lintDebug
- Android: ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest
- iOS: xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' test -only-testing:ReguertaTests -quiet

Closes #159