### PR TITLE
🐛 fix(orders): align last order presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-12 | 🐛 fix(orders): align last order presentation
 - 2026-07-12 | 🐛 fix(orders): polish received orders UI
 - 2026-07-11 | 🐛 fix(android-orders): align purchase group title
 - 2026-07-11 | 🐛 fix(ios-orders): shrink purchase badge text

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/formatting/ReguertaCurrencyFormatting.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/formatting/ReguertaCurrencyFormatting.kt
@@ -19,3 +19,10 @@ internal fun Double.toEuroCurrencyText(locale: Locale): String =
         minimumFractionDigits = 2
         maximumFractionDigits = 2
     }.format(this)
+
+internal fun Double.toQuantityText(locale: Locale = Locale.getDefault()): String =
+    NumberFormat.getNumberInstance(locale).apply {
+        isGroupingUsed = false
+        minimumFractionDigits = 0
+        maximumFractionDigits = 3
+    }.format(this)

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/orders/ReguertaRootMyOrderRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/orders/ReguertaRootMyOrderRoute.kt
@@ -1,6 +1,7 @@
 package com.reguerta.user.presentation.orders
 
 import com.reguerta.user.presentation.formatting.toEuroCurrencyText
+import com.reguerta.user.presentation.formatting.toQuantityText
 import com.reguerta.user.presentation.shifts.toWeekKey
 import com.reguerta.user.presentation.root.normalized
 import com.reguerta.user.presentation.root.toIsoWeekStartDate
@@ -69,6 +70,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -1214,13 +1216,21 @@ private fun MyOrderSummaryTotalBar(
 
 @Composable
 private fun MyOrderPreviousProducerCard(group: MyOrderPreviousOrderGroup) {
+    val locale = LocalConfiguration.current.locales[0]
+    val singleQuantityLabel = stringResource(R.string.my_order_quantity_single)
+    val pluralQuantityFormat = stringResource(R.string.my_order_quantity_plural_format)
     PersonalOrderSummaryProducerCard(
         companyName = group.companyName,
         lines = group.lines.map { line ->
             PersonalOrderSummaryLineUi(
                 productName = line.productName,
                 packagingLine = line.packagingLine,
-                quantityLabel = line.quantityLabel,
+                quantityLabel = localizedGenericOrderHistoryQuantityLabel(
+                    rawLabel = line.quantityLabel,
+                    locale = locale,
+                    singleLabel = singleQuantityLabel,
+                    pluralFormat = pluralQuantityFormat,
+                ),
                 subtotal = line.subtotal,
             )
         },
@@ -1921,11 +1931,7 @@ private fun String.searchNormalized(): String =
         .lowercase(Locale.getDefault())
 
 private fun Double.toUiDecimal(): String =
-    if (this % 1.0 == 0.0) {
-        toLong().toString()
-    } else {
-        String.format(Locale.getDefault(), "%.2f", this)
-    }
+    toQuantityText()
 
 private fun Double.isApproximatelyOne(): Boolean =
     kotlin.math.abs(this - 1.0) < 0.0001

--- a/android/Reguerta/app/src/main/res/values/strings.xml
+++ b/android/Reguerta/app/src/main/res/values/strings.xml
@@ -390,8 +390,8 @@
     <string name="my_order_total_format">Total: %1$s</string>
     <string name="my_order_confirmed_total_sum_format">Order total: %1$s</string>
     <string name="my_order_producer_subtotal_format">Total: %1$s</string>
-    <string name="my_order_previous_title">Mi último pedido</string>
-    <string name="my_order_previous_week_format">Semana %1$s</string>
+    <string name="my_order_previous_title">My last order</string>
+    <string name="my_order_previous_week_format">Week %1$s</string>
     <string name="my_order_previous_loading">Loading previous order…</string>
     <string name="my_order_previous_empty">No order was registered last week</string>
     <string name="my_order_previous_error">We could not load your previous-week order.</string>

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/domain/orders/OrderHistoryWeekTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/domain/orders/OrderHistoryWeekTest.kt
@@ -69,7 +69,7 @@ class OrderHistoryWeekTest {
     }
 
     @Test
-    fun myOrdersHistoryPresentation_localizesGenericUnitLabelsOnly() {
+    fun orderSummaries_localizeGenericUnitLabelsOnly() {
         assertEquals(
             "1 unit",
             localizedGenericOrderHistoryQuantityLabel("1 ud.", Locale.US, "1 unit", "%1\$d units"),
@@ -77,6 +77,10 @@ class OrderHistoryWeekTest {
         assertEquals(
             "3 units",
             localizedGenericOrderHistoryQuantityLabel("3 uds.", Locale.US, "1 unit", "%1\$d units"),
+        )
+        assertEquals(
+            "2 units",
+            localizedGenericOrderHistoryQuantityLabel("2 ud(s).", Locale.US, "1 unit", "%1\$d units"),
         )
         assertEquals(
             "1 kg",

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/formatting/ReguertaCurrencyFormattingTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/formatting/ReguertaCurrencyFormattingTest.kt
@@ -2,6 +2,7 @@ package com.reguerta.user.presentation.formatting
 
 import com.reguerta.user.presentation.root.toSessionUiDecimal
 import java.util.Locale
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -26,5 +27,14 @@ class ReguertaCurrencyFormattingTest {
     fun sessionDecimalTextUsesLocaleDecimalSeparator() {
         assertTrue(12.5.toSessionUiDecimal(Locale.forLanguageTag("es-ES")).contains("12,5"))
         assertTrue(12.5.toSessionUiDecimal(Locale.US).contains("12.5"))
+    }
+
+    @Test
+    fun quantityTextUsesUpToThreeDecimalsWithoutTrailingZeros() {
+        assertEquals("1", 1.0.toQuantityText(Locale.US))
+        assertEquals("0.5", 0.5.toQuantityText(Locale.US))
+        assertEquals("0.125", 0.125.toQuantityText(Locale.US))
+        assertEquals("0.124", 0.1236.toQuantityText(Locale.US))
+        assertEquals("0,5", 0.5.toQuantityText(Locale.forLanguageTag("es-ES")))
     }
 }

--- a/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderCheckout.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderCheckout.swift
@@ -3,10 +3,16 @@ import Foundation
 
 extension Double {
     var myOrderUiDecimal: String {
-        if truncatingRemainder(dividingBy: 1) == 0 {
-            return String(Int(self))
-        }
-        return String(format: "%.2f", self)
+        myOrderUiDecimal(locale: reguertaPresentationLocale())
+    }
+
+    func myOrderUiDecimal(locale: Locale) -> String {
+        formatted(
+            .number
+                .grouping(.never)
+                .precision(.fractionLength(0...3))
+                .locale(locale)
+        )
     }
 }
 

--- a/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderPreviousOrder.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderPreviousOrder.swift
@@ -371,34 +371,40 @@ func myOrderProducerStatusesByVendor(from data: [String: Any]) -> [String: Produ
     }
 }
 
-func myOrderPackagingLine(from data: [String: Any]) -> String {
+func myOrderPackagingLine(
+    from data: [String: Any],
+    locale: Locale = reguertaPresentationLocale()
+) -> String {
     let containerName = ((data["packContainerName"] as? String)?
         .trimmingCharacters(in: .whitespacesAndNewlines))
-        .flatMap { $0.isEmpty ? nil : $0 } ??
-        (((data["unitName"] as? String)?
-            .trimmingCharacters(in: .whitespacesAndNewlines))
-            .flatMap { $0.isEmpty ? nil : $0 } ?? "")
-    let quantity = ((data["packContainerQty"] as? NSNumber)?.doubleValue
-        ?? (data["unitQty"] as? NSNumber)?.doubleValue
-        ?? 1).myOrderUiDecimal
+        .flatMap { $0.isEmpty ? nil : $0 }
+    let containerQuantity = (data["packContainerQty"] as? NSNumber)?.doubleValue
+    var containerComponents: [String] = []
+    if let containerQuantity, abs(containerQuantity - 1) >= 0.000_1 {
+        containerComponents.append(containerQuantity.myOrderUiDecimal(locale: locale))
+    }
+    if let containerName {
+        containerComponents.append(containerName)
+    }
+
+    let measureQuantity = (data["unitQty"] as? NSNumber)?.doubleValue ?? 1
     let unitName = ((data["unitName"] as? String)?
         .trimmingCharacters(in: .whitespacesAndNewlines))
         .flatMap { $0.isEmpty ? nil : $0 } ?? ""
     let unitPlural = ((data["unitPlural"] as? String)?
         .trimmingCharacters(in: .whitespacesAndNewlines))
-        .flatMap { $0.isEmpty ? nil : $0 } ?? ""
-    let unit = ((data["packContainerAbbreviation"] as? String)?
-        .trimmingCharacters(in: .whitespacesAndNewlines))
-        .flatMap { $0.isEmpty ? nil : $0 } ??
-        ((data["packContainerPlural"] as? String)?
-            .trimmingCharacters(in: .whitespacesAndNewlines))
-        .flatMap { $0.isEmpty ? nil : $0 } ??
+        .flatMap { $0.isEmpty ? nil : $0 } ?? unitName
+    let unit =
         ((data["unitAbbreviation"] as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines))
         .flatMap { $0.isEmpty ? nil : $0 } ??
-        ((((data["packContainerQty"] as? NSNumber)?.doubleValue ?? 1) == 1) ? unitName : unitPlural)
+        (abs(measureQuantity - 1) < 0.000_1 ? unitName : unitPlural)
 
-    return [containerName, quantity, unit]
+    return [
+        containerComponents.joined(separator: " "),
+        measureQuantity.myOrderUiDecimal(locale: locale),
+        unit,
+    ]
         .filter { !$0.isEmpty }
         .joined(separator: " ")
 }

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRoute.swift
@@ -67,6 +67,12 @@ struct MyOrderRouteView: View {
     let onReadOnlyModeChange: (Bool) -> Void
     let onCheckoutSuccessAcknowledge: () -> Void
 
+    @Environment(\.locale) var locale
+
+    var presentationLocale: Locale {
+        reguertaPresentationLocale(fallback: locale)
+    }
+
     var body: some View {
         routeContent
             .overlay(alignment: .bottom) {

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteOverlays.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteOverlays.swift
@@ -88,7 +88,12 @@ extension MyOrderRouteView {
     var cartOverlayHeader: some View {
         HStack(spacing: tokens.spacing.sm) {
             Spacer(minLength: 0)
-            Text(l10n(AccessL10nKey.myOrderProducerSubtotalFormat, viewModel.cartTotal.euroCurrencyText()))
+            Text(
+                l10n(
+                    AccessL10nKey.myOrderProducerSubtotalFormat,
+                    viewModel.cartTotal.euroCurrencyText(locale: presentationLocale)
+                )
+            )
                 .font(tokens.typography.titleCard.weight(.semibold))
                 .foregroundStyle(tokens.colors.actionPrimary)
                 .lineLimit(1)
@@ -144,7 +149,12 @@ extension MyOrderRouteView {
                             .font(tokens.typography.body.weight(.semibold))
                             .foregroundStyle(tokens.colors.textPrimary)
                             .lineLimit(2)
-                        Text(l10n(AccessL10nKey.myOrderPricePerUnitFormat, product.price.euroCurrencyText()))
+                        Text(
+                            l10n(
+                                AccessL10nKey.myOrderPricePerUnitFormat,
+                                product.price.euroCurrencyText(locale: presentationLocale)
+                            )
+                        )
                             .font(tokens.typography.bodySecondary)
                             .foregroundStyle(tokens.colors.textSecondary)
                     }
@@ -212,10 +222,13 @@ extension MyOrderRouteView {
                 message: noPickupEcoBaskets > 0
                     ? l10n(
                         AccessL10nKey.myOrderCheckoutSuccessWithNoPickupMessage,
-                        total.euroCurrencyText(),
+                        total.euroCurrencyText(locale: presentationLocale),
                         noPickupEcoBaskets
                     )
-                    : l10n(AccessL10nKey.myOrderCheckoutSuccessMessage, total.euroCurrencyText()),
+                    : l10n(
+                        AccessL10nKey.myOrderCheckoutSuccessMessage,
+                        total.euroCurrencyText(locale: presentationLocale)
+                    ),
                 primaryAction: ReguertaDialogAction(
                     title: l10n(AccessL10nKey.commonAccept),
                     action: handleCheckoutSuccessAcknowledged

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteSections.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteSections.swift
@@ -40,7 +40,10 @@ extension MyOrderRouteView {
             }
 
             orderTotalBar(
-                l10n(AccessL10nKey.myOrderConfirmedTotalFormat, viewModel.cartTotal.euroCurrencyText())
+                l10n(
+                    AccessL10nKey.myOrderConfirmedTotalFormat,
+                    viewModel.cartTotal.euroCurrencyText(locale: presentationLocale)
+                )
             )
                 .accessibilityIdentifier("myOrder.confirmedTotalBar")
         }
@@ -104,7 +107,10 @@ extension MyOrderRouteView {
 
             if case .loaded(let snapshot) = viewModel.previousOrderState {
                 orderTotalBar(
-                    l10n(AccessL10nKey.myOrderConfirmedTotalFormat, snapshot.total.euroCurrencyText())
+                    l10n(
+                        AccessL10nKey.myOrderConfirmedTotalFormat,
+                        snapshot.total.euroCurrencyText(locale: presentationLocale)
+                    )
                 )
                     .accessibilityIdentifier("myOrder.previousTotalBar")
             }
@@ -152,7 +158,12 @@ extension MyOrderRouteView {
 
             HStack {
                 Spacer()
-                Text(l10n(AccessL10nKey.myOrderProducerSubtotalFormat, group.subtotal.euroCurrencyText()))
+                Text(
+                    l10n(
+                        AccessL10nKey.myOrderProducerSubtotalFormat,
+                        group.subtotal.euroCurrencyText(locale: presentationLocale)
+                    )
+                )
                     .font(tokens.typography.body.weight(.semibold))
                     .foregroundStyle(Color(red: 0.78, green: 0.38, blue: 0.36))
             }
@@ -175,57 +186,22 @@ extension MyOrderRouteView {
                 Text(confirmedQuantityLabel(for: line))
                     .font(tokens.typography.body.weight(.semibold))
                     .foregroundStyle(tokens.colors.textPrimary)
-                Text(line.subtotal.euroCurrencyText())
+                Text(line.subtotal.euroCurrencyText(locale: presentationLocale))
                     .font(tokens.typography.body.weight(.semibold))
                     .foregroundStyle(tokens.colors.textPrimary)
             }
         }
     }
 
-    @ViewBuilder
     func previousProducerCard(_ group: MyOrderPreviousOrderGroup) -> some View {
-        reguertaCard {
-            VStack(alignment: .leading, spacing: tokens.spacing.sm) {
-                Text(group.companyName)
-                    .font(tokens.typography.titleCard.weight(.semibold))
-                    .foregroundStyle(tokens.colors.actionPrimary)
-
-                Divider()
-                    .overlay(tokens.colors.borderSubtle)
-
-                ForEach(group.lines) { line in
-                    VStack(alignment: .leading, spacing: tokens.spacing.xs) {
-                        HStack(alignment: .firstTextBaseline, spacing: tokens.spacing.sm) {
-                            VStack(alignment: .leading, spacing: tokens.spacing.xs) {
-                                Text(line.productName)
-                                    .font(tokens.typography.body.weight(.semibold))
-                                    .foregroundStyle(tokens.colors.textPrimary)
-                                Text(line.packagingLine)
-                                    .font(tokens.typography.bodySecondary)
-                                    .foregroundStyle(tokens.colors.textSecondary)
-                            }
-                            Spacer()
-                            Text(line.quantityLabel)
-                                .font(tokens.typography.body.weight(.semibold))
-                                .foregroundStyle(tokens.colors.textPrimary)
-                            Text(line.subtotal.euroCurrencyText())
-                                .font(tokens.typography.body.weight(.semibold))
-                                .foregroundStyle(tokens.colors.textPrimary)
-                        }
-                    }
-                }
-
-                Divider()
-                    .overlay(tokens.colors.borderSubtle)
-
-                HStack {
-                    Spacer()
-                    Text(l10n(AccessL10nKey.myOrderProducerSubtotalFormat, group.subtotal.euroCurrencyText()))
-                        .font(tokens.typography.body.weight(.semibold))
-                        .foregroundStyle(Color(red: 0.78, green: 0.38, blue: 0.36))
-                }
-            }
-        }
+        PersonalOrderSummaryProducerCard(
+            tokens: tokens,
+            group: group,
+            locale: presentationLocale,
+            quantitySingleLabel: l10n(AccessL10nKey.myOrderQuantitySingle),
+            quantityPluralFormat: l10n(AccessL10nKey.myOrderQuantityPluralFormat),
+            producerTotalKey: AccessL10nKey.myOrderProducerSubtotalFormat
+        )
     }
 
     func confirmedQuantityLabel(for line: MyOrderConfirmedLine) -> String {
@@ -503,7 +479,7 @@ extension MyOrderRouteView {
             product.pricingMode == .weight
                 ? AccessL10nKey.myOrderPricePerKgFormat
                 : AccessL10nKey.myOrderPricePerUnitFormat,
-            product.price.euroCurrencyText()
+            product.price.euroCurrencyText(locale: presentationLocale)
         )
     }
 

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrdersHistoryRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrdersHistoryRoute.swift
@@ -152,72 +152,19 @@ private struct OrderSummaryList: View {
         ScrollView(.vertical, showsIndicators: false) {
             LazyVStack(spacing: tokens.spacing.md) {
                 ForEach(groups) { group in
-                    OrderSummaryProducerCard(tokens: tokens, group: group, locale: locale)
+                    PersonalOrderSummaryProducerCard(
+                        tokens: tokens,
+                        group: group,
+                        locale: locale,
+                        quantitySingleLabel: l10n(AccessL10nKey.orderHistoryQuantitySingle),
+                        quantityPluralFormat: l10n(AccessL10nKey.orderHistoryQuantityPluralFormat),
+                        producerTotalKey: AccessL10nKey.orderHistoryProducerTotalFormat
+                    )
                 }
             }
             .padding(.bottom, bottomPadding)
         }
         .ignoresSafeArea(.container, edges: .bottom)
-    }
-}
-
-private struct OrderSummaryProducerCard: View {
-    let tokens: ReguertaDesignTokens
-    let group: MyOrderPreviousOrderGroup
-    let locale: Locale
-
-    var body: some View {
-        reguertaCard {
-            VStack(alignment: .leading, spacing: tokens.spacing.sm) {
-                Text(group.companyName)
-                    .font(tokens.typography.titleCard.weight(.semibold))
-                    .foregroundStyle(tokens.colors.actionPrimary)
-
-                Divider()
-                    .overlay(tokens.colors.borderSubtle)
-
-                ForEach(group.lines) { line in
-                    HStack(alignment: .firstTextBaseline, spacing: tokens.spacing.sm) {
-                        VStack(alignment: .leading, spacing: tokens.spacing.xs) {
-                            Text(line.productName)
-                                .font(tokens.typography.body.weight(.semibold))
-                                .foregroundStyle(tokens.colors.textPrimary)
-                            Text(line.packagingLine)
-                                .font(tokens.typography.bodySecondary)
-                                .foregroundStyle(tokens.colors.textSecondary)
-                        }
-                        Spacer()
-                        Text(
-                            localizedGenericOrderHistoryQuantityLabel(
-                                line.quantityLabel,
-                                singleLabel: l10n(AccessL10nKey.orderHistoryQuantitySingle),
-                                pluralFormat: l10n(AccessL10nKey.orderHistoryQuantityPluralFormat)
-                            )
-                        )
-                            .font(tokens.typography.body.weight(.semibold))
-                            .foregroundStyle(tokens.colors.textPrimary)
-                        Text(line.subtotal.euroCurrencyText(locale: locale))
-                            .font(tokens.typography.body.weight(.semibold))
-                            .foregroundStyle(tokens.colors.textPrimary)
-                    }
-                }
-
-                Divider()
-                    .overlay(tokens.colors.borderSubtle)
-
-                HStack {
-                    Spacer()
-                    Text(
-                        l10n(
-                            AccessL10nKey.orderHistoryProducerTotalFormat,
-                            group.subtotal.euroCurrencyText(locale: locale)
-                        )
-                    )
-                        .font(tokens.typography.body.weight(.semibold))
-                        .foregroundStyle(Color(red: 0.78, green: 0.38, blue: 0.36))
-                }
-            }
-        }
     }
 }
 

--- a/ios/Reguerta/Reguerta/Presentation/Orders/PersonalOrderSummaryCard.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/PersonalOrderSummaryCard.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+struct PersonalOrderSummaryProducerCard: View {
+    let tokens: ReguertaDesignTokens
+    let group: MyOrderPreviousOrderGroup
+    let locale: Locale
+    let quantitySingleLabel: String
+    let quantityPluralFormat: String
+    let producerTotalKey: String
+
+    var body: some View {
+        reguertaCard {
+            VStack(alignment: .leading, spacing: tokens.spacing.sm) {
+                Text(group.companyName)
+                    .font(tokens.typography.titleCard.weight(.semibold))
+                    .foregroundStyle(tokens.colors.actionPrimary)
+
+                summaryDivider
+
+                ForEach(group.lines) { line in
+                    PersonalOrderSummaryLineRow(
+                        tokens: tokens,
+                        line: line,
+                        quantityText: localizedGenericOrderHistoryQuantityLabel(
+                            line.quantityLabel,
+                            singleLabel: quantitySingleLabel,
+                            pluralFormat: quantityPluralFormat
+                        ),
+                        subtotalText: line.subtotal.euroCurrencyText(locale: locale)
+                    )
+                }
+
+                summaryDivider
+
+                Text(
+                    l10n(
+                        producerTotalKey,
+                        group.subtotal.euroCurrencyText(locale: locale)
+                    )
+                )
+                    .font(tokens.typography.body.weight(.semibold))
+                    .foregroundStyle(Color(red: 0.78, green: 0.38, blue: 0.36))
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+        }
+    }
+
+    private var summaryDivider: some View {
+        Divider()
+            .overlay(tokens.colors.borderSubtle)
+            .accessibilityHidden(true)
+    }
+}
+
+private struct PersonalOrderSummaryLineRow: View {
+    let tokens: ReguertaDesignTokens
+    let line: MyOrderPreviousOrderLine
+    let quantityText: String
+    let subtotalText: String
+
+    var body: some View {
+        HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: tokens.spacing.xs) {
+                Text(line.productName)
+                    .font(tokens.typography.body.weight(.semibold))
+                    .foregroundStyle(tokens.colors.textPrimary)
+                    .lineLimit(2)
+                Text(line.packagingLine)
+                    .font(tokens.typography.bodySecondary)
+                    .foregroundStyle(tokens.colors.textSecondary)
+                    .lineLimit(2)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.trailing, tokens.spacing.sm)
+
+            columnDivider
+
+            Text(quantityText)
+                .font(tokens.typography.body.weight(.semibold))
+                .foregroundStyle(tokens.colors.textPrimary)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .minimumScaleFactor(0.8)
+                .padding(.horizontal, tokens.spacing.xs)
+                .frame(width: 72.resize)
+
+            columnDivider
+
+            Text(subtotalText)
+                .font(tokens.typography.body.weight(.semibold))
+                .foregroundStyle(tokens.colors.textPrimary)
+                .multilineTextAlignment(.trailing)
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+                .padding(.leading, tokens.spacing.sm)
+                .frame(width: 82.resize, alignment: .trailing)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(minHeight: 64.resize)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var columnDivider: some View {
+        Divider()
+            .overlay(tokens.colors.borderSubtle)
+            .accessibilityHidden(true)
+    }
+}

--- a/ios/Reguerta/ReguertaTests/ReguertaCurrencyFormattingTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaCurrencyFormattingTests.swift
@@ -38,4 +38,16 @@ struct ReguertaCurrencyFormattingTests {
         #expect(12.5.productUIDecimal(locale: Locale(identifier: "es_ES")) == "12,5")
         #expect(12.5.productUIDecimal(locale: Locale(identifier: "en_US")) == "12.5")
     }
+
+    @Test
+    func orderQuantityUsesUpToThreeDecimalsWithoutTrailingZeros() {
+        let english = Locale(identifier: "en_US")
+        let spanish = Locale(identifier: "es_ES")
+
+        #expect(1.0.myOrderUiDecimal(locale: english) == "1")
+        #expect(0.5.myOrderUiDecimal(locale: english) == "0.5")
+        #expect(0.125.myOrderUiDecimal(locale: english) == "0.125")
+        #expect(0.1236.myOrderUiDecimal(locale: english) == "0.124")
+        #expect(0.5.myOrderUiDecimal(locale: spanish) == "0,5")
+    }
 }

--- a/ios/Reguerta/ReguertaTests/ReguertaOrdersHistoryViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaOrdersHistoryViewModelTests.swift
@@ -28,7 +28,7 @@ struct ReguertaOrdersHistoryViewModelTests {
     }
 
     @Test
-    func myOrdersHistoryPresentationLocalizesGenericUnitLabelsOnly() {
+    func orderSummariesLocalizeGenericUnitLabelsOnly() {
         #expect(
             localizedGenericOrderHistoryQuantityLabel(
                 "1 ud.",
@@ -42,6 +42,13 @@ struct ReguertaOrdersHistoryViewModelTests {
                 singleLabel: "1 unit",
                 pluralFormat: "%lld units"
             ) == "3 units"
+        )
+        #expect(
+            localizedGenericOrderHistoryQuantityLabel(
+                "2 ud(s).",
+                singleLabel: "1 unit",
+                pluralFormat: "%lld units"
+            ) == "2 units"
         )
         #expect(
             localizedGenericOrderHistoryQuantityLabel(

--- a/ios/Reguerta/ReguertaTests/ReguertaOrdersViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaOrdersViewModelTests.swift
@@ -28,6 +28,74 @@ struct ReguertaOrdersViewModelTests {
     }
 
     @Test
+    func myOrderPackagingLineKeepsContainerAndMeasureQuantitiesSeparate() {
+        #expect(
+            myOrderPackagingLine(from: [
+                "packContainerName": "Caja",
+                "packContainerQty": NSNumber(value: 1),
+                "unitQty": NSNumber(value: 6),
+                "unitName": "unidad",
+                "unitPlural": "ud(s).",
+            ]) == "Caja 6 ud(s)."
+        )
+        #expect(
+            myOrderPackagingLine(from: [
+                "packContainerName": "Caja",
+                "packContainerQty": NSNumber(value: 2),
+                "unitQty": NSNumber(value: 6),
+                "unitName": "unidad",
+                "unitPlural": "ud(s).",
+            ]) == "2 Caja 6 ud(s)."
+        )
+        #expect(
+            myOrderPackagingLine(from: [
+                "packContainerName": "Paquete",
+                "packContainerQty": NSNumber(value: 1),
+                "unitQty": NSNumber(value: 500),
+                "unitName": "gramo",
+                "unitPlural": "gramos",
+                "unitAbbreviation": "g",
+            ]) == "Paquete 500 g"
+        )
+        #expect(
+            myOrderPackagingLine(from: [
+                "packContainerName": "Pieza",
+                "packContainerQty": NSNumber(value: 1),
+                "unitQty": NSNumber(value: 1),
+                "unitName": "kilo",
+                "unitPlural": "kilos",
+                "unitAbbreviation": "kg",
+            ]) == "Pieza 1 kg"
+        )
+        #expect(
+            myOrderPackagingLine(
+                from: [
+                    "packContainerName": "Pieza",
+                    "packContainerQty": NSNumber(value: 1),
+                    "unitQty": NSNumber(value: 0.5),
+                    "unitName": "kilo",
+                    "unitPlural": "kilos",
+                    "unitAbbreviation": "kg",
+                ],
+                locale: Locale(identifier: "en_US")
+            ) == "Pieza 0.5 kg"
+        )
+        #expect(
+            myOrderPackagingLine(
+                from: [
+                    "packContainerName": "Pieza",
+                    "packContainerQty": NSNumber(value: 1),
+                    "unitQty": NSNumber(value: 0.125),
+                    "unitName": "kilo",
+                    "unitPlural": "kilos",
+                    "unitAbbreviation": "kg",
+                ],
+                locale: Locale(identifier: "en_US")
+            ) == "Pieza 0.125 kg"
+        )
+    }
+
+    @Test
     func receivedOrdersCopyResolvesFromTheLocalizationCatalog() {
         let keys = [
             AccessL10nKey.receivedOrdersTitle,


### PR DESCRIPTION
## Summary

- align last-order titles, generic quantity labels, EUR formatting, and measurement precision across iOS and Android
- restore the shared iOS producer card with product/quantity/price columns and horizontal/vertical dividers
- keep container and measure quantities separate in packaging copy and add regression coverage

## Validation

- `./gradlew app:testDebugUnitTest app:lintDebug --no-daemon`
- `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest --no-daemon` (11 tests passed)
- `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:ReguertaTests test`
- iOS UI suite in serial mode: 8 passed, 4 launch screenshot variants intentionally skipped by the suite

Closes #184