### PR TITLE
Fix delivery helper assignment and shifts UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ All notable changes to this project will be documented in this file.
 
 ### Documentation
 
+- 2026-07-10 | 📝 docs(shifts): link HU-063 pull request
 - 2026-05-03 | 📝 docs(design): refine home drawer proposal
 - 2026-05-03 | 📝 docs(design): add home drawer proposal
 - 2026-05-03 | 📝 docs(design): add home dashboard proposal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-10 | 🐛 fix(shifts): align helper assignments
 - 2026-07-08 | 🐛 fix(android-orders): polish order cards
 - 2026-07-07 | 🐛 fix(ui): polish drawer and mobile spacing
 - 2026-07-07 | 🐛 fix(home): align weekly delivery summary

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootHomeRoute.kt
@@ -389,6 +389,7 @@ internal fun HomeRoute(
                             stringResource(R.string.news_editor_title_edit)
                         }
                         currentDestination == HomeDestination.NOTIFICATIONS -> ""
+                        currentDestination == HomeDestination.SHIFTS -> ""
                         currentDestination == HomeDestination.PROFILE && !sharedProfileTitleOverride.isNullOrBlank() -> {
                             sharedProfileTitleOverride.orEmpty()
                         }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootSettingsDeliveryCalendarComponents.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootSettingsDeliveryCalendarComponents.kt
@@ -71,7 +71,7 @@ internal fun DeliveryCalendarWeekPickerDialog(
                 fontWeight = FontWeight.SemiBold,
             )
             Text(
-                text = "Selecciona un dia de reparto futuro con encargado.",
+                text = "Selecciona un dia de reparto futuro con responsable.",
                 style = MaterialTheme.typography.bodyMedium,
             )
             ExposedDropdownMenuBox(

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootShiftSupport.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootShiftSupport.kt
@@ -74,7 +74,7 @@ internal fun ShiftAssignment.leftBoardLines(overrides: List<DeliveryCalendarOver
         val localDate = effectiveDateMillis(overrides).toLocalDate()
         listOf(
             ShiftBoardLine(
-                text = localDate.toLocalizedMonthLabel(),
+                text = localDate.toLocalizedMonthYearLabel(),
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
@@ -93,10 +93,13 @@ internal fun ShiftAssignment.leftBoardLines(overrides: List<DeliveryCalendarOver
     }
 }
 
-internal fun ShiftAssignment.primaryBoardNames(members: List<Member>): List<String> = when (type) {
+internal fun ShiftAssignment.primaryBoardNames(
+    members: List<Member>,
+    resolvedHelperUserId: String?,
+): List<String> = when (type) {
     ShiftType.DELIVERY -> buildList {
         assignedUserIds.firstOrNull()?.let { add(members.displayNameFor(it)) }
-        add(helperUserId?.let { members.displayNameFor(it) } ?: "—")
+        add(resolvedHelperUserId?.let { members.displayNameFor(it) } ?: "—")
     }.ifEmpty { listOf("—", "—") }
     ShiftType.MARKET -> assignedUserIds
         .map { memberId -> members.displayNameFor(memberId) }
@@ -109,6 +112,18 @@ internal fun ShiftAssignment.primaryBoardNames(members: List<Member>): List<Stri
         }
 }
 
+internal fun List<ShiftAssignment>.resolvedHelperUserIdFor(shift: ShiftAssignment): String? {
+    if (shift.type != ShiftType.DELIVERY) return null
+
+    return asSequence()
+        .filter { candidate ->
+            candidate.type == ShiftType.DELIVERY && candidate.dateMillis > shift.dateMillis
+        }
+        .minByOrNull { candidate -> candidate.dateMillis }
+        ?.assignedUserIds
+        ?.firstOrNull()
+}
+
 internal fun ShiftAssignment.canBeRequestedBy(
     currentMemberId: String,
     overrides: List<DeliveryCalendarOverride>,
@@ -119,10 +134,13 @@ internal fun ShiftAssignment.canBeRequestedBy(
         assignedUserIds.contains(currentMemberId)
 }
 
-internal fun ShiftAssignment.highlightedBoardNameIndex(currentMemberId: String): Int? = when (type) {
+internal fun ShiftAssignment.highlightedBoardNameIndex(
+    currentMemberId: String,
+    resolvedHelperUserId: String?,
+): Int? = when (type) {
     ShiftType.DELIVERY -> when {
         assignedUserIds.firstOrNull() == currentMemberId -> 0
-        helperUserId == currentMemberId -> 1
+        resolvedHelperUserId == currentMemberId -> 1
         else -> null
     }
     ShiftType.MARKET -> assignedUserIds.indexOf(currentMemberId).takeIf { it >= 0 }
@@ -137,7 +155,7 @@ internal fun List<ShiftAssignment>.nextDeliveryLeadShift(
         .filter { shift ->
             shift.type == ShiftType.DELIVERY &&
                 shift.assignedUserIds.firstOrNull() == memberId &&
-                shift.effectiveDateMillis(overrides) >= nowMillis
+                shift.isUpcomingEffectiveDay(overrides, nowMillis)
         }
         .minByOrNull { shift -> shift.effectiveDateMillis(overrides) }
 
@@ -146,13 +164,13 @@ internal fun List<ShiftAssignment>.nextDeliveryHelperShift(
     overrides: List<DeliveryCalendarOverride>,
     nowMillis: Long,
 ): ShiftAssignment? =
-    asSequence()
-        .filter { shift ->
-            shift.type == ShiftType.DELIVERY &&
-                shift.helperUserId == memberId &&
-                shift.effectiveDateMillis(overrides) >= nowMillis
-        }
-        .minByOrNull { shift -> shift.effectiveDateMillis(overrides) }
+    nextDeliveryLeadShift(memberId, overrides, nowMillis)?.let { nextLeadShift ->
+        asSequence()
+            .filter { shift ->
+                shift.type == ShiftType.DELIVERY && shift.dateMillis < nextLeadShift.dateMillis
+            }
+            .maxByOrNull { shift -> shift.dateMillis }
+    }
 
 internal fun List<ShiftAssignment>.nextMarketAssignedShift(
     memberId: String,
@@ -163,7 +181,7 @@ internal fun List<ShiftAssignment>.nextMarketAssignedShift(
         .filter { shift ->
             shift.type == ShiftType.MARKET &&
                 shift.assignedUserIds.contains(memberId) &&
-                shift.effectiveDateMillis(overrides) >= nowMillis
+                shift.isUpcomingEffectiveDay(overrides, nowMillis)
         }
         .minByOrNull { shift -> shift.effectiveDateMillis(overrides) }
 
@@ -318,9 +336,20 @@ private fun LocalDate.toLocalizedBoardDate(): String {
     return "$weekday $dayOfMonth $month"
 }
 
-private fun LocalDate.toLocalizedMonthLabel(): String {
+private fun ShiftAssignment.isUpcomingEffectiveDay(
+    overrides: List<DeliveryCalendarOverride>,
+    nowMillis: Long,
+): Boolean =
+    effectiveDateMillis(overrides).toLocalDate() >= nowMillis.toLocalDate()
+
+private fun LocalDate.toLocalizedMonthYearLabel(): String {
     val locale = Locale.getDefault()
-    return month.getDisplayName(TextStyle.FULL, locale).toTitleCase(locale)
+    val monthLabel = month
+        .getDisplayName(TextStyle.SHORT, locale)
+        .trimEnd('.')
+        .take(3)
+        .toTitleCase(locale)
+    return "$monthLabel $year"
 }
 
 private fun LocalDate.toLocalizedWeekdayLabel(): String {

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootShiftsRoutes.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/access/ReguertaRootShiftsRoutes.kt
@@ -2,12 +2,15 @@ package com.reguerta.user.presentation.access
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -18,7 +21,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -35,6 +37,7 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.reguerta.user.R
@@ -89,6 +92,13 @@ fun ShiftsRoute(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
+        Text(
+            text = stringResource(R.string.shifts_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.semantics { heading() },
+        )
+
         if (hasShiftSwapActivity) {
             ShiftSwapRequestsCard(
                 requests = shiftSwapRequests,
@@ -169,12 +179,16 @@ private fun MyNextShiftsSection(
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(10.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
             text = stringResource(R.string.shifts_next_title),
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.SemiBold,
-            modifier = Modifier.semantics { heading() },
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Normal,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { heading() },
         )
 
         if (isLoading) {
@@ -182,6 +196,8 @@ private fun MyNextShiftsSection(
                 text = stringResource(R.string.shifts_loading),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
             )
         } else {
             ReguertaCard(
@@ -190,22 +206,25 @@ private fun MyNextShiftsSection(
                 Column(
                     modifier = Modifier.fillMaxWidth(),
                     verticalArrangement = Arrangement.spacedBy(10.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(16.dp),
-                        verticalAlignment = Alignment.Top,
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
                             text = stringResource(R.string.shifts_type_delivery),
-                            style = MaterialTheme.typography.titleSmall,
+                            style = MaterialTheme.typography.bodyLarge,
                             fontWeight = FontWeight.SemiBold,
                             color = MaterialTheme.colorScheme.primary,
+                            textAlign = TextAlign.Center,
                             modifier = Modifier.weight(1f),
                         )
                         Column(
                             modifier = Modifier.weight(2f),
                             verticalArrangement = Arrangement.spacedBy(8.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
                         ) {
                             NextShiftDateLine(
                                 label = stringResource(R.string.shifts_next_delivery_helper),
@@ -223,20 +242,22 @@ private fun MyNextShiftsSection(
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(16.dp),
-                        verticalAlignment = Alignment.Top,
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
                             text = stringResource(R.string.shifts_type_market),
-                            style = MaterialTheme.typography.titleSmall,
+                            style = MaterialTheme.typography.bodyLarge,
                             fontWeight = FontWeight.SemiBold,
                             color = MaterialTheme.colorScheme.primary,
+                            textAlign = TextAlign.Center,
                             modifier = Modifier.weight(1f),
                         )
                         Text(
                             text = marketShift.shiftShortDateLabel(deliveryCalendarOverrides),
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.SemiBold,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Normal,
                             color = MaterialTheme.colorScheme.onSurface,
+                            textAlign = TextAlign.Center,
                             modifier = Modifier.weight(2f),
                         )
                     }
@@ -254,10 +275,11 @@ private fun NextShiftDateLine(
     modifier: Modifier = Modifier,
 ): Unit = Text(
     text = "$value $label",
-    modifier = modifier,
-    style = if (prominent) MaterialTheme.typography.titleMedium else MaterialTheme.typography.bodyMedium,
-    fontWeight = if (prominent) FontWeight.SemiBold else FontWeight.Normal,
+    modifier = modifier.fillMaxWidth(),
+    style = if (prominent) MaterialTheme.typography.bodyMedium else MaterialTheme.typography.bodySmall,
+    fontWeight = FontWeight.Normal,
     color = MaterialTheme.colorScheme.onSurface,
+    textAlign = TextAlign.Center,
 )
 
 @Composable
@@ -342,6 +364,7 @@ private fun ShiftBoardSection(
                     ) { shift ->
                         ShiftBoardCard(
                             shift = shift,
+                            deliveryShifts = deliveryShifts,
                             deliveryCalendarOverrides = deliveryCalendarOverrides,
                             members = members,
                             currentMemberId = currentMemberId,
@@ -370,11 +393,10 @@ private fun ShiftBoardSegmentSelector(
     ) {
         ShiftBoardSegment.entries.forEach { segment ->
             val isSelected = selectedSegment == segment
-            TextButton(
-                onClick = { onSegmentSelected(segment) },
+            Box(
                 modifier = Modifier
                     .weight(1f)
-                    .clip(RoundedCornerShape(20.dp))
+                    .clip(RoundedCornerShape(18.dp))
                     .semantics { selected = isSelected }
                     .background(
                         if (isSelected) {
@@ -382,10 +404,14 @@ private fun ShiftBoardSegmentSelector(
                         } else {
                             MaterialTheme.colorScheme.surface.copy(alpha = 0f)
                         }
-                    ),
+                    )
+                    .clickable { onSegmentSelected(segment) }
+                    .padding(vertical = 7.dp, horizontal = 8.dp),
+                contentAlignment = Alignment.Center,
             ) {
                 Text(
                     text = stringResource(segment.labelRes),
+                    style = MaterialTheme.typography.bodyLarge,
                     color = if (isSelected) {
                         MaterialTheme.colorScheme.primary
                     } else {
@@ -401,20 +427,24 @@ private fun ShiftBoardSegmentSelector(
 @Composable
 private fun ShiftBoardCard(
     shift: ShiftAssignment,
+    deliveryShifts: List<ShiftAssignment>,
     deliveryCalendarOverrides: List<DeliveryCalendarOverride>,
     members: List<Member>,
     currentMemberId: String?,
     containerColor: Color,
     onRequestShiftSwap: (String) -> Unit,
 ) {
-    val primaryNames = shift.primaryBoardNames(members)
+    val resolvedHelperUserId = remember(shift, deliveryShifts) {
+        deliveryShifts.resolvedHelperUserIdFor(shift)
+    }
+    val primaryNames = shift.primaryBoardNames(members, resolvedHelperUserId)
     val leftLines = shift.leftBoardLines(deliveryCalendarOverrides)
     val leftAlignment = if (shift.type == ShiftType.MARKET) Alignment.CenterHorizontally else Alignment.Start
     val canRequestShiftSwap = remember(shift, currentMemberId, deliveryCalendarOverrides) {
         currentMemberId != null && shift.canBeRequestedBy(currentMemberId, deliveryCalendarOverrides)
     }
-    val highlightedIndex = remember(shift, currentMemberId) {
-        currentMemberId?.let { shift.highlightedBoardNameIndex(it) }
+    val highlightedIndex = remember(shift, currentMemberId, resolvedHelperUserId) {
+        currentMemberId?.let { shift.highlightedBoardNameIndex(it, resolvedHelperUserId) }
     }
     Card(
         colors = CardDefaults.cardColors(containerColor = containerColor),
@@ -427,10 +457,11 @@ private fun ShiftBoardCard(
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Column(
-                    modifier = Modifier.weight(0.38f),
+                    modifier = Modifier.weight(0.30f),
                     horizontalAlignment = leftAlignment,
                     verticalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
@@ -446,7 +477,7 @@ private fun ShiftBoardCard(
                 }
 
                 Column(
-                    modifier = Modifier.weight(0.62f),
+                    modifier = Modifier.weight(0.70f),
                     verticalArrangement = Arrangement.spacedBy(6.dp),
                 ) {
                     primaryNames.forEachIndexed { index, name ->
@@ -466,6 +497,8 @@ private fun ShiftBoardCard(
                             } else {
                                 MaterialTheme.colorScheme.onSurface
                             },
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                         )
                     }
                     if (shift.status != ShiftStatus.PLANNED) {
@@ -478,12 +511,19 @@ private fun ShiftBoardCard(
                 }
             }
             if (highlightedIndex != null && canRequestShiftSwap) {
-                ReguertaButton(
-                    label = stringResource(R.string.shift_swap_request_button_label),
-                    variant = ReguertaButtonVariant.SECONDARY,
-                    fullWidth = false,
-                    onClick = { onRequestShiftSwap(shift.id) },
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    ReguertaButton(
+                        label = stringResource(R.string.shift_swap_request_button_label),
+                        variant = ReguertaButtonVariant.SECONDARY,
+                        modifier = Modifier.widthIn(min = 192.dp),
+                        cornerRadius = 999.dp,
+                        fullWidth = false,
+                        onClick = { onRequestShiftSwap(shift.id) },
+                    )
+                }
             }
         }
     }

--- a/android/Reguerta/app/src/main/res/values-es/strings.xml
+++ b/android/Reguerta/app/src/main/res/values-es/strings.xml
@@ -82,7 +82,7 @@
     <string name="home_shell_badge_soon">Pronto</string>
     <string name="home_shell_weekly_title">Contexto semanal</string>
     <string name="home_shell_weekly_responsible">Responsable</string>
-    <string name="home_shell_weekly_support">Ayudante</string>
+    <string name="home_shell_weekly_support">Apoyo</string>
     <string name="home_shell_weekly_main_producer">Productor principal</string>
     <string name="home_shell_weekly_delivery">Día de reparto</string>
     <string name="home_shell_weekly_delivery_default">Miércoles</string>
@@ -110,8 +110,8 @@
     <string name="shifts_next_title">Mis próximos turnos</string>
     <string name="shifts_next_subtitle">Consulta tu próximo reparto y tu próximo mercado.</string>
     <string name="shifts_next_delivery">Próximo reparto</string>
-    <string name="shifts_next_delivery_lead">Encargado</string>
-    <string name="shifts_next_delivery_helper">Ayudante</string>
+    <string name="shifts_next_delivery_lead">Responsable</string>
+    <string name="shifts_next_delivery_helper">Apoyo</string>
     <string name="shifts_next_market">Próximo mercado</string>
     <string name="shifts_next_pending">Pendiente de asignación</string>
     <string name="shifts_view_all">Ver todos los turnos</string>
@@ -158,7 +158,7 @@
     <string name="shift_swap_request_status_applied">Aplicada</string>
     <string name="feedback_shift_swap_no_candidates">Todavía no hay socios futuros válidos a los que pedir el cambio.</string>
     <string name="shifts_assigned_members_format">Asignados: %1$s</string>
-    <string name="shifts_helper_format">Ayudante: %1$s</string>
+    <string name="shifts_helper_format">Apoyo: %1$s</string>
     <string name="home_shell_news_title">Últimas noticias</string>
     <string name="home_shell_news_intro">Este espacio queda preparado para mostrar las últimas novedades de la comunidad.</string>
     <string name="home_shell_news_item_one">Aquí aparecerán avisos semanales y cambios de reparto.</string>
@@ -202,7 +202,7 @@
     <string name="users_editor_title_edit">Actualizar regüertense</string>
     <string name="users_editor_company_name_label">Nombre de la empresa</string>
     <string name="users_editor_phone_label">Teléfono</string>
-    <string name="users_editor_common_purchase_manager_label">Socio encargado de compras comunes</string>
+    <string name="users_editor_common_purchase_manager_label">Socio responsable de compras comunes</string>
     <string name="users_editor_save_action_create">Autorizar</string>
     <string name="users_editor_save_action_update">Actualizar</string>
     <string name="users_card_action_edit">Editar usuario</string>

--- a/android/Reguerta/app/src/main/res/values/strings.xml
+++ b/android/Reguerta/app/src/main/res/values/strings.xml
@@ -110,8 +110,8 @@
     <string name="shifts_next_title">My next shifts</string>
     <string name="shifts_next_subtitle">Keep track of your upcoming delivery and market assignments.</string>
     <string name="shifts_next_delivery">Next delivery</string>
-    <string name="shifts_next_delivery_lead">Lead</string>
-    <string name="shifts_next_delivery_helper">Helper</string>
+    <string name="shifts_next_delivery_lead">Responsible</string>
+    <string name="shifts_next_delivery_helper">Support</string>
     <string name="shifts_next_market">Next market</string>
     <string name="shifts_next_pending">Pending assignment</string>
     <string name="shifts_view_all">View all shifts</string>
@@ -158,7 +158,7 @@
     <string name="shift_swap_request_status_applied">Applied</string>
     <string name="feedback_shift_swap_no_candidates">There are no eligible future members to request a swap from yet.</string>
     <string name="shifts_assigned_members_format">Assigned: %1$s</string>
-    <string name="shifts_helper_format">Helper: %1$s</string>
+    <string name="shifts_helper_format">Support: %1$s</string>
     <string name="home_shell_news_title">Latest news</string>
     <string name="home_shell_news_intro">This space is ready for the latest community updates.</string>
     <string name="home_shell_news_item_one">Weekly notices and delivery changes will appear here.</string>
@@ -202,7 +202,7 @@
     <string name="users_editor_title_edit">Update Regüertense</string>
     <string name="users_editor_company_name_label">Company name</string>
     <string name="users_editor_phone_label">Phone number</string>
-    <string name="users_editor_common_purchase_manager_label">Member in charge of common purchases</string>
+    <string name="users_editor_common_purchase_manager_label">Member responsible for common purchases</string>
     <string name="users_editor_save_action_create">Authorize</string>
     <string name="users_editor_save_action_update">Update</string>
     <string name="users_card_action_edit">Edit user</string>

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/access/ShiftPresentationHelpersTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/access/ShiftPresentationHelpersTest.kt
@@ -24,9 +24,9 @@ class ShiftPresentationHelpersTest {
         val memberId = "member_1"
         val shifts = listOf(
             deliveryShift(
-                id = "past_lead",
+                id = "helper_for_next_lead",
                 date = LocalDate.of(2026, 5, 1),
-                assignedUserIds = listOf(memberId),
+                assignedUserIds = listOf("member_2"),
             ),
             deliveryShift(
                 id = "next_lead",
@@ -34,10 +34,9 @@ class ShiftPresentationHelpersTest {
                 assignedUserIds = listOf(memberId),
             ),
             deliveryShift(
-                id = "next_helper",
+                id = "following_delivery",
                 date = LocalDate.of(2026, 5, 15),
                 assignedUserIds = listOf("member_2"),
-                helperUserId = memberId,
             ),
             marketShift(
                 id = "next_market",
@@ -48,8 +47,51 @@ class ShiftPresentationHelpersTest {
         val nowMillis = millis(LocalDate.of(2026, 5, 2))
 
         assertEquals("next_lead", shifts.nextDeliveryLeadShift(memberId, emptyList(), nowMillis)?.id)
-        assertEquals("next_helper", shifts.nextDeliveryHelperShift(memberId, emptyList(), nowMillis)?.id)
+        assertEquals("helper_for_next_lead", shifts.nextDeliveryHelperShift(memberId, emptyList(), nowMillis)?.id)
         assertEquals("next_market", shifts.nextMarketAssignedShift(memberId, emptyList(), nowMillis)?.id)
+    }
+
+    @Test
+    fun nextDeliveryHelperStaysPairedWithFollowingLeadAfterHelperDate() {
+        val memberId = "nohemi"
+        val helperDelivery = deliveryShift(
+            id = "delivery_2026_w28",
+            date = LocalDate.of(2026, 7, 8),
+            assignedUserIds = listOf("mercedes"),
+        )
+        val leadDelivery = deliveryShift(
+            id = "delivery_2026_w29",
+            date = LocalDate.of(2026, 7, 15),
+            assignedUserIds = listOf(memberId),
+        )
+        val shifts = listOf(helperDelivery, leadDelivery)
+        val nowMillis = millis(LocalDate.of(2026, 7, 10)) + 15L * 60L * 60L * 1_000L
+
+        assertEquals("delivery_2026_w28", shifts.nextDeliveryHelperShift(memberId, emptyList(), nowMillis)?.id)
+        assertEquals("delivery_2026_w29", shifts.nextDeliveryLeadShift(memberId, emptyList(), nowMillis)?.id)
+    }
+
+    @Test
+    fun deliveryBoardDerivesHelperFromFollowingLeadInsteadOfStoredHelper() {
+        val helperDelivery = deliveryShift(
+            id = "delivery_2026_w29",
+            date = LocalDate.of(2026, 7, 15),
+            assignedUserIds = listOf("nohemi"),
+            helperUserId = "stale_helper",
+        )
+        val followingLead = deliveryShift(
+            id = "delivery_2026_w30",
+            date = LocalDate.of(2026, 7, 22),
+            assignedUserIds = listOf("pedro"),
+            helperUserId = "stale_last_helper",
+        )
+        val shifts = listOf(helperDelivery, followingLead)
+
+        val resolvedHelperUserId = shifts.resolvedHelperUserIdFor(helperDelivery)
+
+        assertEquals("pedro", resolvedHelperUserId)
+        assertEquals(1, helperDelivery.highlightedBoardNameIndex("pedro", resolvedHelperUserId))
+        assertEquals(null, shifts.resolvedHelperUserIdFor(followingLead))
     }
 
     @Test

--- a/ios/Reguerta/Reguerta/Presentation/Root/ContentView+DomainSupport.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Root/ContentView+DomainSupport.swift
@@ -201,6 +201,18 @@ extension Date {
         return formatter.string(from: self).replacingOccurrences(of: ".", with: "")
     }
 
+    var shortMonthYearLabel: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateFormat = "MMM"
+        let month = formatter.string(from: self)
+            .replacingOccurrences(of: ".", with: "")
+            .prefix(3)
+            .capitalized
+        let year = Calendar.current.component(.year, from: self)
+        return "\(month) \(year)"
+    }
+
     var dayNumberLabel: String {
         let formatter = DateFormatter()
         formatter.locale = Locale.current

--- a/ios/Reguerta/Reguerta/Presentation/Shifts/ContentView+ShiftsRouteComponents.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Shifts/ContentView+ShiftsRouteComponents.swift
@@ -9,7 +9,7 @@ struct ShiftBoardCardView: View {
     let onStartSwapRequestForShift: (String) -> Void
 
     private var leftColumnWidth: CGFloat {
-        shift.type == .market ? 88.resize : 104.resize
+        shift.type == .market ? 80.resize : 88.resize
     }
 
     private var leftAlignment: HorizontalAlignment {
@@ -18,7 +18,7 @@ struct ShiftBoardCardView: View {
 
     private var highlightedIndex: Int? {
         guard let currentMemberId = viewModel.currentMember?.id else { return nil }
-        return shift.highlightedBoardNameIndex(for: currentMemberId)
+        return viewModel.highlightedBoardNameIndex(for: shift, currentMemberId: currentMemberId)
     }
 
     private var canRequestSwap: Bool {
@@ -26,30 +26,45 @@ struct ShiftBoardCardView: View {
         return viewModel.canRequestSwapForShift(shift, currentMemberId: currentMemberId)
     }
 
+    private var leftLines: [ShiftBoardDisplayLine] {
+        viewModel.shiftLeftBoardLines(shift, tokens: tokens).enumerated().map { index, line in
+            ShiftBoardDisplayLine(id: "\(shift.id)-left-\(index)", line: line)
+        }
+    }
+
+    private var boardNames: [ShiftBoardDisplayName] {
+        viewModel.boardNames(for: shift).enumerated().map { index, name in
+            ShiftBoardDisplayName(id: "\(shift.id)-name-\(index)", index: index, name: name)
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: tokens.spacing.sm) {
-            HStack(alignment: .top, spacing: tokens.spacing.md) {
+            HStack(alignment: .center, spacing: tokens.spacing.md) {
                 VStack(alignment: leftAlignment, spacing: tokens.spacing.xs) {
-                    ForEach(Array(viewModel.shiftLeftBoardLines(shift, tokens: tokens).enumerated()), id: \.offset) { _, line in
-                        Text(line.text)
-                            .font(line.font)
-                            .fontWeight(line.weight)
-                            .foregroundStyle(line.color)
+                    ForEach(leftLines) { item in
+                        Text(item.line.text)
+                            .font(item.line.font)
+                            .fontWeight(item.line.weight)
+                            .foregroundStyle(item.line.color)
                             .multilineTextAlignment(shift.type == .market ? .center : .leading)
                     }
                 }
                 .frame(width: leftColumnWidth, alignment: shift.type == .market ? .center : .leading)
 
                 VStack(alignment: .leading, spacing: tokens.spacing.xs) {
-                    ForEach(Array(shift.boardNames(session: viewModel.currentSession).enumerated()), id: \.offset) { index, name in
-                        Text(name)
-                            .font(boardNameFont(index: index))
-                            .fontWeight(boardNameWeight(index: index))
+                    ForEach(boardNames) { item in
+                        Text(item.name)
+                            .font(boardNameFont(index: item.index))
+                            .fontWeight(boardNameWeight(index: item.index))
                             .foregroundStyle(
-                                highlightedIndex == index
+                                highlightedIndex == item.index
                                 ? tokens.colors.actionPrimary
                                 : tokens.colors.textPrimary
                             )
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.78)
+                            .allowsTightening(true)
                     }
                     if shift.status != .planned {
                         Text(LocalizedStringKey(shift.status.titleKey))
@@ -57,11 +72,18 @@ struct ShiftBoardCardView: View {
                             .foregroundStyle(tokens.colors.textSecondary)
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
             if highlightedIndex != nil && canRequestSwap {
-                reguertaButton(LocalizedStringKey(shiftSwapCopy.ask), variant: .text, fullWidth: false) {
+                reguertaButton(
+                    LocalizedStringKey(shiftSwapCopy.ask),
+                    variant: .secondary,
+                    fullWidth: false,
+                    fixedWidth: 196.resize
+                ) {
                     onStartSwapRequestForShift(shift.id)
                 }
+                .frame(maxWidth: .infinity, alignment: .center)
             }
         }
         .padding(tokens.spacing.lg)
@@ -95,6 +117,17 @@ struct ShiftBoardCardView: View {
         }
         return tokens.colors.actionPrimary.opacity(0.15)
     }
+}
+
+private struct ShiftBoardDisplayLine: Identifiable {
+    let id: String
+    let line: ShiftBoardLine
+}
+
+private struct ShiftBoardDisplayName: Identifiable {
+    let id: String
+    let index: Int
+    let name: String
 }
 
 struct ShiftSwapRequestRouteView: View {

--- a/ios/Reguerta/Reguerta/Presentation/Shifts/ContentView+ShiftsRoutes.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Shifts/ContentView+ShiftsRoutes.swift
@@ -53,20 +53,25 @@ private struct MyNextShiftsSectionView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: tokens.spacing.sm) {
+        VStack(alignment: .center, spacing: tokens.spacing.sm) {
             Text(localizedKey(AccessL10nKey.shiftsNextTitle))
-                .font(tokens.typography.titleCard)
+                .font(tokens.typography.body)
+                .fontWeight(.regular)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity, alignment: .center)
                 .accessibilityAddTraits(.isHeader)
 
             if viewModel.isLoadingShifts {
                 Text(localizedKey(AccessL10nKey.shiftsLoading))
                     .font(tokens.typography.bodySecondary)
                     .foregroundStyle(tokens.colors.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity, alignment: .center)
             } else {
                 reguertaCard {
-                    VStack(alignment: .leading, spacing: tokens.spacing.sm) {
+                    VStack(alignment: .center, spacing: tokens.spacing.sm) {
                         nextShiftRow(titleKey: AccessL10nKey.shiftsTypeDelivery) {
-                            VStack(alignment: .leading, spacing: tokens.spacing.sm) {
+                            VStack(alignment: .center, spacing: tokens.spacing.sm) {
                                 nextDateLine(
                                     titleKey: AccessL10nKey.shiftsNextDeliveryHelper,
                                     value: dateLabel(viewModel.nextDeliveryHelperShift),
@@ -83,9 +88,10 @@ private struct MyNextShiftsSectionView: View {
                             .overlay(tokens.colors.borderSubtle.opacity(0.65))
                         nextShiftRow(titleKey: AccessL10nKey.shiftsTypeMarket) {
                             Text(dateLabel(viewModel.nextMarketAssignedShift))
-                                .font(tokens.typography.titleCard)
-                                .fontWeight(.semibold)
+                                .font(tokens.typography.bodySecondary)
+                                .fontWeight(.regular)
                                 .foregroundStyle(tokens.colors.textPrimary)
+                                .multilineTextAlignment(.center)
                                 .lineLimit(1)
                                 .minimumScaleFactor(0.82)
                         }
@@ -94,30 +100,32 @@ private struct MyNextShiftsSectionView: View {
                 .accessibilityElement(children: .combine)
             }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 
     private func nextShiftRow<Content: View>(
         titleKey: String,
         @ViewBuilder content: () -> Content
     ) -> some View {
-        HStack(alignment: .top, spacing: tokens.spacing.lg) {
+        HStack(alignment: .center, spacing: tokens.spacing.lg) {
             Text(localizedKey(titleKey))
                 .font(tokens.typography.body.weight(.semibold))
                 .foregroundStyle(tokens.colors.actionPrimary)
-                .frame(width: 104, alignment: .leading)
+                .multilineTextAlignment(.center)
+                .frame(width: 104, alignment: .center)
 
             content()
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .center)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 
     private func nextDateLine(titleKey: String, value: String, prominent: Bool) -> some View {
         Text("\(value) \(l10n(titleKey))")
-            .font(prominent ? tokens.typography.titleCard : tokens.typography.bodySecondary)
-            .fontWeight(prominent ? .semibold : .regular)
+            .font(prominent ? tokens.typography.body : tokens.typography.bodySecondary)
+            .fontWeight(.regular)
             .foregroundStyle(tokens.colors.textPrimary)
+            .multilineTextAlignment(.center)
             .lineLimit(1)
             .minimumScaleFactor(0.82)
     }

--- a/ios/Reguerta/Reguerta/Presentation/Shifts/ShiftsFeatureViewModel+Display.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Shifts/ShiftsFeatureViewModel+Display.swift
@@ -7,19 +7,16 @@ extension ShiftsFeatureViewModel {
         return deliveryShifts
             .filter {
                 $0.assignedUserIds.first == memberId &&
-                    effectiveDateMillis(for: $0) >= currentNowMillis
+                    isUpcomingEffectiveDay($0)
             }
             .min { effectiveDateMillis(for: $0) < effectiveDateMillis(for: $1) }
     }
 
     var nextDeliveryHelperShift: ShiftAssignment? {
-        guard let memberId = currentMember?.id else { return nil }
+        guard let nextLeadShift = nextDeliveryLeadShift else { return nil }
         return deliveryShifts
-            .filter {
-                $0.helperUserId == memberId &&
-                    effectiveDateMillis(for: $0) >= currentNowMillis
-            }
-            .min { effectiveDateMillis(for: $0) < effectiveDateMillis(for: $1) }
+            .filter { $0.dateMillis < nextLeadShift.dateMillis }
+            .max { $0.dateMillis < $1.dateMillis }
     }
 
     var nextMarketAssignedShift: ShiftAssignment? {
@@ -27,7 +24,7 @@ extension ShiftsFeatureViewModel {
         return marketShifts
             .filter {
                 $0.assignedUserIds.contains(memberId) &&
-                    effectiveDateMillis(for: $0) >= currentNowMillis
+                    isUpcomingEffectiveDay($0)
             }
             .min { effectiveDateMillis(for: $0) < effectiveDateMillis(for: $1) }
     }
@@ -78,6 +75,14 @@ extension ShiftsFeatureViewModel {
         Date(timeIntervalSince1970: TimeInterval(effectiveDateMillis(for: shift)) / 1_000)
     }
 
+    private func isUpcomingEffectiveDay(_ shift: ShiftAssignment) -> Bool {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(
+            for: Date(timeIntervalSince1970: TimeInterval(currentNowMillis) / 1_000)
+        )
+        return calendar.startOfDay(for: effectiveDate(for: shift)) >= today
+    }
+
     func localizedEffectiveDateTime(_ shift: ShiftAssignment) -> String {
         localizedDateTime(effectiveDateMillis(for: shift))
     }
@@ -109,15 +114,12 @@ extension ShiftsFeatureViewModel {
             ]
         case .market:
             let date = effectiveDate(for: shift)
-            let monthFormatter = DateFormatter()
-            monthFormatter.locale = Locale.current
-            monthFormatter.dateFormat = "LLLL"
             let weekdayFormatter = DateFormatter()
             weekdayFormatter.locale = Locale.current
             weekdayFormatter.dateFormat = "EEEE"
             return [
                 ShiftBoardLine(
-                    text: monthFormatter.string(from: date).capitalized,
+                    text: date.shortMonthYearLabel,
                     font: tokens.typography.bodySecondary,
                     weight: .semibold,
                     color: tokens.colors.textPrimary
@@ -135,6 +137,48 @@ extension ShiftsFeatureViewModel {
                     color: tokens.colors.textPrimary
                 )
             ]
+        }
+    }
+
+    func resolvedHelperUserId(for shift: ShiftAssignment) -> String? {
+        guard shift.type == .delivery else { return nil }
+
+        let followingLead = deliveryShifts
+            .filter { $0.dateMillis > shift.dateMillis }
+            .min { $0.dateMillis < $1.dateMillis }
+
+        return followingLead?.assignedUserIds.first
+    }
+
+    func boardNames(for shift: ShiftAssignment) -> [String] {
+        switch shift.type {
+        case .delivery:
+            let leadName = shift.assignedUserIds.first.map {
+                boardDisplayName(for: $0)
+            } ?? "—"
+            let helperName = resolvedHelperUserId(for: shift).map {
+                boardDisplayName(for: $0)
+            } ?? "—"
+            return [leadName, helperName]
+        case .market:
+            return shift.boardNames(session: currentSession)
+        }
+    }
+
+    private func boardDisplayName(for memberId: String) -> String {
+        guard let currentSession else { return memberId }
+        return displayName(for: memberId, in: currentSession)
+    }
+
+    func highlightedBoardNameIndex(for shift: ShiftAssignment, currentMemberId: String) -> Int? {
+        switch shift.type {
+        case .delivery:
+            if shift.assignedUserIds.first == currentMemberId {
+                return 0
+            }
+            return resolvedHelperUserId(for: shift) == currentMemberId ? 1 : nil
+        case .market:
+            return shift.highlightedBoardNameIndex(for: currentMemberId)
         }
     }
 

--- a/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
+++ b/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
@@ -1475,7 +1475,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Selecciona un día de reparto futuro con encargado."
+            "value" : "Selecciona un día de reparto futuro con responsable."
           }
         }
       }
@@ -3173,7 +3173,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ayudante"
+            "value" : "Apoyo"
           }
         }
       }
@@ -7332,13 +7332,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Helper: %1$@"
+            "value" : "Support: %1$@"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ayudante: %1$@"
+            "value" : "Apoyo: %1$@"
           }
         }
       }
@@ -7400,13 +7400,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Helper"
+            "value" : "Support"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ayudante"
+            "value" : "Apoyo"
           }
         }
       }
@@ -7417,13 +7417,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lead"
+            "value" : "Responsible"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Encargado"
+            "value" : "Responsable"
           }
         }
       }
@@ -7782,13 +7782,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Member in charge of common purchases"
+            "value" : "Member responsible for common purchases"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Socio encargado de compras comunes"
+            "value" : "Socio responsable de compras comunes"
           }
         }
       }

--- a/ios/Reguerta/ReguertaTests/ReguertaShiftsPresentationViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaShiftsPresentationViewModelTests.swift
@@ -16,9 +16,8 @@ struct ReguertaShiftsPresentationViewModelTests {
         let helperDelivery = shift(
             id: "helper_delivery",
             type: .delivery,
-            dateMillis: testMillis(year: 2026, month: 5, day: 15),
-            assignedUserIds: ["member_2"],
-            helperUserId: currentMember.id
+            dateMillis: testMillis(year: 2026, month: 5, day: 1),
+            assignedUserIds: ["member_2"]
         )
         let market = shift(
             id: "market_assigned",
@@ -38,6 +37,69 @@ struct ReguertaShiftsPresentationViewModelTests {
         #expect(viewModel.nextDeliveryLeadShift?.id == leadDelivery.id)
         #expect(viewModel.nextDeliveryHelperShift?.id == helperDelivery.id)
         #expect(viewModel.nextMarketAssignedShift?.id == market.id)
+    }
+
+    @Test
+    func shiftsViewModelDerivesTodayHelperFromFollowingLeadShift() async {
+        let currentMember = shiftMember(id: "nohemi", displayName: "Nohemi")
+        let helperDelivery = shift(
+            id: "delivery_2026_w28",
+            type: .delivery,
+            dateMillis: testMillis(year: 2026, month: 7, day: 8),
+            assignedUserIds: ["mercedes"]
+        )
+        let leadDelivery = shift(
+            id: "delivery_2026_w29",
+            type: .delivery,
+            dateMillis: testMillis(year: 2026, month: 7, day: 15),
+            assignedUserIds: [currentMember.id]
+        )
+        let viewModel = makeShiftsViewModel(
+            currentMember: currentMember,
+            members: [currentMember],
+            shiftRepository: InMemoryShiftRepository(items: [helperDelivery, leadDelivery]),
+            nowMillisProvider: { testMillis(year: 2026, month: 7, day: 10) + 15 * 60 * 60 * 1_000 }
+        )
+
+        await viewModel.refreshShifts()
+
+        #expect(viewModel.nextDeliveryHelperShift?.id == helperDelivery.id)
+        #expect(viewModel.nextDeliveryLeadShift?.id == leadDelivery.id)
+        #expect(viewModel.resolvedHelperUserId(for: helperDelivery) == currentMember.id)
+        #expect(viewModel.boardNames(for: helperDelivery).last == currentMember.displayName)
+        #expect(viewModel.highlightedBoardNameIndex(for: helperDelivery, currentMemberId: currentMember.id) == 1)
+    }
+
+    @Test
+    func shiftsViewModelUsesFollowingLeadOverPersistedHelperForBoardNames() async {
+        let currentMember = shiftMember(id: "nohemi", displayName: "Nohemi")
+        let followingLead = shiftMember(id: "pedro", displayName: "Pedro")
+        let delivery = shift(
+            id: "delivery_2026_w29",
+            type: .delivery,
+            dateMillis: testMillis(year: 2026, month: 7, day: 15),
+            assignedUserIds: [currentMember.id],
+            helperUserId: "stale_helper"
+        )
+        let nextDelivery = shift(
+            id: "delivery_2026_w30",
+            type: .delivery,
+            dateMillis: testMillis(year: 2026, month: 7, day: 22),
+            assignedUserIds: [followingLead.id],
+            helperUserId: "stale_last_helper"
+        )
+        let viewModel = makeShiftsViewModel(
+            currentMember: currentMember,
+            members: [currentMember, followingLead],
+            shiftRepository: InMemoryShiftRepository(items: [delivery, nextDelivery]),
+            nowMillisProvider: { testMillis(year: 2026, month: 7, day: 10) }
+        )
+
+        await viewModel.refreshShifts()
+
+        #expect(viewModel.resolvedHelperUserId(for: delivery) == followingLead.id)
+        #expect(viewModel.boardNames(for: delivery).last == followingLead.displayName)
+        #expect(viewModel.resolvedHelperUserId(for: nextDelivery) == nil)
     }
 
     @Test

--- a/spec/issues/hu-063-shifts-helper-and-ui-polish-issue.md
+++ b/spec/issues/hu-063-shifts-helper-and-ui-polish-issue.md
@@ -1,0 +1,49 @@
+# [HU-063] Corregir ayudante de reparto y pulir UI de turnos
+
+## Summary
+
+Ajustar la pantalla de turnos para que iOS calcule el ayudante de reparto igual que Android y aplicar retoques visuales de paridad en ambas apps.
+
+## Links
+- GitHub Issue: #163
+- URL: https://github.com/JFrancoG/ReguertaPlus/issues/163
+- Spec: spec/shifts/hu-063-shifts-helper-and-ui-polish/spec.md
+- Plan: spec/shifts/hu-063-shifts-helper-and-ui-polish/plan.md
+- Tasks: spec/shifts/hu-063-shifts-helper-and-ui-polish/tasks.md
+
+## Acceptance criteria
+
+- iOS y Android muestran como ayudante a la persona que sera encargada en el siguiente reparto, sin depender del campo persistido; solo la ultima semana sin siguiente reparto queda pendiente.
+- "Mis proximos turnos" / "My next shifts" mantiene la semana de ayudante asociada al siguiente turno de encargado aunque el dia de reparto ya haya pasado.
+- Las fechas de las tarjetas quedan centradas en vertical respecto a los nombres y los nombres largos reciben mas ancho util.
+- El bloque "Mis proximos turnos" / "My next shifts" queda centrado, con fuente ligeramente mas pequena y peso regular.
+- "Solicitar cambio" / "Request swap" se muestra como boton centrado y con el estilo ya usado en Android.
+- En turnos de mercado, el mes se muestra como tres iniciales y ano, por ejemplo "Mar 2026".
+- El titulo principal "Turnos" / "Shifts" aparece debajo de la flecha de vuelta en ambas plataformas.
+
+## Scope
+
+### In Scope
+- Pantallas de turnos Android e iOS.
+- Logica iOS de ayudante/encargado de reparto.
+- Formato de cabeceras de turno de mercado.
+- Specs y mirror de issue bajo `spec/`.
+
+### Out of Scope
+- Cambios en persistencia de solicitudes de cambio.
+- Cambios en la sincronizacion de Google Sheets o Firestore.
+- Redisenar la arquitectura general de turnos.
+
+## Implementation checklist
+- [x] Crear rama y artefactos HU/spec/plan/tasks.
+- [x] Revisar logica actual de turnos en iOS y Android.
+- [x] Corregir calculo iOS de ayudante de reparto con calendario de reparto.
+- [x] Pulir jerarquia visual en ambas apps.
+- [x] Validar con fixtures/datos reales del 8 y 15 de julio de 2026.
+- [x] Ejecutar validacion relevante por plataforma o documentar bloqueos.
+
+## Suggested labels
+- type:feature
+- area:shifts
+- platform:cross
+- priority:P2

--- a/spec/issues/hu-063-shifts-helper-and-ui-polish-issue.md
+++ b/spec/issues/hu-063-shifts-helper-and-ui-polish-issue.md
@@ -7,6 +7,7 @@ Ajustar la pantalla de turnos para que iOS calcule el ayudante de reparto igual 
 ## Links
 - GitHub Issue: #163
 - URL: https://github.com/JFrancoG/ReguertaPlus/issues/163
+- Pull Request: #164 https://github.com/JFrancoG/ReguertaPlus/pull/164
 - Spec: spec/shifts/hu-063-shifts-helper-and-ui-polish/spec.md
 - Plan: spec/shifts/hu-063-shifts-helper-and-ui-polish/plan.md
 - Tasks: spec/shifts/hu-063-shifts-helper-and-ui-polish/tasks.md

--- a/spec/shifts/hu-063-shifts-helper-and-ui-polish/plan.md
+++ b/spec/shifts/hu-063-shifts-helper-and-ui-polish/plan.md
@@ -1,0 +1,30 @@
+# Plan - HU-063 (Shifts helper and UI polish)
+
+## Goal
+
+Make delivery helper assignment trustworthy on iOS and align the shifts screen presentation across Android and iOS.
+
+## Workstreams
+
+1. Behavior discovery
+- Trace Android delivery helper inference and calendar-exception handling.
+- Trace iOS delivery helper inference and identify why the 8 July 2026 helper is missing.
+- Confirm available test seams or fixtures for delivery weeks around 8 and 15 July 2026.
+
+2. iOS behavior
+- Pair the helper row in upcoming shifts with the delivery immediately before the member's next lead shift, even after that helper date has passed.
+- Respect `plus-collection/deliveryCalendar` exceptions before falling back to Wednesday.
+- Resolve board helper names only from the following delivery lead; the final delivery without a following lead remains pending.
+- Add targeted unit coverage where the existing test structure supports it.
+
+3. Cross-platform UI polish
+- Move the main `Turnos` / `Shifts` title below the back arrow.
+- Center and soften the upcoming-shifts block values.
+- Center the shift-swap action and keep it visually button-like.
+- Format market month labels as `MMM yyyy`.
+- Center the date column vertically against the names and favor the name column on compact cards.
+
+4. Validation
+- Run touched-platform unit/lint/build checks from `AGENTS.md`.
+- Manually inspect or screenshot the relevant shifts states when local tooling allows it.
+- Record any temporary platform parity gap in the handoff.

--- a/spec/shifts/hu-063-shifts-helper-and-ui-polish/spec.md
+++ b/spec/shifts/hu-063-shifts-helper-and-ui-polish/spec.md
@@ -1,0 +1,91 @@
+# HU-063 - Shifts helper and UI polish
+
+## Metadata
+- issue_id: #163
+- priority: P2
+- platform: both
+- status: implemented
+
+## Context and problem
+
+The shifts screen already exposes delivery and market turns, but the upcoming-shifts block can show a helper as pending after the helper delivery date has passed. The expected rule is that the lead of the following delivery week is the helper in the current delivery week. The normal delivery day is Wednesday unless `plus-collection/deliveryCalendar` contains an exception for that week.
+
+There are also small UI parity adjustments requested after comparing Android and iOS screenshots: hierarchy of the upcoming-shifts block, request-swap button alignment, market month label width, and main title placement.
+
+## User story
+
+As a cooperative member I want my upcoming shifts to show the correct helper/lead sequence and a consistent cross-platform layout so that I can trust the planning at a glance.
+
+## Scope
+
+### In Scope
+- Helper-name resolution on delivery cards and in the upcoming delivery role for both platforms.
+- Shift-facing role copy uses the cooperative terminology: Responsable/Apoyo in Spanish and Responsible/Support in English.
+- Cross-platform shifts UI polish:
+  - centered upcoming-shifts section title/content;
+  - slightly smaller regular font for upcoming-shifts values;
+  - centered swap-request button;
+  - market month label formatted as `MMM yyyy`;
+  - main shifts title placed below the back arrow.
+  - vertically centered date block and wider name column on shift cards.
+- Validation against the 8 July 2026 helper and 15 July 2026 lead case.
+
+### Out of Scope
+- Firestore schema changes.
+- Google Sheets synchronization changes.
+- Shift swap lifecycle changes beyond button presentation.
+- Admin planning tools.
+
+## Linked functional requirements
+
+- RF-TURN-01
+- RF-TURN-02
+- RF-TURN-04
+
+## Acceptance criteria
+
+- iOS and Android show the lead of the following logical delivery week as helper on the current delivery card, without using the persisted helper field.
+- iOS shows Nohemi as helper for the 8 July 2026 delivery shift when Nohemi is lead for the following delivery week.
+- "Mis proximos turnos" / "My next shifts" keeps that helper delivery paired with the member's next lead shift even after the helper date has passed.
+- Only the last delivery week with no following lead shows the helper as pending.
+- The helper lookup respects delivery-day exceptions from `plus-collection/deliveryCalendar`; otherwise it uses Wednesday as the default delivery day.
+- Android keeps the same helper assignment behavior and stays visually aligned with the updated contract.
+- The lead row in iOS upcoming shifts has a slightly larger regular type treatment, and visible role labels use Responsable/Apoyo.
+- The "Mis proximos turnos" / "My next shifts" block is centered and its values use regular weight with slightly smaller text than before.
+- The "Solicitar cambio" / "Request swap" action appears as a centered button on delivery shift cards where swaps are available.
+- Market cards show the month label with three-letter month plus year, for example `Mar 2026`.
+- The screen title "Turnos" / "Shifts" is visually below the back arrow on both platforms.
+- Compact screens remain readable with long member names.
+- The delivery-card date lines are vertically centered against the names and long names receive enough width to stay on one line whenever possible.
+
+## Dependencies
+
+- Depends on HU-015 for the base shifts feed.
+- Builds on HU-041 for segmented delivery/market cards.
+- Uses the delivery calendar behavior from HU-042.
+
+## Risks
+
+- Main risk: iOS and Android may model delivery-day exceptions with different helper APIs.
+  - Mitigation: trace both implementations before changing behavior and keep the product rule explicit in tests.
+- Secondary risk: visual changes may regress compact device layouts.
+  - Mitigation: validate screenshot-like states on small iOS and Android viewports/emulators when possible.
+
+## Validation plan
+
+- Android:
+  - `./gradlew app:testDebugUnitTest`
+  - `./gradlew app:lintDebug`
+  - `./gradlew app:connectedDebugAndroidTest` when a device/emulator is available or if UI behavior requires it.
+- iOS:
+  - `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17' test`
+  - If the simulator name is unavailable, use another valid simulator and report it.
+
+## Definition of Done (DoD)
+
+- [x] Story acceptance criteria validated.
+- [x] Implementation aligned with linked RFs.
+- [x] Android/iOS parity reviewed or temporary gap documented.
+- [x] Agreed tests executed or skipped with reason.
+- [x] Technical/functional documentation updated.
+- [ ] Issue and PR linked.

--- a/spec/shifts/hu-063-shifts-helper-and-ui-polish/spec.md
+++ b/spec/shifts/hu-063-shifts-helper-and-ui-polish/spec.md
@@ -88,4 +88,4 @@ As a cooperative member I want my upcoming shifts to show the correct helper/lea
 - [x] Android/iOS parity reviewed or temporary gap documented.
 - [x] Agreed tests executed or skipped with reason.
 - [x] Technical/functional documentation updated.
-- [ ] Issue and PR linked.
+- [x] Issue #163 and PR #164 linked.

--- a/spec/shifts/hu-063-shifts-helper-and-ui-polish/tasks.md
+++ b/spec/shifts/hu-063-shifts-helper-and-ui-polish/tasks.md
@@ -38,4 +38,4 @@
 ## 7. Closure
 - [x] Apply the Responsable/Apoyo role terminology and reinforce the iOS upcoming responsible row.
 - [x] Update DoD status in `spec.md`.
-- [ ] Link PR when created.
+- [x] Link PR #164.

--- a/spec/shifts/hu-063-shifts-helper-and-ui-polish/tasks.md
+++ b/spec/shifts/hu-063-shifts-helper-and-ui-polish/tasks.md
@@ -1,0 +1,41 @@
+# Tasks - HU-063 (Shifts helper and UI polish)
+
+## 1. Preparation
+- [x] Create `codex/hu-063-shifts-helper-and-ui-polish` branch.
+- [x] Create GitHub issue #163.
+- [x] Create issue mirror and story docs.
+- [x] Review current Android/iOS shifts implementations.
+
+## 2. iOS behavior
+- [x] Locate helper/lead derivation for delivery upcoming shifts.
+- [x] Pair the helper row with the delivery week before the next lead shift, including after its delivery day has passed.
+- [x] Validate Nohemi helper on 8 July 2026 and lead on 15 July 2026.
+- [x] Add/update tests for default Wednesday and exception-day delivery weeks.
+
+## 3. Android UI
+- [x] Center upcoming-shifts block and soften value typography.
+- [x] Center request-swap button while preserving the Android button style.
+- [x] Format market month label as `MMM yyyy`.
+- [x] Place main title below the back arrow if needed.
+
+## 4. iOS UI
+- [x] Center upcoming-shifts block and soften value typography.
+- [x] Center request-swap button with button-like treatment.
+- [x] Format market month label as `MMM yyyy`.
+- [x] Place main title below the back arrow.
+
+## 5. Validation
+- [x] Run Android unit tests and lint or document why skipped.
+- [x] Run iOS tests/build or document why skipped.
+- [x] Record validation and parity notes, including known runner/device blockers.
+
+## 6. Follow-up: helper names and compact cards
+- [x] Resolve each delivery helper from the lead of the following delivery week, leaving the final delivery without a following lead pending.
+- [x] Use the resolved helper for board names and current-member highlighting on Android and iOS.
+- [x] Vertically center the date block and widen the name area on delivery cards.
+- [x] Add regression coverage for a missing or stale helper field on both platforms.
+
+## 7. Closure
+- [x] Apply the Responsable/Apoyo role terminology and reinforce the iOS upcoming responsible row.
+- [x] Update DoD status in `spec.md`.
+- [ ] Link PR when created.


### PR DESCRIPTION
## Summary
- Derive each delivery support assignment from the following delivery responsible on Android and iOS.
- Keep the support week paired with the member's next responsible week, even after that delivery date has passed.
- Apply the requested shifts UI, sizing, alignment, month-label, swap-action, and role terminology refinements.

## Root cause
Upcoming shifts and delivery cards depended on the persisted helper field or filtered past delivery days, so the automatic support assignment could appear pending.

## Validation
- Android: `./gradlew app:testDebugUnitTest --console=plain`
- Android: `./gradlew app:lintDebug --console=plain`
- Android device tests: `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest --console=plain`
- iOS: 158/158 `ReguertaTests` passed on iPhone 17 (iOS 26.5)
- Localization catalog JSON validation and `git diff --check`

Closes #163