### PR TITLE
🐛 fix(navigation): return broadcast editor home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-12 | 🐛 fix(navigation): return broadcast editor home
 - 2026-07-12 | 🐛 fix(users): gate purchase manager by producer
 - 2026-07-12 | 🐛 fix(users): refine member editor controls
 - 2026-07-12 | 🐛 fix(users): refine member editor layout

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/home/ReguertaRootHomeModels.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/home/ReguertaRootHomeModels.kt
@@ -59,6 +59,12 @@ internal fun HomeDestination.subtitleRes(): Int = when (this) {
     HomeDestination.ADMIN_BROADCAST -> R.string.notifications_editor_subtitle
 }
 
+internal fun HomeDestination.backDestination(): HomeDestination = when (this) {
+    HomeDestination.PUBLISH_NEWS -> HomeDestination.NEWS
+    HomeDestination.SHIFT_SWAP_REQUEST -> HomeDestination.SHIFTS
+    else -> HomeDestination.DASHBOARD
+}
+
 internal fun shouldHideHomeShellTitle(
     destination: HomeDestination,
     isMyOrderCartVisible: Boolean,

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/home/ReguertaRootHomeRoute.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/home/ReguertaRootHomeRoute.kt
@@ -477,12 +477,7 @@ internal fun HomeRoute(
                                 } else if (currentDestination == HomeDestination.MY_ORDER) {
                                     isMyOrderCartVisible = false
                                 }
-                                navigateHome(when (currentDestination) {
-                                    HomeDestination.PUBLISH_NEWS -> HomeDestination.NEWS
-                                    HomeDestination.ADMIN_BROADCAST -> HomeDestination.NOTIFICATIONS
-                                    HomeDestination.SHIFT_SWAP_REQUEST -> HomeDestination.SHIFTS
-                                    else -> HomeDestination.DASHBOARD
-                                })
+                                navigateHome(currentDestination.backDestination())
                             }
                         },
                         onOpenMenu = {

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/home/HomeNavigationTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/home/HomeNavigationTest.kt
@@ -1,0 +1,26 @@
+package com.reguerta.user.presentation.home
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeNavigationTest {
+    @Test
+    fun adminBroadcastBackReturnsToDashboard() {
+        assertEquals(
+            HomeDestination.DASHBOARD,
+            HomeDestination.ADMIN_BROADCAST.backDestination(),
+        )
+    }
+
+    @Test
+    fun contextualEditorsKeepTheirParentDestination() {
+        assertEquals(
+            HomeDestination.NEWS,
+            HomeDestination.PUBLISH_NEWS.backDestination(),
+        )
+        assertEquals(
+            HomeDestination.SHIFTS,
+            HomeDestination.SHIFT_SWAP_REQUEST.backDestination(),
+        )
+    }
+}

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellViewModel.swift
@@ -121,7 +121,7 @@ extension AccessRootViewModel {
             homeDestination = .news
         case .adminBroadcast:
             newsNotificationsViewModel.clearNotificationEditor()
-            homeDestination = .notifications
+            homeDestination = .dashboard
         case .shiftSwapRequest:
             shiftsViewModel.clearShiftSwapDraft()
             homeDestination = .shifts

--- a/ios/Reguerta/ReguertaTests/ReguertaNewsNotificationsViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaNewsNotificationsViewModelTests.swift
@@ -298,6 +298,16 @@ struct ReguertaNewsNotificationsViewModelTests {
     }
 
     @Test
+    func notificationEditorBackReturnsToDashboard() {
+        let rootViewModel = ReguertaAppEnvironment.preview().accessRootViewModel
+        rootViewModel.homeDestination = .adminBroadcast
+
+        rootViewModel.handleHomePrimaryAction()
+
+        #expect(rootViewModel.homeDestination == .dashboard)
+    }
+
+    @Test
     func notificationsViewModelSendsAdminBroadcastPayloadAndClearsDraft() async {
         let admin = newsAdminMember(id: "admin_1")
         let repository = InMemoryNotificationRepository(items: [])


### PR DESCRIPTION
## Summary

- return from the notification editor to Home on Android and iOS
- preserve the existing contextual back destinations for news and shift editors
- add regression coverage on both platforms

## Validation

- Android: ./gradlew app:testDebugUnitTest app:lintDebug
- Android: ANDROID_SERIAL=emulator-5554 ./gradlew app:connectedDebugAndroidTest (11/11 passed)
- iOS: xcodebuild -project Reguerta.xcodeproj -scheme Reguerta -configuration Debug -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:ReguertaTests test

## Known environment issue

- The full iOS suite still encounters the existing LLDB UI-runner error: DebuggerVersionStore.StoreError / no debugger version. The ReguertaTests target passes.