### PR TITLE
🐛 fix(android-ui): space screen header content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-10 | 🐛 fix(android-ui): space screen header content
 - 2026-07-10 | 🐛 fix(community): merge profile intro copy
 - 2026-07-10 | 🐛 fix(android-ui): standardize screen headers
 - 2026-07-10 | 🐛 fix(ui): restore news image and header layout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ All notable changes to this project will be documented in this file.
 
 ### Documentation
 
+- 2026-07-10 | 📝 docs(app): link HU-065 pull request
 - 2026-07-10 | 📝 docs(app): link HU-064 pull request
 - 2026-07-10 | 📝 docs(shifts): link HU-063 pull request
 - 2026-05-03 | 📝 docs(design): refine home drawer proposal

--- a/android/Reguerta/app/src/androidTest/java/com/reguerta/user/HomeShellTopBarTest.kt
+++ b/android/Reguerta/app/src/androidTest/java/com/reguerta/user/HomeShellTopBarTest.kt
@@ -1,8 +1,11 @@
 package com.reguerta.user
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.reguerta.user.presentation.home.HomeShellTopBar
 import com.reguerta.user.ui.theme.ReguertaTheme
@@ -33,6 +36,31 @@ class HomeShellTopBarTest {
     }
 
     @Test
+    fun backNavigationTitleAddsEightDpBeforeContent() {
+        setTopBarContent(
+            title = "News",
+            canNavigateBack = true,
+            contentAfterHeader = "First content",
+        )
+
+        val titleBounds = composeRule
+            .onNodeWithText("News")
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val contentBounds = composeRule
+            .onNodeWithText("First content")
+            .fetchSemanticsNode()
+            .boundsInRoot
+        val expectedGapPx = with(composeRule.density) { 8.dp.toPx() }
+        val actualGapPx = contentBounds.top - titleBounds.bottom
+
+        assertTrue(
+            "Expected an 8 dp gap below the screen title, but measured $actualGapPx px",
+            actualGapPx >= expectedGapPx - 1f,
+        )
+    }
+
+    @Test
     fun dashboardTitleRemainsInsideMenuRow() {
         setTopBarContent(title = "Friday, July 10", canNavigateBack = false)
 
@@ -53,21 +81,25 @@ class HomeShellTopBarTest {
     private fun setTopBarContent(
         title: String,
         canNavigateBack: Boolean,
+        contentAfterHeader: String? = null,
     ) {
         composeRule.setContent {
             ReguertaTheme {
-                HomeShellTopBar(
-                    title = title,
-                    canNavigateBack = canNavigateBack,
-                    showsNotificationsAction = false,
-                    hasNotificationIndicator = false,
-                    showsCartAction = false,
-                    cartUnits = 0,
-                    onBack = {},
-                    onOpenMenu = {},
-                    onOpenNotifications = {},
-                    onOpenCart = {},
-                )
+                Column {
+                    HomeShellTopBar(
+                        title = title,
+                        canNavigateBack = canNavigateBack,
+                        showsNotificationsAction = false,
+                        hasNotificationIndicator = false,
+                        showsCartAction = false,
+                        cartUnits = 0,
+                        onBack = {},
+                        onOpenMenu = {},
+                        onOpenNotifications = {},
+                        onOpenCart = {},
+                    )
+                    contentAfterHeader?.let { Text(text = it) }
+                }
             }
         }
     }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/ReguertaScreenHeader.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/ui/components/ReguertaScreenHeader.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -71,6 +72,8 @@ fun ReguertaScreenTitle(
         text = title,
         style = MaterialTheme.typography.headlineSmall,
         fontWeight = FontWeight.SemiBold,
-        modifier = modifier.semantics { heading() },
+        modifier = modifier
+            .padding(bottom = 8.dp)
+            .semantics { heading() },
     )
 }

--- a/spec/app/hu-065-screen-header-spacing/plan.md
+++ b/spec/app/hu-065-screen-header-spacing/plan.md
@@ -1,0 +1,21 @@
+# Plan - HU-065 (Android screen header spacing)
+
+## Goal
+
+Create a consistent 8 dp visual gap below every shared Android screen title.
+
+## Workstreams
+
+1. Shared component
+- Apply bottom-only padding in `ReguertaScreenTitle`.
+- Preserve existing typography and semantics.
+
+2. Regression coverage
+- Render the shared back header followed immediately by content.
+- Verify the measured title-to-content gap is at least 8 dp.
+- Keep Dashboard geometry coverage unchanged.
+
+3. Validation and delivery
+- Run Android unit tests, lint, and connected UI tests.
+- Review the diff for route-specific or unrelated changes.
+- Commit, push, and open a draft pull request linked to issue #169.

--- a/spec/app/hu-065-screen-header-spacing/spec.md
+++ b/spec/app/hu-065-screen-header-spacing/spec.md
@@ -1,0 +1,49 @@
+# HU-065 - Android screen header spacing
+
+## Metadata
+- issue_id: #169
+- priority: P3
+- platform: android
+- status: implemented
+
+## Context and problem
+
+The shared Android screen header now provides consistent navigation and title hierarchy, but content begins too close to the title. The spacing belongs in the shared screen-title primitive so static and dynamic screen titles remain aligned.
+
+## User story
+
+As a member I want a little breathing room below each screen title so that the header and following content are easier to scan.
+
+## Scope
+
+### In scope
+- Add 8 dp of bottom padding to the shared Android screen-title primitive.
+- Preserve navigation-row, title typography, heading semantics, and trailing actions.
+- Add geometry coverage for the title-to-content gap.
+
+### Out of scope
+- iOS layout changes.
+- Top, start, or end padding changes.
+- Dashboard compact-header changes.
+
+## Acceptance criteria
+
+- Shared Android screen titles add exactly 8 dp of bottom space before following content.
+- The spacing is inherited without route-specific modifiers.
+- Dashboard, back navigation, and header actions retain their current behavior.
+- Android validation passes on unit tests, lint, and the available emulator.
+
+## Validation evidence
+
+- `./gradlew app:testDebugUnitTest` passed.
+- `./gradlew app:lintDebug` passed.
+- `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest` passed 10 tests on `Pixel_8_Pro_API_35` (API 35), including the 8 dp title-to-content geometry assertion.
+- Platform parity: intentional Android-only change because the affected shared component is Android-specific; iOS layout is unchanged.
+- Existing unrelated local changes in Android/iOS Bylaws, Home routing, and localization files were preserved and excluded from this story.
+
+## Definition of Done
+
+- [x] Acceptance criteria validated.
+- [x] Android-only parity scope documented.
+- [x] Relevant checks executed.
+- [ ] GitHub issue and pull request linked.

--- a/spec/app/hu-065-screen-header-spacing/spec.md
+++ b/spec/app/hu-065-screen-header-spacing/spec.md
@@ -40,10 +40,11 @@ As a member I want a little breathing room below each screen title so that the h
 - `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest` passed 10 tests on `Pixel_8_Pro_API_35` (API 35), including the 8 dp title-to-content geometry assertion.
 - Platform parity: intentional Android-only change because the affected shared component is Android-specific; iOS layout is unchanged.
 - Existing unrelated local changes in Android/iOS Bylaws, Home routing, and localization files were preserved and excluded from this story.
+- Delivery: GitHub issue #169 and draft pull request #170 are mutually linked.
 
 ## Definition of Done
 
 - [x] Acceptance criteria validated.
 - [x] Android-only parity scope documented.
 - [x] Relevant checks executed.
-- [ ] GitHub issue and pull request linked.
+- [x] GitHub issue and pull request linked.

--- a/spec/app/hu-065-screen-header-spacing/tasks.md
+++ b/spec/app/hu-065-screen-header-spacing/tasks.md
@@ -17,6 +17,6 @@
 - [x] Record validation evidence.
 
 ## 4. Delivery
-- [ ] Update changelog.
-- [ ] Commit and push the focused change.
-- [ ] Open a draft pull request linked to issue #169.
+- [x] Update changelog.
+- [x] Commit and push the focused change.
+- [x] Open draft pull request #170 linked to issue #169.

--- a/spec/app/hu-065-screen-header-spacing/tasks.md
+++ b/spec/app/hu-065-screen-header-spacing/tasks.md
@@ -1,0 +1,22 @@
+# Tasks - HU-065 (Android screen header spacing)
+
+## 1. Preparation
+- [x] Create `codex/hu-065-screen-header-spacing` from current `main`.
+- [x] Create GitHub issue #169 with Android app labels.
+- [x] Create story docs and issue mirror.
+
+## 2. Implementation
+- [x] Add 8 dp bottom padding to the shared screen-title primitive.
+- [x] Preserve existing navigation and title semantics.
+- [x] Add targeted geometry coverage.
+
+## 3. Validation
+- [x] Run Android unit tests.
+- [x] Run Android lint.
+- [x] Run connected Android UI tests on the available emulator.
+- [x] Record validation evidence.
+
+## 4. Delivery
+- [ ] Update changelog.
+- [ ] Commit and push the focused change.
+- [ ] Open a draft pull request linked to issue #169.

--- a/spec/issues/hu-065-screen-header-spacing-issue.md
+++ b/spec/issues/hu-065-screen-header-spacing-issue.md
@@ -1,0 +1,17 @@
+# Issue mirror - HU-065
+
+- GitHub issue: https://github.com/JFrancoG/ReguertaPlus/issues/169
+- Title: `[HU-065] Separar el título del contenido en Android`
+- Labels: `bug`, `area:app`, `platform:android`, `priority:P3`
+- Branch: `codex/hu-065-screen-header-spacing`
+
+## Summary
+
+Add 8 dp of bottom-only padding to the shared Android screen-title component so following content no longer appears crowded against the title.
+
+## Acceptance criteria
+
+- Every shared Android screen title inherits the 8 dp gap.
+- Navigation, actions, typography, and heading semantics remain unchanged.
+- Dashboard keeps its compact header.
+- Unit, lint, and connected UI validation are recorded in the story spec.

--- a/spec/issues/hu-065-screen-header-spacing-issue.md
+++ b/spec/issues/hu-065-screen-header-spacing-issue.md
@@ -1,6 +1,7 @@
 # Issue mirror - HU-065
 
 - GitHub issue: https://github.com/JFrancoG/ReguertaPlus/issues/169
+- Draft pull request: https://github.com/JFrancoG/ReguertaPlus/pull/170
 - Title: `[HU-065] Separar el título del contenido en Android`
 - Labels: `bug`, `area:app`, `platform:android`, `priority:P3`
 - Branch: `codex/hu-065-screen-header-spacing`


### PR DESCRIPTION
## Summary

- Add 8 dp of bottom-only padding to the shared Android screen-title primitive.
- Apply the spacing to static and dynamic screen titles without route-specific modifiers.
- Add Compose geometry coverage that measures the title-to-content gap.
- Add HU-065 planning and validation artifacts.

## Validation

- Android app:testDebugUnitTest: passed.
- Android app:lintDebug: passed.
- Android app:connectedDebugAndroidTest: 10 tests passed on Pixel_8_Pro_API_35, including the new 8 dp geometry assertion.

## Parity

Intentional Android-only change: the affected shared component is Android-specific; iOS layout is unchanged.

## Local worktree note

Existing unrelated user changes in Bylaws, Home routing, and Android/iOS localization files were preserved and excluded from this PR.

Closes #169