### PR TITLE
[P1-10] Evitar registrar tokens FCM en iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-27 | 🐛 fix(ios): stop logging FCM tokens
 - 2026-07-25 | 🐛 fix(bylaws): ground local answers in article evidence
 - 2026-07-12 | 🐛 fix(navigation): return broadcast editor home
 - 2026-07-12 | 🐛 fix(users): gate purchase manager by producer

--- a/ios/Reguerta/Reguerta/App/AppDelegate.swift
+++ b/ios/Reguerta/Reguerta/App/AppDelegate.swift
@@ -32,12 +32,11 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
             return
         }
         Messaging.messaging().apnsToken = deviceToken
-        Messaging.messaging().token { token, error in
+        Messaging.messaging().token { _, error in
             if let error {
                 print("Unable to fetch FCM token after APNs registration: \(error.localizedDescription)")
                 return
             }
-            print("FCM token refreshed after APNs registration: \(token ?? "nil")")
         }
     }
 
@@ -70,7 +69,6 @@ extension AppDelegate: MessagingDelegate {
         guard !Self.usesMockAuth else {
             return
         }
-        print("FCM registration token received: \(fcmToken ?? "nil")")
         Task {
             await KeyManager.shared.save(fcmToken, for: .fcmToken)
             let token = fcmToken?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/ios/Reguerta/ReguertaTests/FCMTokenLoggingSecurityTests.swift
+++ b/ios/Reguerta/ReguertaTests/FCMTokenLoggingSecurityTests.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Testing
+
+struct FCMTokenLoggingSecurityTests {
+    @Test
+    func appDelegateDoesNotInterpolateFCMRegistrationTokens() throws {
+        let source = try String(contentsOf: appDelegateURL(), encoding: .utf8)
+
+        #expect(source.contains(#"\(token"#) == false)
+        #expect(source.contains(#"\(fcmToken"#) == false)
+    }
+
+    private func appDelegateURL() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Reguerta/App/AppDelegate.swift")
+    }
+}


### PR DESCRIPTION
## Resumen

- Elimina los dos logs que exponían el token FCM completo en `AppDelegate`.
- Descarta con `_` el token del callback APNs que solo se utilizaba para imprimirlo.
- Mantiene intactos Keychain, Firestore, el registro del dispositivo y los callbacks.
- Añade una regresión Swift Testing acotada a las dos interpolaciones prohibidas.

## TDD

- RED: 1/1 fallo, con ambas expectativas detectando `\(token` y `\(fcmToken`.
- GREEN: 1/1 correcto tras el cambio mínimo.

## Validación

- Xcode MCP build: correcto, sin warnings nuevos.
- Suite `Reguerta-Develop`: 309 tests; 308 correctos, 0 fallos y 1 UI launch test omitido previamente.
- Búsqueda global: ningún `print`/`Logger` interpola `token` o `fcmToken`.
- `git diff --check`: correcto.
- Dos auditorías independientes: sin hallazgos; revisión SwiftUI/accesibilidad N/A.

## Riesgos conocidos

- Permanecen 6 warnings SwiftLint ya existentes en `main`.
- El contrato de fuente protege estas dos formas concretas; no sustituye una prueba física de APNs/FCM, cuyo comportamiento no cambia.

Closes #200