### PR TITLE
[HU-062] Pulir cards de pedidos Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-08 | 🐛 fix(android-orders): polish order cards
 - 2026-07-07 | 🐛 fix(ui): polish drawer and mobile spacing
 - 2026-07-07 | 🐛 fix(home): align weekly delivery summary
 - 2026-05-22 | 🐛 fix(orders): correct received order prep display

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/data/orders/FirestoreOrdersRepository.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/data/orders/FirestoreOrdersRepository.kt
@@ -453,17 +453,19 @@ private fun orderSummaryLine(payload: Map<String, Any>): OrderSummaryLine {
 
 private fun orderPackagingLine(payload: Map<String, Any>): String {
     val containerName = (payload["packContainerName"] as? String)?.trim()?.takeIf(String::isNotBlank)
-        ?: (payload["unitName"] as? String)?.trim().orEmpty()
-    val quantity = ((payload["packContainerQty"] as? Number)?.toDouble()
-        ?: (payload["unitQty"] as? Number)?.toDouble()
-        ?: 1.0).toOrderUiDecimal()
+    val containerQuantity = (payload["packContainerQty"] as? Number)?.toDouble()
+    val containerLabel = listOfNotNull(
+        containerQuantity
+            ?.takeUnless { it.isOrderApproximatelyOne() }
+            ?.toOrderUiDecimal(),
+        containerName,
+    ).joinToString(separator = " ")
     val unitName = (payload["unitName"] as? String)?.trim().orEmpty()
-    val unitPlural = (payload["unitPlural"] as? String)?.trim().orEmpty()
-    val unit = (payload["packContainerAbbreviation"] as? String)?.trim()?.takeIf(String::isNotBlank)
-        ?: (payload["packContainerPlural"] as? String)?.trim()?.takeIf(String::isNotBlank)
-        ?: (payload["unitAbbreviation"] as? String)?.trim()?.takeIf(String::isNotBlank)
-        ?: if ((payload["packContainerQty"] as? Number)?.toDouble() == 1.0) unitName else unitPlural
-    return listOf(containerName, quantity, unit)
+    val unitPlural = (payload["unitPlural"] as? String)?.trim().orEmpty().ifBlank { unitName }
+    val unitQuantity = (payload["unitQty"] as? Number)?.toDouble() ?: 1.0
+    val unit = (payload["unitAbbreviation"] as? String)?.trim()?.takeIf(String::isNotBlank)
+        ?: if (unitQuantity.isOrderApproximatelyOne()) unitName else unitPlural
+    return listOf(containerLabel, unitQuantity.toOrderUiDecimal(), unit)
         .filter(String::isNotBlank)
         .joinToString(separator = " ")
 }
@@ -485,6 +487,9 @@ private fun Double.toOrderUiDecimal(): String {
     if (this % 1.0 == 0.0) return toLong().toString()
     return String.format(Locale.US, "%.2f", this).trimEnd('0').trimEnd('.')
 }
+
+private fun Double.isOrderApproximatelyOne(): Boolean =
+    kotlin.math.abs(this - 1.0) < 0.0001
 
 private fun buildReceivedOrdersSnapshot(
     lines: List<ReceivedOrderLineRecord>,

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/PersonalOrderSummaryCard.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/PersonalOrderSummaryCard.kt
@@ -1,0 +1,148 @@
+package com.reguerta.user.presentation.access
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.reguerta.user.R
+
+internal data class PersonalOrderSummaryLineUi(
+    val productName: String,
+    val packagingLine: String,
+    val quantityLabel: String,
+    val subtotal: Double,
+)
+
+@Composable
+internal fun PersonalOrderSummaryProducerCard(
+    companyName: String,
+    lines: List<PersonalOrderSummaryLineUi>,
+    subtotal: Double,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.38f)),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = companyName,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.primary,
+            )
+
+            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.30f))
+
+            lines.forEach { line ->
+                PersonalOrderSummaryLineRow(line = line)
+            }
+
+            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.30f))
+
+            Text(
+                text = stringResource(R.string.my_order_producer_subtotal_format, subtotal.toEuroCurrencyText()),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.End,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PersonalOrderSummaryLineRow(line: PersonalOrderSummaryLineUi) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Min),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = line.productName,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = line.packagingLine,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        PersonalOrderSummaryColumnDivider()
+
+        Text(
+            text = line.quantityLabel,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .width(56.dp)
+                .padding(horizontal = 8.dp),
+        )
+
+        PersonalOrderSummaryColumnDivider()
+
+        Text(
+            text = line.subtotal.toEuroCurrencyText(),
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.End,
+            modifier = Modifier
+                .width(80.dp)
+                .padding(start = 10.dp),
+        )
+    }
+}
+
+@Composable
+private fun PersonalOrderSummaryColumnDivider() {
+    Box(
+        modifier = Modifier
+            .fillMaxHeight()
+            .width(1.dp)
+            .background(MaterialTheme.colorScheme.outline.copy(alpha = 0.30f)),
+    )
+}

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeRoute.kt
@@ -207,7 +207,6 @@ internal fun HomeRoute(
     var isMyOrderReadOnlyMode by rememberSaveable { mutableStateOf(false) }
     var isMyOrderCartVisible by rememberSaveable { mutableStateOf(false) }
     var sharedProfileTitleOverride by rememberSaveable { mutableStateOf<String?>(null) }
-    var myOrdersHistoryTitleOverride by rememberSaveable { mutableStateOf<String?>(null) }
     var receivedOrdersHistoryTitleOverride by rememberSaveable { mutableStateOf<String?>(null) }
     val member = when (mode) {
         is SessionMode.Authorized -> mode.member
@@ -243,9 +242,6 @@ internal fun HomeRoute(
         }
         if (destination != HomeDestination.PROFILE) {
             sharedProfileTitleOverride = null
-        }
-        if (destination != HomeDestination.MY_ORDERS) {
-            myOrdersHistoryTitleOverride = null
         }
         if (destination != HomeDestination.RECEIVED_ORDERS_HISTORY) {
             receivedOrdersHistoryTitleOverride = null
@@ -387,15 +383,14 @@ internal fun HomeRoute(
                         currentDestination == HomeDestination.MY_ORDER && isMyOrderCartVisible && !isMyOrderReadOnlyMode -> {
                             stringResource(R.string.my_order_cart_title)
                         }
+                        currentDestination == HomeDestination.MY_ORDER && isMyOrderReadOnlyMode -> ""
+                        currentDestination == HomeDestination.MY_ORDERS -> ""
                         currentDestination == HomeDestination.PUBLISH_NEWS && editingNewsId != null -> {
                             stringResource(R.string.news_editor_title_edit)
                         }
                         currentDestination == HomeDestination.NOTIFICATIONS -> ""
                         currentDestination == HomeDestination.PROFILE && !sharedProfileTitleOverride.isNullOrBlank() -> {
                             sharedProfileTitleOverride.orEmpty()
-                        }
-                        currentDestination == HomeDestination.MY_ORDERS -> {
-                            myOrdersHistoryTitleOverride ?: stringResource(R.string.my_orders_history_title_fallback)
                         }
                         currentDestination == HomeDestination.RECEIVED_ORDERS_HISTORY -> {
                             receivedOrdersHistoryTitleOverride ?: stringResource(R.string.home_shell_action_received_orders)
@@ -620,9 +615,6 @@ internal fun HomeRoute(
                     modifier = Modifier.fillMaxSize(),
                     currentMember = member,
                     nowOverrideMillis = nowOverrideMillis,
-                    onTitleChanged = { titleOverride ->
-                        myOrdersHistoryTitleOverride = titleOverride
-                    },
                     )
 
                     HomeDestination.RECEIVED_ORDERS -> ReceivedOrdersRoute(

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeShellComponents.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeShellComponents.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
@@ -86,7 +87,10 @@ fun HomeShellTopBar(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        IconButton(onClick = if (canNavigateBack) onBack else onOpenMenu) {
+        IconButton(
+            modifier = if (canNavigateBack) Modifier.offset(x = (-12).dp) else Modifier,
+            onClick = if (canNavigateBack) onBack else onOpenMenu,
+        ) {
             Icon(
                 imageVector = if (canNavigateBack) Icons.AutoMirrored.Filled.ArrowBack else Icons.Filled.Menu,
                 contentDescription = if (canNavigateBack) {

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrderRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrderRoute.kt
@@ -1162,14 +1162,6 @@ private fun MyOrderPreviousOrderSummary(
                 }
 
                 is MyOrderPreviousOrderState.Loaded -> {
-                    Text(
-                        text = stringResource(
-                            R.string.my_order_previous_week_format,
-                            state.snapshot.weekKey,
-                        ),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
                     LazyColumn(
                         modifier = Modifier.weight(1f),
                         contentPadding = PaddingValues(bottom = 120.dp),
@@ -1226,72 +1218,18 @@ private fun MyOrderSummaryTotalBar(
 
 @Composable
 private fun MyOrderPreviousProducerCard(group: MyOrderPreviousOrderGroup) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Text(
-                text = group.companyName,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.primary,
+    PersonalOrderSummaryProducerCard(
+        companyName = group.companyName,
+        lines = group.lines.map { line ->
+            PersonalOrderSummaryLineUi(
+                productName = line.productName,
+                packagingLine = line.packagingLine,
+                quantityLabel = line.quantityLabel,
+                subtotal = line.subtotal,
             )
-
-            MyOrderProducerDivider()
-
-            group.lines.forEach { line ->
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.Top,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Column(
-                        modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(2.dp),
-                    ) {
-                        Text(
-                            text = line.productName,
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.SemiBold,
-                        )
-                        Text(
-                            text = line.packagingLine,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                    Text(
-                        text = line.quantityLabel,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                    Text(
-                        text = line.subtotal.toEuroCurrencyText(),
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                }
-            }
-
-            MyOrderProducerDivider()
-
-            Row(modifier = Modifier.fillMaxWidth()) {
-                Spacer(modifier = Modifier.weight(1f))
-                Text(
-                    text = stringResource(
-                        R.string.my_order_producer_subtotal_format,
-                        group.subtotal.toEuroCurrencyText(),
-                    ),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
-        }
-    }
+        },
+        subtotal = group.subtotal,
+    )
 }
 
 @Composable
@@ -1977,6 +1915,9 @@ private fun Double.toUiDecimal(): String =
         String.format(Locale.getDefault(), "%.2f", this)
     }
 
+private fun Double.isApproximatelyOne(): Boolean =
+    kotlin.math.abs(this - 1.0) < 0.0001
+
 private fun countNoPickupEcoBasketUnits(
     products: List<Product>,
     selectedQuantities: Map<String, Int>,
@@ -2319,23 +2260,21 @@ private fun Map<String, Any>.readProducerStatusesByVendor(): Map<String, MyOrder
 private fun packagingLineFromOrderLinePayload(payload: Map<String, Any>): String {
     val containerName = (payload["packContainerName"] as? String)
         ?.takeIf(String::isNotBlank)
-        ?: (payload["unitName"] as? String).orEmpty()
-    val quantity = ((payload["packContainerQty"] as? Number)?.toDouble()
-        ?: (payload["unitQty"] as? Number)?.toDouble()
-        ?: 1.0).toUiDecimal()
+    val containerQuantity = (payload["packContainerQty"] as? Number)?.toDouble()
+    val containerLabel = listOfNotNull(
+        containerQuantity
+            ?.takeUnless { it.isApproximatelyOne() }
+            ?.toUiDecimal(),
+        containerName,
+    ).joinToString(separator = " ")
+    val measureQuantity = ((payload["unitQty"] as? Number)?.toDouble() ?: 1.0).toUiDecimal()
     val fallbackUnitName = (payload["unitName"] as? String).orEmpty()
-    val fallbackUnitPlural = (payload["unitPlural"] as? String).orEmpty()
-    val unitLabel = (payload["packContainerAbbreviation"] as? String)
-        ?.takeIf(String::isNotBlank)
-        ?: (payload["packContainerPlural"] as? String)?.takeIf(String::isNotBlank)
-        ?: (payload["unitAbbreviation"] as? String)?.takeIf(String::isNotBlank)
-        ?: if (((payload["packContainerQty"] as? Number)?.toDouble() ?: 1.0) == 1.0) {
-            fallbackUnitName
-        } else {
-            fallbackUnitPlural
-        }
+    val fallbackUnitPlural = (payload["unitPlural"] as? String).orEmpty().ifBlank { fallbackUnitName }
+    val unitQuantity = (payload["unitQty"] as? Number)?.toDouble() ?: 1.0
+    val unitLabel = (payload["unitAbbreviation"] as? String)?.takeIf(String::isNotBlank)
+        ?: if (unitQuantity.isApproximatelyOne()) fallbackUnitName else fallbackUnitPlural
 
-    return listOf(containerName, quantity, unitLabel)
+    return listOf(containerLabel, measureQuantity, unitLabel)
         .filter { value -> value.isNotBlank() }
         .joinToString(separator = " ")
 }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrdersHistoryRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootMyOrdersHistoryRoute.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -34,7 +33,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -54,7 +52,6 @@ import com.reguerta.user.data.orders.FirestoreOrdersRepository
 import com.reguerta.user.domain.access.Member
 import com.reguerta.user.domain.orders.OrderHistoryWeekOption
 import com.reguerta.user.domain.orders.OrderSummaryGroup
-import com.reguerta.user.domain.orders.OrderSummaryLine
 import com.reguerta.user.domain.orders.OrderSummarySnapshot
 
 @Composable
@@ -62,7 +59,6 @@ internal fun MyOrdersHistoryRoute(
     modifier: Modifier = Modifier,
     currentMember: Member?,
     nowOverrideMillis: Long?,
-    onTitleChanged: (String?) -> Unit = {},
 ) {
     val firestore = remember { FirebaseFirestore.getInstance() }
     val repository = remember(firestore) { FirestoreOrdersRepository(firestore = firestore) }
@@ -80,13 +76,6 @@ internal fun MyOrdersHistoryRoute(
             ),
         )
     }
-    LaunchedEffect(state.selectedWeek?.orderTitle) {
-        onTitleChanged(state.selectedWeek?.orderTitle)
-    }
-    DisposableEffect(Unit) {
-        onDispose { onTitleChanged(null) }
-    }
-
     MyOrdersHistoryContent(
         state = state,
         onPrevious = viewModel::selectPreviousWeek,
@@ -120,6 +109,14 @@ private fun MyOrdersHistoryContent(
             modifier = Modifier.fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
+            state.selectedWeek?.orderTitle?.let { orderTitle ->
+                Text(
+                    text = orderTitle,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
             OrderHistoryWeekHeader(
                 selectedWeek = state.selectedWeek,
                 canGoPrevious = state.canGoPrevious,
@@ -215,12 +212,12 @@ private fun GlassWeekNavigationButton(
 ) {
     Surface(
         shape = CircleShape,
-        color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = if (enabled) 0.62f else 0.18f),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = if (enabled) 1f else 0.45f),
         tonalElevation = if (enabled) 8.dp else 0.dp,
         shadowElevation = if (enabled) 3.dp else 0.dp,
         border = BorderStroke(
             1.dp,
-            MaterialTheme.colorScheme.primary.copy(alpha = if (enabled) 0.34f else 0.12f),
+            MaterialTheme.colorScheme.outline.copy(alpha = if (enabled) 0.80f else 0.35f),
         ),
     ) {
         IconButton(
@@ -248,10 +245,10 @@ private fun GlassWeekPickerButton(
 ) {
     Surface(
         shape = RoundedCornerShape(50),
-        color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.56f),
+        color = MaterialTheme.colorScheme.surfaceVariant,
         tonalElevation = 8.dp,
         shadowElevation = 3.dp,
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.32f)),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.80f)),
     ) {
         TextButton(onClick = onClick) {
             Text(
@@ -330,69 +327,18 @@ private fun OrderSummaryList(
 
 @Composable
 private fun OrderSummaryProducerCard(group: OrderSummaryGroup) {
-    Card(modifier = Modifier.fillMaxWidth()) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Text(
-                text = group.companyName,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.primary,
+    PersonalOrderSummaryProducerCard(
+        companyName = group.companyName,
+        lines = group.lines.map { line ->
+            PersonalOrderSummaryLineUi(
+                productName = line.productName,
+                packagingLine = line.packagingLine,
+                quantityLabel = line.quantityLabel,
+                subtotal = line.subtotal,
             )
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.24f))
-            group.lines.forEach { line ->
-                OrderSummaryLineRow(line = line)
-            }
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.24f))
-            Text(
-                text = stringResource(R.string.my_order_producer_subtotal_format, group.subtotal.toEuroCurrencyText()),
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.error,
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.End,
-            )
-        }
-    }
-}
-
-@Composable
-private fun OrderSummaryLineRow(line: OrderSummaryLine) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.Top,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(2.dp),
-        ) {
-            Text(
-                text = line.productName,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.SemiBold,
-            )
-            Text(
-                text = line.packagingLine,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        Text(
-            text = line.quantityLabel,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.SemiBold,
-        )
-        Text(
-            text = line.subtotal.toEuroCurrencyText(),
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.SemiBold,
-        )
-    }
+        },
+        subtotal = group.subtotal,
+    )
 }
 
 @Composable

--- a/android/Reguerta/app/src/main/res/values/strings.xml
+++ b/android/Reguerta/app/src/main/res/values/strings.xml
@@ -331,8 +331,8 @@
     <string name="my_order_total_format">Total: %1$s</string>
     <string name="my_order_confirmed_total_sum_format">Order total: %1$s</string>
     <string name="my_order_producer_subtotal_format">Total: %1$s</string>
-    <string name="my_order_previous_title">My last order</string>
-    <string name="my_order_previous_week_format">Week %1$s</string>
+    <string name="my_order_previous_title">Mi último pedido</string>
+    <string name="my_order_previous_week_format">Semana %1$s</string>
     <string name="my_order_previous_loading">Loading previous order…</string>
     <string name="my_order_previous_empty">No order was registered last week</string>
     <string name="my_order_previous_error">We could not load your previous-week order.</string>

--- a/spec/issues/hu-062-android-order-card-polish-issue.md
+++ b/spec/issues/hu-062-android-order-card-polish-issue.md
@@ -1,0 +1,48 @@
+# [HU-062] Pulir cards de pedidos Android con paridad iOS
+
+## Summary
+
+Ajustar las pantallas Android de `Mi último pedido` y `Todos mis pedidos` para que las cards de resumen de pedido usen el fondo verde del diseño iOS, el título principal quede limpio bajo la flecha de volver y las filas de producto se formateen con una estructura visual equivalente a iOS.
+
+## Links
+- GitHub Issue: #161
+- URL: https://github.com/JFrancoG/ReguertaPlus/issues/161
+- Spec: spec/orders/hu-062-android-order-card-polish/spec.md
+- Plan: spec/orders/hu-062-android-order-card-polish/plan.md
+- Tasks: spec/orders/hu-062-android-order-card-polish/tasks.md
+
+## Acceptance criteria
+
+- Las cards de productores en Android dejan de usar el fondo gris/morado actual y pasan a un contenedor verde alineado con iOS.
+- `Mi último pedido` muestra solo el título principal de la pantalla bajo la flecha de volver, sin duplicar un título de shell tipo `Order`.
+- `Mi último pedido` no muestra una línea secundaria con el week key (`Semana 2026-Wxx`).
+- `Todos mis pedidos` conserva el rango/selector semanal y usa el mismo patrón de card y filas que `Mi último pedido`.
+- En `Todos mis pedidos`, el rango `Pedido dd MMM - dd MMM` se muestra dentro de la pantalla bajo la flecha de volver, no como título centrado del top bar.
+- Las flechas y el selector semanal usan superficies verdes del tema, sin caer en el `primaryContainer` morado.
+- Cada fila de producto se organiza con descripción a la izquierda, cantidad centrada y precio a la derecha, con separadores verticales/horizontales equivalentes al layout iOS.
+- La descripción de envase muestra `(cantidad envase si != 1) envase cantidad medida medida`, no vuelve a usar el envase como unidad de medida.
+- La corrección no cambia lecturas Firestore, histórico semanal ni cálculos de total.
+
+## Scope
+
+### In Scope
+- Android, pantallas de pedidos personales.
+- Reutilización del componente visual de resumen de pedido cuando sea posible.
+- Specs y mirror de issue bajo `spec/`.
+
+### Out of Scope
+- Cambios iOS.
+- Cambios backend/Firestore.
+- Rediseño global de navegación.
+
+## Implementation checklist
+- [x] Crear artefactos HU/spec/plan/tasks.
+- [x] Ajustar componente Android de cards de resumen.
+- [x] Ajustar título principal en `Mi último pedido`.
+- [x] Validar unit tests/lint Android relevantes.
+
+## Suggested labels
+- type:feature
+- area:orders
+- platform:android
+- priority:P2

--- a/spec/orders/hu-062-android-order-card-polish/plan.md
+++ b/spec/orders/hu-062-android-order-card-polish/plan.md
@@ -1,0 +1,25 @@
+# Plan - HU-062 (Android order card polish)
+
+## Approach
+
+Keep this as a focused Android UI polish pass. Reuse the existing order summary route and history route, sharing one corrected card/row treatment where the codebase already shares the component.
+
+## Implementation steps
+
+1. Locate the Android composables for `Mi último pedido`, `Todos mis pedidos`, and shared order summary cards.
+2. Compare Android row/card structure against the iOS screenshots and source where useful.
+3. Replace the gray/purple producer card surface with the green order-card surface used by the iOS reference.
+4. Rework product rows into description, quantity, and price columns with subtle separators.
+5. Suppress the duplicate shell title for `Mi último pedido` while keeping the route heading visible below the back arrow.
+6. Run focused Android validation and update tasks with evidence.
+
+## Validation
+
+- Android: `./gradlew app:testDebugUnitTest`
+- Android: `./gradlew app:lintDebug`
+- Android: `./gradlew app:connectedDebugAndroidTest` only if an emulator/device is available, because this is UI-facing.
+
+## Notes
+
+- iOS is the visual reference for this pass.
+- There is no expected iOS or backend code change.

--- a/spec/orders/hu-062-android-order-card-polish/spec.md
+++ b/spec/orders/hu-062-android-order-card-polish/spec.md
@@ -1,0 +1,70 @@
+# HU-062 - Android order card polish
+
+## Metadata
+- issue_id: 161
+- priority: P2
+- platform: android
+- status: implemented-local
+
+## Context and problem
+
+Android already has functional personal order summary screens, but the current visual treatment diverges from the iOS reference captured during review.
+
+The producer cards in `Mi último pedido` and `Todos mis pedidos` use a gray/purple surface that reads as accidental inside the dark green app shell. `Mi último pedido` also shows an extra shell title above the real screen title. Product rows are readable, but they do not follow the iOS structure where description, quantity, and price sit in clear columns with subtle separators.
+
+## User story
+
+As a member I want my Android order summaries to match the iOS visual structure so that recent and historical orders feel coherent across platforms.
+
+## Scope
+
+### In Scope
+- Update Android producer summary cards for `Mi último pedido`.
+- Update Android producer summary cards for `Todos mis pedidos`.
+- Remove or suppress the duplicate shell title on `Mi último pedido` while keeping the real screen title under the back arrow.
+- Format product rows with left description, centered quantity, right price, and subtle dividers aligned with iOS.
+- Keep all order totals, week selection, and data reads unchanged.
+
+### Out of Scope
+- iOS UI changes.
+- Backend, Firestore, or Cloud Functions changes.
+- Navigation model changes outside the affected title treatment.
+- Broad design-system refactors.
+
+## Acceptance criteria
+
+- Android producer cards use a green order-card surface aligned with the iOS screenshots instead of the current gray/purple background.
+- `Mi último pedido` does not show a duplicate `Order`/shell title above the main `Mi último pedido` heading.
+- `Mi último pedido` does not show the raw week-key line (`Semana 2026-Wxx`) under the heading.
+- `Todos mis pedidos` keeps the weekly range title and selector while reusing the corrected card and row treatment.
+- `Todos mis pedidos` renders the order range below the back arrow inside the route content instead of centered in the shell top bar.
+- Weekly previous/next buttons and picker use green theme surfaces instead of the purple `primaryContainer` fallback.
+- Each product row visually separates description, quantity, and price into stable columns on phone widths.
+- Product metadata under the name shows optional container quantity + container name followed by measure quantity + measure name.
+- Producer subtotal remains visually distinct and right aligned.
+- Existing empty/loading/error states continue to work.
+- No order data, totals, Firestore queries, or history bounds change.
+
+## Dependencies
+
+- Existing HU-058 weekly order history.
+- Existing HU-005 previous-order summary behavior.
+- iOS screenshots and implementation as visual reference for row formatting.
+
+## Risks
+
+- Risk: tighter columns may truncate long product names on narrow screens.
+  - Mitigation: keep the name column flexible, allow line wrapping, and use fixed-width trailing columns only where needed.
+- Risk: title changes could affect other routes that rely on the same shell API.
+  - Mitigation: scope the shell-title override to the previous-order route.
+- Risk: shared order summary components may affect both current and history screens.
+  - Mitigation: intentionally reuse the corrected card treatment and validate both routes.
+
+## Definition of Done (DoD)
+
+- [x] Acceptance criteria validated on Android.
+- [x] Android unit tests run.
+- [x] Android lint run or skipped with a documented reason.
+- [x] Android connected tests run on an available emulator.
+- [x] Documentation/tasks updated with validation evidence.
+- [ ] PR linked.

--- a/spec/orders/hu-062-android-order-card-polish/tasks.md
+++ b/spec/orders/hu-062-android-order-card-polish/tasks.md
@@ -1,0 +1,38 @@
+# Tasks - HU-062 (Android order card polish)
+
+GitHub tracking:
+
+- #161 - Pulir cards de pedidos Android con paridad iOS.
+
+## 1. Bootstrap
+- [x] Create GitHub issue.
+- [x] Create branch `codex/hu-062-android-order-card-polish`.
+- [x] Add issue mirror, spec, plan, and tasks.
+
+## 2. Android UI
+- [x] Locate shared order summary card composables.
+- [x] Replace gray/purple producer card surface with green order-card surface.
+- [x] Format product rows into iOS-like description, quantity, and price columns.
+- [x] Remove duplicate shell title from `Mi último pedido`.
+- [x] Verify `Todos mis pedidos` keeps weekly navigation and uses corrected cards.
+- [x] Remove raw week-key subtitle from `Mi último pedido`.
+- [x] Move the `Todos mis pedidos` order range below the back arrow.
+- [x] Replace purple weekly selector controls with green themed surfaces.
+- [x] Correct order-line packaging text to use container plus measure.
+
+## 3. Validation
+- [x] Run Android unit tests.
+- [x] Run Android lint.
+- [x] Run Android instrumented tests or document why unavailable.
+- [x] Record manual visual/source checks.
+
+Validation evidence:
+
+- `./gradlew app:testDebugUnitTest` passed.
+- `./gradlew app:lintDebug` passed.
+- `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest` passed on Pixel_4_A12_API29 AVD.
+- Manual source check: Android `Mi último pedido` and `Todos mis pedidos` now share `PersonalOrderSummaryProducerCard`; iOS screenshots/source were used as the row/card reference, and the follow-up screenshot issues were checked against the edited code paths.
+
+## 4. Closure
+- [x] Update task status and validation evidence.
+- [ ] Open PR linked to #161.


### PR DESCRIPTION
## Summary

- Polish Android personal order summary cards for `Mi último pedido` and `Todos mis pedidos` using the green order-card surface.
- Align order rows with iOS-style description, quantity, price columns and corrected packaging text.
- Move the order-history date range below the back arrow and keep the back arrow closer to the screen edge.
- Add HU-062 spec, plan, tasks, issue mirror, and changelog entry.

## Validation

- `./gradlew app:testDebugUnitTest`
- `./gradlew app:lintDebug`
- `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest` on Pixel_4_A12_API29 AVD

## Notes

- iOS was used as visual reference; no iOS changes are included in this PR.
- There is a local unstaged iOS formatting change in `ShiftsFeatureSupport.swift` that is intentionally excluded from this branch commit.

Closes #161