### PR TITLE
fix(users): gate purchase manager by producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-12 | 🐛 fix(users): gate purchase manager by producer
 - 2026-07-12 | 🐛 fix(users): refine member editor controls
 - 2026-07-12 | 🐛 fix(users): refine member editor layout
 - 2026-07-12 | 🐛 fix(android-orders): show product fallback image

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/users/ReguertaRootUsersRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/users/ReguertaRootUsersRoute.kt
@@ -286,18 +286,20 @@ private fun UsersEditorForm(
                 )
             }
 
-            RoleSwitchRow(
-                checked = draft.isCommonPurchaseManager,
-                label = stringResource(R.string.users_editor_common_purchase_manager_label),
-                onCheckedChange = {
-                    onDraftChanged(
-                        draft.withCommonPurchaseManagerSelection(
-                            isSelected = it,
-                            commonPurchasesCompanyName = commonPurchasesCompanyName,
-                        ),
-                    )
-                },
-            )
+            if (draft.isProducer) {
+                RoleSwitchRow(
+                    checked = draft.isCommonPurchaseManager,
+                    label = stringResource(R.string.users_editor_common_purchase_manager_label),
+                    onCheckedChange = {
+                        onDraftChanged(
+                            draft.withCommonPurchaseManagerSelection(
+                                isSelected = it,
+                                commonPurchasesCompanyName = commonPurchasesCompanyName,
+                            ),
+                        )
+                    },
+                )
+            }
 
             RoleSwitchRow(
                 checked = draft.isProducer,

--- a/ios/Reguerta/Reguerta/Presentation/Users/ContentView+UsersRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Users/ContentView+UsersRoute.swift
@@ -215,10 +215,12 @@ private struct UsersEditorView: View {
                         )
                     }
 
-                    roleToggle(
-                        AccessL10nKey.usersEditorCommonPurchaseManagerLabel,
-                        isOn: commonPurchaseManagerBinding
-                    )
+                    if viewModel.draft.isProducer {
+                        roleToggle(
+                            AccessL10nKey.usersEditorCommonPurchaseManagerLabel,
+                            isOn: commonPurchaseManagerBinding
+                        )
+                    }
 
                     roleToggle(AccessL10nKey.roleProducer, isOn: producerBinding)
 


### PR DESCRIPTION
## Summary
- keep the purchase-manager switch below the inputs and above Producer
- hide the switch while Producer is disabled on Android and iOS
- preserve the updated label and 32 dp/pt bottom spacing

## Validation
- `./gradlew app:testDebugUnitTest app:lintDebug`
- `ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest` (11/11, Pixel_8_Pro_API_35 / Android 15)
- `xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:ReguertaTests test`

## Known environment limitation
- The full iOS UI runner remains blocked locally by `DebuggerVersionStore / no debugger version`; the app and unit suite compile and pass.

Closes #194