### PR TITLE
fix(users): refine member editor layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-12 | 🐛 fix(users): refine member editor layout
 - 2026-07-12 | 🐛 fix(android-orders): show product fallback image
 - 2026-07-12 | 🐛 fix(orders): stabilize editable order summary
 - 2026-07-12 | 🐛 fix(orders): localize checkout dialogs

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/users/ReguertaRootUsersRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/users/ReguertaRootUsersRoute.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -245,71 +244,75 @@ private fun UsersEditorForm(
     val focusManager = LocalFocusManager.current
     val commonPurchasesCompanyName = stringResource(R.string.users_editor_common_purchase_company_name)
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(bottom = 24.dp),
-        verticalArrangement = Arrangement.spacedBy(20.dp),
-    ) {
-        ReguertaInputField(
-            label = stringResource(R.string.common_input_email_label),
-            value = draft.email,
-            onValueChange = { onDraftChanged(draft.copy(email = it)) },
-            readOnly = editingMember != null,
-            keyboardType = KeyboardType.Email,
-            showClearAction = editingMember == null,
-        )
-
-        ReguertaInputField(
-            label = stringResource(R.string.admin_input_display_name_label),
-            value = draft.displayName,
-            onValueChange = { onDraftChanged(draft.copy(displayName = it)) },
-            showClearAction = true,
-        )
-
-        ReguertaInputField(
-            label = stringResource(R.string.users_editor_phone_label),
-            value = draft.phoneNumber,
-            onValueChange = { onDraftChanged(draft.copy(phoneNumber = it)) },
-            keyboardType = KeyboardType.Phone,
-            showClearAction = true,
-        )
-
-        CommonPurchaseManagerSwitchRow(
-            checked = draft.isCommonPurchaseManager,
-            label = stringResource(R.string.users_editor_common_purchase_manager_label),
-            onCheckedChange = {
-                onDraftChanged(
-                    draft.withCommonPurchaseManagerSelection(
-                        isSelected = it,
-                        commonPurchasesCompanyName = commonPurchasesCompanyName,
-                    ),
-                )
-            },
-        )
-
-        RoleCheckboxRow(
-            checked = draft.isProducer,
-            label = stringResource(R.string.role_producer),
-            onCheckedChange = { onDraftChanged(draft.withProducerSelection(it)) },
-        )
-
-        if (draft.isProducer) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
             ReguertaInputField(
-                label = stringResource(R.string.users_editor_company_name_label),
-                value = draft.companyName,
-                onValueChange = { onDraftChanged(draft.copy(companyName = it)) },
-                readOnly = draft.isCommonPurchaseManager,
-                showClearAction = !draft.isCommonPurchaseManager,
+                label = stringResource(R.string.common_input_email_label),
+                value = draft.email,
+                onValueChange = { onDraftChanged(draft.copy(email = it)) },
+                readOnly = editingMember != null,
+                keyboardType = KeyboardType.Email,
+                showClearAction = editingMember == null,
+            )
+
+            ReguertaInputField(
+                label = stringResource(R.string.admin_input_display_name_label),
+                value = draft.displayName,
+                onValueChange = { onDraftChanged(draft.copy(displayName = it)) },
+                showClearAction = true,
+            )
+
+            ReguertaInputField(
+                label = stringResource(R.string.users_editor_phone_label),
+                value = draft.phoneNumber,
+                onValueChange = { onDraftChanged(draft.copy(phoneNumber = it)) },
+                keyboardType = KeyboardType.Phone,
+                showClearAction = true,
+            )
+
+            if (draft.isProducer) {
+                ReguertaInputField(
+                    label = stringResource(R.string.users_editor_company_name_label),
+                    value = draft.companyName,
+                    onValueChange = { onDraftChanged(draft.copy(companyName = it)) },
+                    readOnly = draft.isCommonPurchaseManager,
+                    showClearAction = !draft.isCommonPurchaseManager,
+                )
+            }
+
+            RoleSwitchRow(
+                checked = draft.isProducer,
+                label = stringResource(R.string.role_producer),
+                onCheckedChange = { onDraftChanged(draft.withProducerSelection(it)) },
+            )
+
+            if (draft.isProducer) {
+                RoleSwitchRow(
+                    checked = draft.isCommonPurchaseManager,
+                    label = stringResource(R.string.users_editor_common_purchase_manager_label),
+                    onCheckedChange = {
+                        onDraftChanged(
+                            draft.withCommonPurchaseManagerSelection(
+                                isSelected = it,
+                                commonPurchasesCompanyName = commonPurchasesCompanyName,
+                            ),
+                        )
+                    },
+                )
+            }
+
+            RoleSwitchRow(
+                checked = draft.isAdmin,
+                label = stringResource(R.string.role_admin),
+                onCheckedChange = { onDraftChanged(draft.copy(isAdmin = it)) },
             )
         }
-
-        RoleCheckboxRow(
-            checked = draft.isAdmin,
-            label = stringResource(R.string.role_admin),
-            onCheckedChange = { onDraftChanged(draft.copy(isAdmin = it)) },
-        )
 
         ReguertaButton(
             label = stringResource(
@@ -319,6 +322,7 @@ private fun UsersEditorForm(
                     R.string.users_editor_save_action_update
                 },
             ),
+            modifier = Modifier.padding(top = 20.dp, bottom = 24.dp),
             variant = ReguertaButtonVariant.PRIMARY,
             onClick = {
                 focusManager.clearFocus(force = true)
@@ -405,22 +409,7 @@ private fun UserListItem(
 }
 
 @Composable
-private fun RoleCheckboxRow(
-    checked: Boolean,
-    label: String,
-    onCheckedChange: (Boolean) -> Unit,
-) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Checkbox(checked = checked, onCheckedChange = onCheckedChange)
-        Text(label)
-    }
-}
-
-@Composable
-private fun CommonPurchaseManagerSwitchRow(
+private fun RoleSwitchRow(
     checked: Boolean,
     label: String,
     onCheckedChange: (Boolean) -> Unit,

--- a/ios/Reguerta/Reguerta/Presentation/Users/ContentView+UsersRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Users/ContentView+UsersRoute.swift
@@ -178,65 +178,71 @@ private struct UsersEditorView: View {
     @Bindable var viewModel: UsersFeatureViewModel
 
     var body: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: tokens.spacing.lg) {
-                reguertaInputField(
-                    LocalizedStringKey(AccessL10nKey.emailLabel),
-                    text: $viewModel.draft.email,
-                    isReadOnly: viewModel.editingMember != nil,
-                    showsClearAction: viewModel.editingMember == nil,
-                    keyboardType: .emailAddress
-                )
-
-                reguertaInputField(
-                    LocalizedStringKey(AccessL10nKey.displayNameLabel),
-                    text: $viewModel.draft.displayName,
-                    showsClearAction: true,
-                    textInputAutocapitalization: .words,
-                    autocorrectionDisabled: false
-                )
-
-                reguertaInputField(
-                    LocalizedStringKey(AccessL10nKey.usersEditorPhoneLabel),
-                    text: $viewModel.draft.phoneNumber,
-                    showsClearAction: true,
-                    keyboardType: .phonePad
-                )
-
-                roleToggle(
-                    AccessL10nKey.usersEditorCommonPurchaseManagerLabel,
-                    isOn: commonPurchaseManagerBinding
-                )
-                roleToggle(AccessL10nKey.roleProducer, isOn: producerBinding)
-
-                if viewModel.draft.isProducer {
+        VStack(spacing: 0) {
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: tokens.spacing.lg) {
                     reguertaInputField(
-                        LocalizedStringKey(AccessL10nKey.usersEditorCompanyNameLabel),
-                        text: $viewModel.draft.companyName,
-                        isReadOnly: viewModel.draft.isCommonPurchaseManager,
-                        showsClearAction: !viewModel.draft.isCommonPurchaseManager,
+                        LocalizedStringKey(AccessL10nKey.emailLabel),
+                        text: $viewModel.draft.email,
+                        isReadOnly: viewModel.editingMember != nil,
+                        showsClearAction: viewModel.editingMember == nil,
+                        keyboardType: .emailAddress
+                    )
+
+                    reguertaInputField(
+                        LocalizedStringKey(AccessL10nKey.displayNameLabel),
+                        text: $viewModel.draft.displayName,
+                        showsClearAction: true,
                         textInputAutocapitalization: .words,
                         autocorrectionDisabled: false
                     )
-                }
 
-                roleToggle(AccessL10nKey.roleAdmin, isOn: $viewModel.draft.isAdmin)
+                    reguertaInputField(
+                        LocalizedStringKey(AccessL10nKey.usersEditorPhoneLabel),
+                        text: $viewModel.draft.phoneNumber,
+                        showsClearAction: true,
+                        keyboardType: .phonePad
+                    )
 
-                reguertaButton(
-                    LocalizedStringKey(
-                        viewModel.editingMember == nil
-                            ? AccessL10nKey.usersEditorActionCreate
-                            : AccessL10nKey.usersEditorActionUpdate
-                    ),
-                    isEnabled: !viewModel.isSavingMember,
-                    isLoading: viewModel.isSavingMember
-                ) {
-                    Task { _ = await viewModel.saveDraft() }
+                    if viewModel.draft.isProducer {
+                        reguertaInputField(
+                            LocalizedStringKey(AccessL10nKey.usersEditorCompanyNameLabel),
+                            text: $viewModel.draft.companyName,
+                            isReadOnly: viewModel.draft.isCommonPurchaseManager,
+                            showsClearAction: !viewModel.draft.isCommonPurchaseManager,
+                            textInputAutocapitalization: .words,
+                            autocorrectionDisabled: false
+                        )
+                    }
+
+                    roleToggle(AccessL10nKey.roleProducer, isOn: producerBinding)
+
+                    if viewModel.draft.isProducer {
+                        roleToggle(
+                            AccessL10nKey.usersEditorCommonPurchaseManagerLabel,
+                            isOn: commonPurchaseManagerBinding
+                        )
+                    }
+
+                    roleToggle(AccessL10nKey.roleAdmin, isOn: $viewModel.draft.isAdmin)
                 }
             }
+            .scrollDismissesKeyboard(.interactively)
+
+            reguertaButton(
+                LocalizedStringKey(
+                    viewModel.editingMember == nil
+                        ? AccessL10nKey.usersEditorActionCreate
+                        : AccessL10nKey.usersEditorActionUpdate
+                ),
+                isEnabled: !viewModel.isSavingMember,
+                isLoading: viewModel.isSavingMember
+            ) {
+                Task { _ = await viewModel.saveDraft() }
+            }
+            .padding(.top, tokens.spacing.lg)
             .padding(.bottom, tokens.spacing.sm)
         }
-        .scrollDismissesKeyboard(.interactively)
     }
 
     private func roleToggle(_ key: String, isOn: Binding<Bool>) -> some View {


### PR DESCRIPTION
## Summary
- use switches for all Android role controls
- group company name with the other inputs and show common-purchase responsibility only for producers
- keep the primary action anchored at the bottom on Android and iOS

## Validation
- Android: `./gradlew app:testDebugUnitTest app:lintDebug`
- Android: `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest` (11 tests, Pixel_8_Pro_API_35 / Android 15)
- iOS: `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:ReguertaTests test`

Closes #190