### PR TITLE
fix(users): refine member editor controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-12 | 🐛 fix(users): refine member editor controls
 - 2026-07-12 | 🐛 fix(users): refine member editor layout
 - 2026-07-12 | 🐛 fix(android-orders): show product fallback image
 - 2026-07-12 | 🐛 fix(orders): stabilize editable order summary

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/users/ReguertaRootUsersRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/users/ReguertaRootUsersRoute.kt
@@ -287,25 +287,23 @@ private fun UsersEditorForm(
             }
 
             RoleSwitchRow(
+                checked = draft.isCommonPurchaseManager,
+                label = stringResource(R.string.users_editor_common_purchase_manager_label),
+                onCheckedChange = {
+                    onDraftChanged(
+                        draft.withCommonPurchaseManagerSelection(
+                            isSelected = it,
+                            commonPurchasesCompanyName = commonPurchasesCompanyName,
+                        ),
+                    )
+                },
+            )
+
+            RoleSwitchRow(
                 checked = draft.isProducer,
                 label = stringResource(R.string.role_producer),
                 onCheckedChange = { onDraftChanged(draft.withProducerSelection(it)) },
             )
-
-            if (draft.isProducer) {
-                RoleSwitchRow(
-                    checked = draft.isCommonPurchaseManager,
-                    label = stringResource(R.string.users_editor_common_purchase_manager_label),
-                    onCheckedChange = {
-                        onDraftChanged(
-                            draft.withCommonPurchaseManagerSelection(
-                                isSelected = it,
-                                commonPurchasesCompanyName = commonPurchasesCompanyName,
-                            ),
-                        )
-                    },
-                )
-            }
 
             RoleSwitchRow(
                 checked = draft.isAdmin,
@@ -322,7 +320,7 @@ private fun UsersEditorForm(
                     R.string.users_editor_save_action_update
                 },
             ),
-            modifier = Modifier.padding(top = 20.dp, bottom = 24.dp),
+            modifier = Modifier.padding(top = 20.dp, bottom = 32.dp),
             variant = ReguertaButtonVariant.PRIMARY,
             onClick = {
                 focusManager.clearFocus(force = true)

--- a/android/Reguerta/app/src/main/res/values-es/strings.xml
+++ b/android/Reguerta/app/src/main/res/values-es/strings.xml
@@ -253,7 +253,7 @@
     <string name="users_editor_title_edit">Actualizar regüertense</string>
     <string name="users_editor_company_name_label">Nombre de la empresa</string>
     <string name="users_editor_phone_label">Teléfono</string>
-    <string name="users_editor_common_purchase_manager_label">Socio encargado de compras comunes</string>
+    <string name="users_editor_common_purchase_manager_label">Regüertense encargado de compras</string>
     <string name="users_editor_common_purchase_company_name">Compras Regüerta</string>
     <string name="users_editor_save_action_create">Añadir</string>
     <string name="users_editor_save_action_update">Actualizar</string>

--- a/ios/Reguerta/Reguerta/Presentation/Users/ContentView+UsersRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Users/ContentView+UsersRoute.swift
@@ -215,14 +215,12 @@ private struct UsersEditorView: View {
                         )
                     }
 
-                    roleToggle(AccessL10nKey.roleProducer, isOn: producerBinding)
+                    roleToggle(
+                        AccessL10nKey.usersEditorCommonPurchaseManagerLabel,
+                        isOn: commonPurchaseManagerBinding
+                    )
 
-                    if viewModel.draft.isProducer {
-                        roleToggle(
-                            AccessL10nKey.usersEditorCommonPurchaseManagerLabel,
-                            isOn: commonPurchaseManagerBinding
-                        )
-                    }
+                    roleToggle(AccessL10nKey.roleProducer, isOn: producerBinding)
 
                     roleToggle(AccessL10nKey.roleAdmin, isOn: $viewModel.draft.isAdmin)
                 }
@@ -241,7 +239,7 @@ private struct UsersEditorView: View {
                 Task { _ = await viewModel.saveDraft() }
             }
             .padding(.top, tokens.spacing.lg)
-            .padding(.bottom, tokens.spacing.sm)
+            .padding(.bottom, tokens.spacing.xxl + tokens.spacing.sm)
         }
     }
 

--- a/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
+++ b/ios/Reguerta/Reguerta/Resources/Localizable.xcstrings
@@ -9486,7 +9486,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Socio encargado de compras comunes"
+            "value" : "Regüertense encargado de compras"
           }
         }
       }


### PR DESCRIPTION
## Summary
- restore the common-purchases switch below the inputs and above Producer on Android and iOS
- rename the Spanish role label to «Regüertense encargado de compras»
- add 32 dp/pt of bottom spacing below the primary action

## Validation
- `./gradlew app:testDebugUnitTest app:lintDebug`
- `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest` (11 tests, Pixel_8_Pro_API_35 / Android 15)
- `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:ReguertaTests test`
- Android XML and iOS string-catalog JSON syntax checks

## Known environment limitation
- The full iOS UI runner remains blocked locally by `DebuggerVersionStore / no debugger version`; the app and unit suite compile and pass.

Closes #192