### PR TITLE
🐛 fix(ios-auth): invalidate stale session tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-27 | 🐛 fix(ios-auth): invalidate stale session tasks
 - 2026-07-27 | 🐛 fix(ios): stop logging FCM tokens
 - 2026-07-25 | 🐛 fix(bylaws): ground local answers in article evidence
 - 2026-07-12 | 🐛 fix(navigation): return broadcast editor home

--- a/ios/Reguerta/Reguerta/Data/Firestore/ReguertaFirestorePath.swift
+++ b/ios/Reguerta/Reguerta/Data/Firestore/ReguertaFirestorePath.swift
@@ -5,6 +5,7 @@ typealias ReguertaFirestoreEnvironment = SessionEnvironment
 
 enum ReguertaRuntimeEnvironment {
     private static var sessionOverride: ReguertaFirestoreEnvironment?
+    private static var sessionEnvironmentLease: SessionEnvironmentLease?
     private static var testingBaseEnvironment: ReguertaFirestoreEnvironment?
 
     static var baseFirestoreEnvironment: ReguertaFirestoreEnvironment {
@@ -22,12 +23,22 @@ enum ReguertaRuntimeEnvironment {
         sessionOverride ?? baseFirestoreEnvironment
     }
 
-    static func applySessionEnvironment(_ environment: ReguertaFirestoreEnvironment) {
+    static func applySessionEnvironment(
+        _ environment: ReguertaFirestoreEnvironment,
+        lease: SessionEnvironmentLease
+    ) {
         sessionOverride = environment == baseFirestoreEnvironment ? nil : environment
+        sessionEnvironmentLease = lease
+    }
+
+    static func resetToBaseEnvironment(ifOwnedBy lease: SessionEnvironmentLease) {
+        guard sessionEnvironmentLease == lease else { return }
+        resetToBaseEnvironment()
     }
 
     static func resetToBaseEnvironment() {
         sessionOverride = nil
+        sessionEnvironmentLease = nil
     }
 
     static func setBaseEnvironmentForTesting(_ environment: ReguertaFirestoreEnvironment?) {

--- a/ios/Reguerta/Reguerta/Data/Firestore/RuntimeSessionEnvironmentRouter.swift
+++ b/ios/Reguerta/Reguerta/Data/Firestore/RuntimeSessionEnvironmentRouter.swift
@@ -5,8 +5,12 @@ struct RuntimeSessionEnvironmentRouter: SessionEnvironmentRouting {
         ReguertaRuntimeEnvironment.baseFirestoreEnvironment
     }
 
-    func applyResolvedEnvironment(_ environment: SessionEnvironment) {
-        ReguertaRuntimeEnvironment.applySessionEnvironment(environment)
+    func applyResolvedEnvironment(_ environment: SessionEnvironment, lease: SessionEnvironmentLease) {
+        ReguertaRuntimeEnvironment.applySessionEnvironment(environment, lease: lease)
+    }
+
+    func resetToBaseEnvironment(ifOwnedBy lease: SessionEnvironmentLease) {
+        ReguertaRuntimeEnvironment.resetToBaseEnvironment(ifOwnedBy: lease)
     }
 
     func resetToBaseEnvironment() {
@@ -16,6 +20,7 @@ struct RuntimeSessionEnvironmentRouter: SessionEnvironmentRouting {
 
 struct FixedSessionEnvironmentRouter: SessionEnvironmentRouting {
     let baseEnvironment: SessionEnvironment
+    private let state: FixedSessionEnvironmentRouterState
     private let onApply: @MainActor @Sendable (SessionEnvironment) -> Void
     private let onReset: @MainActor @Sendable () -> Void
 
@@ -25,15 +30,28 @@ struct FixedSessionEnvironmentRouter: SessionEnvironmentRouting {
         onReset: @escaping @MainActor @Sendable () -> Void = {}
     ) {
         self.baseEnvironment = baseEnvironment
+        self.state = FixedSessionEnvironmentRouterState()
         self.onApply = onApply
         self.onReset = onReset
     }
 
-    func applyResolvedEnvironment(_ environment: SessionEnvironment) {
+    func applyResolvedEnvironment(_ environment: SessionEnvironment, lease: SessionEnvironmentLease) {
+        state.activeLease = lease
         onApply(environment)
     }
 
+    func resetToBaseEnvironment(ifOwnedBy lease: SessionEnvironmentLease) {
+        guard state.activeLease == lease else { return }
+        resetToBaseEnvironment()
+    }
+
     func resetToBaseEnvironment() {
+        state.activeLease = nil
         onReset()
     }
+}
+
+@MainActor
+private final class FixedSessionEnvironmentRouterState {
+    var activeLease: SessionEnvironmentLease?
 }

--- a/ios/Reguerta/Reguerta/Domain/Access/AuthorizedMemberResolver.swift
+++ b/ios/Reguerta/Reguerta/Domain/Access/AuthorizedMemberResolver.swift
@@ -17,6 +17,16 @@ nonisolated enum AuthorizedMemberResolutionError: Error, Equatable, Sendable {
     case unauthorized(UnauthorizedReason)
 }
 
+nonisolated struct SessionEnvironmentLease: Equatable, Sendable {
+    private let id: UUID
+}
+
+extension SessionEnvironmentLease {
+    init() {
+        id = UUID()
+    }
+}
+
 nonisolated protocol AuthorizedMemberResolving: Sendable {
     func resolve(
         authPrincipal: AuthPrincipal,
@@ -27,6 +37,7 @@ nonisolated protocol AuthorizedMemberResolving: Sendable {
 @MainActor
 protocol SessionEnvironmentRouting: Sendable {
     var baseEnvironment: SessionEnvironment { get }
-    func applyResolvedEnvironment(_ environment: SessionEnvironment)
+    func applyResolvedEnvironment(_ environment: SessionEnvironment, lease: SessionEnvironmentLease)
+    func resetToBaseEnvironment(ifOwnedBy lease: SessionEnvironmentLease)
     func resetToBaseEnvironment()
 }

--- a/ios/Reguerta/Reguerta/Domain/Access/ResolveAuthorizedSessionUseCase.swift
+++ b/ios/Reguerta/Reguerta/Domain/Access/ResolveAuthorizedSessionUseCase.swift
@@ -16,6 +16,7 @@ struct ResolveAuthorizedSessionUseCase: Sendable {
     }
 
     func execute(authPrincipal: AuthPrincipal) async throws -> AccessResolutionResult {
+        try Task.checkCancellation()
         let resolution: AuthorizedMemberResolution
         do {
             resolution = try await resolver.resolve(
@@ -28,20 +29,26 @@ struct ResolveAuthorizedSessionUseCase: Sendable {
                 return .unauthorized(reason)
             }
         }
+        try Task.checkCancellation()
         guard resolution.isActive else {
             return .unauthorized(.userAccessRestricted)
         }
-        environmentRouter.applyResolvedEnvironment(resolution.environment)
+        let environmentLease = SessionEnvironmentLease()
+        environmentRouter.applyResolvedEnvironment(
+            resolution.environment,
+            lease: environmentLease
+        )
         var keepsResolvedEnvironment = false
         defer {
             if !keepsResolvedEnvironment {
-                environmentRouter.resetToBaseEnvironment()
+                environmentRouter.resetToBaseEnvironment(ifOwnedBy: environmentLease)
             }
         }
 
         guard let member = try await repository.member(id: resolution.memberId) else {
             return .unauthorized(.userNotFoundInAuthorizedUsers)
         }
+        try Task.checkCancellation()
         guard member.isActive,
               member.id == resolution.memberId,
               member.authUid == authPrincipal.uid,

--- a/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+AuthActions.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+AuthActions.swift
@@ -12,27 +12,38 @@ extension SessionViewModel {
             return
         }
 
+        let operation = beginSessionOperation()
+        let provider = authSessionProvider
         isAuthenticating = true
-        Task { @MainActor in
-            let authResult = await authSessionProvider.signIn(email: email, password: password)
+        sessionOperationTask = Task { @MainActor [weak self, provider] in
+            await operation.predecessor?.value
+            guard self?.isCurrentSessionOperation(operation.generation) == true else { return }
+
+            let authResult = await provider.signIn(email: email, password: password)
+            guard let self else {
+                _ = provider.signOut()
+                return
+            }
+            defer { self.finishSessionOperation(operation.generation) }
+            guard isCurrentSessionOperation(operation.generation) else {
+                _ = provider.signOut()
+                return
+            }
 
             switch authResult {
             case .success(let principal):
-                await applyAuthorizedSession(principal: principal)
+                await applyAuthorizedSession(principal: principal, generation: operation.generation)
             case .emailVerificationRequired(let email, let verificationResent, let signedOut):
-                feedbackCenter.show(
-                    verificationResent
+                applyEmailVerificationRequiredSession(
+                    email: email,
+                    firebaseSignOutSucceeded: signedOut,
+                    feedbackMessageKey: verificationResent
                         ? AccessL10nKey.authInfoVerificationResent
                         : AccessL10nKey.authInfoVerificationPending
                 )
-                mode = signedOut
-                    ? .signedOut
-                    : .unauthorized(email: email, reason: .emailVerificationRequired)
             case .failure(let reason):
                 applySignInFailure(reason)
             }
-
-            isAuthenticating = false
         }
     }
 
@@ -49,28 +60,36 @@ extension SessionViewModel {
             return
         }
 
+        let operation = beginSessionOperation()
+        let provider = authSessionProvider
         isRegistering = true
-        Task { @MainActor in
-            let authResult = await authSessionProvider.signUp(email: email, password: password)
+        sessionOperationTask = Task { @MainActor [weak self, provider] in
+            await operation.predecessor?.value
+            guard self?.isCurrentSessionOperation(operation.generation) == true else { return }
+
+            let authResult = await provider.signUp(email: email, password: password)
+            guard let self else {
+                _ = provider.signOut()
+                return
+            }
+            defer { self.finishSessionOperation(operation.generation) }
+            guard isCurrentSessionOperation(operation.generation) else {
+                _ = provider.signOut()
+                return
+            }
 
             switch authResult {
             case .verificationRequired(let email, let verificationSent, let signedOut):
-                feedbackCenter.show(
-                    verificationSent
+                applyEmailVerificationRequiredSession(
+                    email: email,
+                    firebaseSignOutSucceeded: signedOut,
+                    feedbackMessageKey: verificationSent
                         ? AccessL10nKey.authInfoVerificationSent
                         : AccessL10nKey.authInfoVerificationPending
                 )
-                mode = signedOut
-                    ? .signedOut
-                    : .unauthorized(email: email, reason: .emailVerificationRequired)
-                registerEmailInput = ""
-                registerPasswordInput = ""
-                registerRepeatPasswordInput = ""
             case .failure(let reason):
                 applySignUpFailure(reason)
             }
-
-            isRegistering = false
         }
     }
 
@@ -120,43 +139,36 @@ extension SessionViewModel {
     }
 
     func refreshSession(trigger: SessionRefreshTrigger) {
-        let nowMillis = nowMillisProvider()
-        guard sessionRefreshPolicy.shouldRefresh(
-            trigger: trigger,
-            lastRefreshAtMillis: lastSessionRefreshAtMillis,
-            nowMillis: nowMillis,
-            isRefreshInFlight: isSessionRefreshInFlight
-        ) else {
-            return
-        }
+        guard canStartSessionRefresh(trigger: trigger) else { return }
 
+        let operation = beginSessionOperation()
+        let provider = authSessionProvider
         isSessionRefreshInFlight = true
         let hadAuthenticatedSession = mode.isAuthenticatedSession
-        Task { @MainActor in
-            defer {
-                lastSessionRefreshAtMillis = nowMillisProvider()
-                isSessionRefreshInFlight = false
-            }
+        sessionOperationTask = Task { @MainActor [weak self, provider] in
+            await operation.predecessor?.value
+            guard self?.isCurrentSessionOperation(operation.generation) == true else { return }
 
-            let result = await authSessionProvider.refreshCurrentSession()
-            switch result {
-            case .noSession:
-                if hadAuthenticatedSession {
-                    await handleExpiredSession()
-                }
-            case .active(let principal):
-                await applyAuthorizedSession(principal: principal)
-            case .emailVerificationRequired(let email):
-                feedbackCenter.show(AccessL10nKey.authInfoVerificationPending)
-                mode = authSessionProvider.signOut()
-                    ? .signedOut
-                    : .unauthorized(email: email, reason: .emailVerificationRequired)
-            case .failure(let reason):
-                let mapped = mapAuthFailure(reason, flow: .signIn)
-                feedbackCenter.show(mapped.globalMessageKey)
-            case .expired:
-                await handleExpiredSession()
+            let result = await provider.refreshCurrentSession()
+            guard let self else {
+                _ = provider.signOut()
+                return
             }
+            defer {
+                self.finishSessionOperation(operation.generation)
+            }
+            guard isCurrentSessionOperation(operation.generation) else {
+                _ = provider.signOut()
+                return
+            }
+            await applySessionRefreshResult(
+                result,
+                hadAuthenticatedSession: hadAuthenticatedSession,
+                generation: operation.generation
+            )
+
+            guard isCurrentSessionOperation(operation.generation) else { return }
+            lastSessionRefreshAtMillis = nowMillisProvider()
         }
     }
 

--- a/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+AuthSessionSupport.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+AuthSessionSupport.swift
@@ -77,39 +77,47 @@ extension SessionViewModel {
     }
 
     func applyAuthorizedSession(principal: AuthPrincipal) async {
+        await applyAuthorizedSession(
+            principal: principal,
+            generation: sessionOperationGeneration
+        )
+    }
+
+    func applyAuthorizedSession(
+        principal: AuthPrincipal,
+        generation: UInt64
+    ) async {
         do {
             let result = try await resolveAuthorizedSession.execute(authPrincipal: principal)
+            guard isCurrentSessionOperation(generation) else { return }
             switch result {
             case .authorized(let member):
                 await applyAuthorizedSession(
                     principal: principal,
-                    member: member
+                    member: member,
+                    generation: generation
                 )
             case .unauthorized(let reason):
                 if reason == .emailVerificationRequired {
                     let resent = await authSessionProvider.sendCurrentUserEmailVerification()
+                    guard isCurrentSessionOperation(generation) else { return }
                     let signedOut = authSessionProvider.signOut()
-                    feedbackCenter.show(
-                        resent
+                    applyEmailVerificationRequiredSession(
+                        email: principal.email,
+                        firebaseSignOutSucceeded: signedOut,
+                        feedbackMessageKey: resent
                             ? AccessL10nKey.authInfoVerificationResent
                             : AccessL10nKey.authInfoVerificationPending
                     )
-                    if signedOut {
-                        environmentRouter.resetToBaseEnvironment()
-                        mode = .signedOut
-                    } else {
-                        applyUnauthorizedSession(
-                            principalEmail: principal.email,
-                            reason: .emailVerificationRequired
-                        )
-                    }
                 } else {
                     applyUnauthorizedSession(principalEmail: principal.email, reason: reason)
                 }
             }
         } catch FirebaseFunctionClientError.unauthorized {
+            guard isCurrentSessionOperation(generation) else { return }
             await handleExpiredSession()
         } catch {
+            guard isCurrentSessionOperation(generation) else { return }
             feedbackCenter.show(AccessL10nKey.authErrorNetwork)
             applyUnauthorizedSession(
                 principalEmail: principal.email,
@@ -130,16 +138,7 @@ extension SessionViewModel {
         showsExpiredDialog: Bool
     ) {
         let principalEmail = currentPrincipalEmail
-        clearSessionRefreshTracking()
-        environmentRouter.resetToBaseEnvironment()
-        Task {
-            await KeyManager.shared.remove(.authorizedMemberId)
-        }
-        resetAccessCredentialsAndErrors()
-        isAuthenticating = false
-        isRegistering = false
-        isRecoveringPassword = false
-        feedbackCenter.clear()
+        prepareForLocalSessionTermination()
         if firebaseSignOutSucceeded {
             mode = .signedOut
         } else {
@@ -151,6 +150,34 @@ extension SessionViewModel {
         }
         showSessionExpiredDialog = showsExpiredDialog
         showUnauthorizedDialog = !firebaseSignOutSucceeded && !showsExpiredDialog
+    }
+
+    func applyEmailVerificationRequiredSession(
+        email: String,
+        firebaseSignOutSucceeded: Bool,
+        feedbackMessageKey: String
+    ) {
+        prepareForLocalSessionTermination()
+        mode = firebaseSignOutSucceeded
+            ? .signedOut
+            : .unauthorized(email: email, reason: .emailVerificationRequired)
+        feedbackCenter.show(feedbackMessageKey)
+    }
+
+    private func prepareForLocalSessionTermination() {
+        invalidateSessionOperation()
+        clearSessionRefreshTracking()
+        environmentRouter.resetToBaseEnvironment()
+        Task {
+            await KeyManager.shared.remove(.authorizedMemberId)
+        }
+        resetAccessCredentialsAndErrors()
+        isAuthenticating = false
+        isRegistering = false
+        isRecoveringPassword = false
+        feedbackCenter.clear()
+        showSessionExpiredDialog = false
+        showUnauthorizedDialog = false
     }
 
     private var currentPrincipalEmail: String {
@@ -184,14 +211,83 @@ extension SessionViewModel {
         isSessionRefreshInFlight = false
     }
 
+    func canStartSessionRefresh(trigger: SessionRefreshTrigger) -> Bool {
+        guard !isAuthenticating, !isRegistering else { return false }
+        return sessionRefreshPolicy.shouldRefresh(
+            trigger: trigger,
+            lastRefreshAtMillis: lastSessionRefreshAtMillis,
+            nowMillis: nowMillisProvider(),
+            isRefreshInFlight: isSessionRefreshInFlight
+        )
+    }
+
+    func applySessionRefreshResult(
+        _ result: AuthSessionRefreshResult,
+        hadAuthenticatedSession: Bool,
+        generation: UInt64
+    ) async {
+        switch result {
+        case .noSession:
+            if hadAuthenticatedSession {
+                await handleExpiredSession()
+            }
+        case .active(let principal):
+            await applyAuthorizedSession(principal: principal, generation: generation)
+        case .emailVerificationRequired(let email):
+            applyEmailVerificationRequiredSession(
+                email: email,
+                firebaseSignOutSucceeded: authSessionProvider.signOut(),
+                feedbackMessageKey: AccessL10nKey.authInfoVerificationPending
+            )
+        case .failure(let reason):
+            let mapped = mapAuthFailure(reason, flow: .signIn)
+            feedbackCenter.show(mapped.globalMessageKey)
+        case .expired:
+            await handleExpiredSession()
+        }
+    }
+
+    func beginSessionOperation() -> SessionOperationContext {
+        let predecessor = invalidateSessionOperation()
+        return SessionOperationContext(
+            generation: sessionOperationGeneration,
+            predecessor: predecessor
+        )
+    }
+
+    @discardableResult
+    func invalidateSessionOperation() -> Task<Void, Never>? {
+        let invalidatedTask = sessionOperationTask
+        invalidatedTask?.cancel()
+        sessionOperationGeneration += 1
+        isAuthenticating = false
+        isRegistering = false
+        isSessionRefreshInFlight = false
+        return invalidatedTask
+    }
+
+    func isCurrentSessionOperation(_ generation: UInt64) -> Bool {
+        !Task.isCancelled && generation == sessionOperationGeneration
+    }
+
+    func finishSessionOperation(_ generation: UInt64) {
+        guard generation == sessionOperationGeneration else { return }
+        sessionOperationTask = nil
+        isAuthenticating = false
+        isRegistering = false
+        isSessionRefreshInFlight = false
+    }
+
     private func applyAuthorizedSession(
         principal: AuthPrincipal,
-        member: Member
+        member: Member,
+        generation: UInt64
     ) async {
         let members: [Member]
         do {
             members = try await repository.members(visibleTo: member)
         } catch {
+            guard isCurrentSessionOperation(generation) else { return }
             feedbackCenter.show(AccessL10nKey.authErrorNetwork)
             applyUnauthorizedSession(
                 principalEmail: principal.email,
@@ -199,6 +295,7 @@ extension SessionViewModel {
             )
             return
         }
+        guard isCurrentSessionOperation(generation) else { return }
         mode = .authorized(
             AuthorizedSession(
                 principal: principal,
@@ -209,6 +306,7 @@ extension SessionViewModel {
         )
         showSessionExpiredDialog = false
         showUnauthorizedDialog = false
+        guard isCurrentSessionOperation(generation) else { return }
         await registerAuthorizedDeviceBestEffort(member)
     }
 

--- a/ios/Reguerta/Reguerta/Presentation/Root/SessionViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Root/SessionViewModel.swift
@@ -8,6 +8,11 @@ struct AuthorizedSession: Equatable, Sendable {
     var members: [Member]
 }
 
+struct SessionOperationContext {
+    let generation: UInt64
+    let predecessor: Task<Void, Never>?
+}
+
 enum SessionMode: Equatable, Sendable {
     case signedOut
     case unauthorized(email: String, reason: UnauthorizedReason)
@@ -82,6 +87,8 @@ final class SessionViewModel {
     let developImpersonationEnabled: Bool
     var lastSessionRefreshAtMillis: Int64?
     var isSessionRefreshInFlight = false
+    @ObservationIgnored var sessionOperationTask: Task<Void, Never>?
+    @ObservationIgnored var sessionOperationGeneration: UInt64 = 0
 
     var isDevelopImpersonationEnabled: Bool {
         developImpersonationEnabled

--- a/ios/Reguerta/ReguertaTests/ControlledSessionAuthProvider.swift
+++ b/ios/Reguerta/ReguertaTests/ControlledSessionAuthProvider.swift
@@ -1,0 +1,145 @@
+import Testing
+
+@testable import Reguerta
+
+@MainActor
+final class ControlledSessionAuthProvider: AuthSessionProvider {
+    enum Event: Equatable {
+        case signInStarted(Int)
+        case signInCompleted(Int)
+        case signOut
+    }
+
+    private let immediateSignInResult: AuthSignInResult?
+    private let immediateRefreshResult: AuthSessionRefreshResult?
+    private var signInContinuations: [CheckedContinuation<AuthSignInResult, Never>?] = []
+    private var refreshContinuations: [CheckedContinuation<AuthSessionRefreshResult, Never>?] = []
+    private(set) var signInRequestCount = 0
+    private(set) var refreshRequestCount = 0
+    private(set) var signOutCallCount = 0
+    private(set) var isAuthenticated: Bool
+    private(set) var events: [Event] = []
+
+    init(
+        signInResult: AuthSignInResult? = nil,
+        refreshResult: AuthSessionRefreshResult? = nil,
+        isAuthenticated: Bool = false
+    ) {
+        immediateSignInResult = signInResult
+        immediateRefreshResult = refreshResult
+        self.isAuthenticated = isAuthenticated
+    }
+
+    func signIn(email _: String, password _: String) async -> AuthSignInResult {
+        let requestIndex = signInRequestCount
+        signInRequestCount += 1
+        events.append(.signInStarted(requestIndex))
+        if let immediateSignInResult {
+            applyAuthenticationState(for: immediateSignInResult)
+            events.append(.signInCompleted(requestIndex))
+            return immediateSignInResult
+        }
+        let result = await withCheckedContinuation { continuation in
+            signInContinuations.append(continuation)
+        }
+        applyAuthenticationState(for: result)
+        events.append(.signInCompleted(requestIndex))
+        return result
+    }
+
+    func signUp(email _: String, password _: String) async -> AuthSignUpResult {
+        .failure(.unknown)
+    }
+
+    func sendPasswordReset(email _: String) async -> AuthPasswordResetResult {
+        .failure(.unknown)
+    }
+
+    func sendCurrentUserEmailVerification() async -> Bool {
+        false
+    }
+
+    func validIDToken(forcingRefresh _: Bool) async throws -> String {
+        "test-token"
+    }
+
+    func refreshCurrentSession() async -> AuthSessionRefreshResult {
+        refreshRequestCount += 1
+        if let immediateRefreshResult {
+            applyAuthenticationState(for: immediateRefreshResult)
+            return immediateRefreshResult
+        }
+        let result = await withCheckedContinuation { continuation in
+            refreshContinuations.append(continuation)
+        }
+        applyAuthenticationState(for: result)
+        return result
+    }
+
+    @discardableResult
+    func signOut() -> Bool {
+        signOutCallCount += 1
+        isAuthenticated = false
+        events.append(.signOut)
+        return true
+    }
+
+    func waitForSignInRequestCount(_ expectedCount: Int) async -> Bool {
+        for _ in 0 ..< 1_000 {
+            if signInRequestCount >= expectedCount {
+                return true
+            }
+            await Task.yield()
+        }
+        Issue.record("No se iniciaron \(expectedCount) peticiones de login")
+        return false
+    }
+
+    func waitForRefreshRequestCount(_ expectedCount: Int) async -> Bool {
+        for _ in 0 ..< 1_000 {
+            if refreshRequestCount >= expectedCount {
+                return true
+            }
+            await Task.yield()
+        }
+        Issue.record("No se iniciaron \(expectedCount) peticiones de refresh")
+        return false
+    }
+
+    func completeSignIn(at index: Int = 0, with result: AuthSignInResult) {
+        guard signInContinuations.indices.contains(index),
+              let continuation = signInContinuations[index] else {
+            Issue.record("No existe la petición de login \(index)")
+            return
+        }
+        signInContinuations[index] = nil
+        continuation.resume(returning: result)
+    }
+
+    func completeRefresh(at index: Int = 0, with result: AuthSessionRefreshResult) {
+        guard refreshContinuations.indices.contains(index),
+              let continuation = refreshContinuations[index] else {
+            Issue.record("No existe la petición de refresh \(index)")
+            return
+        }
+        refreshContinuations[index] = nil
+        continuation.resume(returning: result)
+    }
+
+    private func applyAuthenticationState(for result: AuthSignInResult) {
+        switch result {
+        case .success:
+            isAuthenticated = true
+        case .emailVerificationRequired(_, _, let signedOut):
+            isAuthenticated = !signedOut
+        case .failure:
+            break
+        }
+    }
+
+    private func applyAuthenticationState(for result: AuthSessionRefreshResult) {
+        if case .active = result {
+            isAuthenticated = true
+        }
+    }
+}

--- a/ios/Reguerta/ReguertaTests/ControlledSessionMemberRepository.swift
+++ b/ios/Reguerta/ReguertaTests/ControlledSessionMemberRepository.swift
@@ -1,0 +1,50 @@
+import Testing
+
+@testable import Reguerta
+
+@MainActor
+final class ControlledSessionMemberRepository: MemberRepository {
+    let memberValue: Member
+    private var memberContinuations: [CheckedContinuation<Member?, any Error>?] = []
+    private(set) var memberRequestCount = 0
+
+    init(member: Member) {
+        memberValue = member
+    }
+
+    func member(id _: String) async throws -> Member? {
+        memberRequestCount += 1
+        return try await withCheckedThrowingContinuation { continuation in
+            memberContinuations.append(continuation)
+        }
+    }
+
+    func members(visibleTo _: Member) async throws -> [Member] {
+        [memberValue]
+    }
+
+    func updateOwnProducerCatalogEnabled(memberId _: String, enabled _: Bool) async throws -> Member {
+        memberValue
+    }
+
+    func waitForMemberRequestCount(_ expectedCount: Int) async -> Bool {
+        for _ in 0 ..< 1_000 {
+            if memberRequestCount >= expectedCount {
+                return true
+            }
+            await Task.yield()
+        }
+        Issue.record("No se iniciaron \(expectedCount) lecturas de miembro")
+        return false
+    }
+
+    func completeMemberRead(at index: Int, with member: Member?) {
+        guard memberContinuations.indices.contains(index),
+              let continuation = memberContinuations[index] else {
+            Issue.record("No existe la lectura de miembro \(index)")
+            return
+        }
+        memberContinuations[index] = nil
+        continuation.resume(returning: member)
+    }
+}

--- a/ios/Reguerta/ReguertaTests/FirebaseFunctionsSecurityBoundaryTests.swift
+++ b/ios/Reguerta/ReguertaTests/FirebaseFunctionsSecurityBoundaryTests.swift
@@ -410,17 +410,25 @@ private final class RecordingSessionEnvironmentRouter: SessionEnvironmentRouting
     let baseEnvironment: SessionEnvironment
     private(set) var appliedEnvironment: SessionEnvironment?
     private(set) var resetCount = 0
+    private var activeLease: SessionEnvironmentLease?
 
     init(baseEnvironment: SessionEnvironment) {
         self.baseEnvironment = baseEnvironment
     }
 
-    func applyResolvedEnvironment(_ environment: SessionEnvironment) {
+    func applyResolvedEnvironment(_ environment: SessionEnvironment, lease: SessionEnvironmentLease) {
         appliedEnvironment = environment
+        activeLease = lease
+    }
+
+    func resetToBaseEnvironment(ifOwnedBy lease: SessionEnvironmentLease) {
+        guard activeLease == lease else { return }
+        resetToBaseEnvironment()
     }
 
     func resetToBaseEnvironment() {
         appliedEnvironment = nil
+        activeLease = nil
         resetCount += 1
     }
 }

--- a/ios/Reguerta/ReguertaTests/SessionOperationInvalidationTests.swift
+++ b/ios/Reguerta/ReguertaTests/SessionOperationInvalidationTests.swift
@@ -1,0 +1,403 @@
+import Testing
+
+@testable import Reguerta
+
+@MainActor
+struct SessionOperationInvalidationTests {
+    @Test("Cerrar sesión invalida un inicio de sesión que termina tarde")
+    func signOutInvalidatesLateSignInSuccess() async {
+        let fixture = authenticatedMember()
+        let principal = authenticatedPrincipal(for: fixture)
+        let provider = ControlledSessionAuthProvider()
+        let viewModel = makeViewModel(
+            member: fixture,
+            provider: provider,
+            resolver: FixedAuthorizedMemberResolver(member: fixture)
+        )
+        viewModel.emailInput = fixture.normalizedEmail
+        viewModel.passwordInput = "secret12"
+
+        viewModel.signIn()
+        guard await provider.waitForSignInRequestCount(1) else { return }
+        guard let operation = viewModel.sessionOperationTask else {
+            Issue.record("La operación de login no tiene propietario")
+            return
+        }
+        viewModel.signOut()
+        provider.completeSignIn(with: .success(principal))
+        await operation.value
+
+        #expect(viewModel.mode == .signedOut)
+        #expect(viewModel.isAuthenticating == false)
+        #expect(provider.isAuthenticated == false)
+    }
+
+    @Test("Cerrar sesión invalida una restauración de sesión que termina tarde")
+    func signOutInvalidatesLateSessionRefresh() async {
+        let fixture = authenticatedMember()
+        let principal = authenticatedPrincipal(for: fixture)
+        let provider = ControlledSessionAuthProvider(isAuthenticated: true)
+        let viewModel = makeViewModel(
+            member: fixture,
+            provider: provider,
+            resolver: FixedAuthorizedMemberResolver(member: fixture)
+        )
+        viewModel.mode = authorizedMode(member: fixture, principal: principal)
+
+        viewModel.refreshSession(trigger: .startup)
+        guard await provider.waitForRefreshRequestCount(1) else { return }
+        guard let operation = viewModel.sessionOperationTask else {
+            Issue.record("La operación de refresh no tiene propietario")
+            return
+        }
+        viewModel.signOut()
+        provider.completeRefresh(with: .active(principal))
+        await operation.value
+
+        #expect(viewModel.mode == .signedOut)
+        #expect(viewModel.isSessionRefreshInFlight == false)
+        #expect(viewModel.lastSessionRefreshAtMillis == nil)
+        #expect(provider.isAuthenticated == false)
+    }
+
+    @Test("Cerrar sesión invalida una autorización pendiente sin reactivar el entorno")
+    func signOutInvalidatesPendingMemberResolution() async {
+        let fixture = authenticatedMember()
+        let principal = authenticatedPrincipal(for: fixture)
+        let provider = ControlledSessionAuthProvider(
+            signInResult: .success(principal)
+        )
+        let resolver = ControlledAuthorizedMemberResolver()
+        let routingRecorder = SessionRoutingRecorder()
+        let viewModel = makeViewModel(
+            member: fixture,
+            provider: provider,
+            resolver: resolver,
+            routingRecorder: routingRecorder
+        )
+        viewModel.emailInput = fixture.normalizedEmail
+        viewModel.passwordInput = "secret12"
+
+        viewModel.signIn()
+        guard await resolver.waitForRequest() else { return }
+        guard let operation = viewModel.sessionOperationTask else {
+            Issue.record("La resolución de miembro no tiene una tarea propietaria")
+            return
+        }
+        viewModel.signOut()
+        await resolver.complete(with: resolution(for: fixture))
+        await operation.value
+
+        #expect(viewModel.mode == .signedOut)
+        #expect(viewModel.isAuthenticating == false)
+        #expect(routingRecorder.appliedEnvironments.isEmpty)
+    }
+
+    @Test("Un nuevo login espera la limpieza del resultado antiguo")
+    func newerSignInWaitsForStaleProviderCleanup() async {
+        let fixture = authenticatedMember()
+        let principal = authenticatedPrincipal(for: fixture)
+        let provider = ControlledSessionAuthProvider()
+        let viewModel = makeViewModel(
+            member: fixture,
+            provider: provider,
+            resolver: FixedAuthorizedMemberResolver(member: fixture)
+        )
+        viewModel.emailInput = fixture.normalizedEmail
+        viewModel.passwordInput = "secret12"
+
+        viewModel.signIn()
+        guard await provider.waitForSignInRequestCount(1) else { return }
+        guard let staleOperation = viewModel.sessionOperationTask else {
+            Issue.record("El primer login no tiene propietario")
+            return
+        }
+        viewModel.signOut()
+
+        viewModel.emailInput = fixture.normalizedEmail
+        viewModel.passwordInput = "secret12"
+        viewModel.signIn()
+        guard let newerOperation = viewModel.sessionOperationTask else {
+            Issue.record("El segundo login no tiene propietario")
+            return
+        }
+
+        provider.completeSignIn(at: 0, with: .success(principal))
+        await staleOperation.value
+        #expect(provider.isAuthenticated == false)
+
+        guard await provider.waitForSignInRequestCount(2) else { return }
+        #expect(provider.events == [
+            .signInStarted(0),
+            .signOut,
+            .signInCompleted(0),
+            .signOut,
+            .signInStarted(1)
+        ])
+        provider.completeSignIn(at: 1, with: .success(principal))
+        await newerOperation.value
+
+        #expect(viewModel.mode.isAuthenticatedSession)
+        #expect(provider.isAuthenticated)
+        #expect(provider.signOutCallCount == 2)
+        #expect(provider.events.last == .signInCompleted(1))
+    }
+
+    @Test("El refresh automático no interrumpe un login interactivo")
+    func automaticRefreshDoesNotCancelInteractiveSignIn() async {
+        let fixture = authenticatedMember()
+        let principal = authenticatedPrincipal(for: fixture)
+        let provider = ControlledSessionAuthProvider(refreshResult: .noSession)
+        let viewModel = makeViewModel(
+            member: fixture,
+            provider: provider,
+            resolver: FixedAuthorizedMemberResolver(member: fixture)
+        )
+        viewModel.emailInput = fixture.normalizedEmail
+        viewModel.passwordInput = "secret12"
+
+        viewModel.signIn()
+        guard await provider.waitForSignInRequestCount(1) else { return }
+        guard let signInOperation = viewModel.sessionOperationTask else {
+            Issue.record("El login no tiene propietario")
+            return
+        }
+
+        viewModel.refreshSession(trigger: .foreground)
+
+        #expect(viewModel.isAuthenticating)
+        #expect(viewModel.isSessionRefreshInFlight == false)
+        provider.completeSignIn(with: .success(principal))
+        await signInOperation.value
+        if let remainingOperation = viewModel.sessionOperationTask {
+            await remainingOperation.value
+        }
+
+        #expect(provider.refreshRequestCount == 0)
+        #expect(viewModel.mode.isAuthenticatedSession)
+        #expect(provider.isAuthenticated)
+    }
+
+    @Test("La verificación pendiente termina el refresh sin conservar tracking")
+    func emailVerificationRefreshInvalidatesTracking() async {
+        let fixture = authenticatedMember()
+        let principal = authenticatedPrincipal(for: fixture)
+        let provider = ControlledSessionAuthProvider(isAuthenticated: true)
+        let viewModel = makeViewModel(
+            member: fixture,
+            provider: provider,
+            resolver: FixedAuthorizedMemberResolver(member: fixture)
+        )
+        viewModel.mode = authorizedMode(member: fixture, principal: principal)
+
+        viewModel.refreshSession(trigger: .startup)
+        guard await provider.waitForRefreshRequestCount(1) else { return }
+        guard let operation = viewModel.sessionOperationTask else {
+            Issue.record("La operación de refresh no tiene propietario")
+            return
+        }
+        provider.completeRefresh(with: .emailVerificationRequired(email: fixture.normalizedEmail))
+        await operation.value
+
+        #expect(viewModel.mode == .signedOut)
+        #expect(viewModel.lastSessionRefreshAtMillis == nil)
+        #expect(viewModel.isSessionRefreshInFlight == false)
+        #expect(provider.isAuthenticated == false)
+    }
+
+    @Test("El rollback antiguo no pisa el entorno de una sesión nueva")
+    func staleRoutingRollbackDoesNotResetNewerLease() async throws {
+        let fixture = authenticatedMember()
+        let principal = authenticatedPrincipal(for: fixture)
+        let repository = ControlledSessionMemberRepository(member: fixture)
+        let routingRecorder = SessionRoutingRecorder()
+        let environmentRouter = FixedSessionEnvironmentRouter(
+            onApply: { routingRecorder.apply($0) },
+            onReset: { routingRecorder.reset() }
+        )
+        let useCase = ResolveAuthorizedSessionUseCase(
+            repository: repository,
+            resolver: FixedAuthorizedMemberResolver(
+                member: fixture,
+                fixedEnvironment: .production
+            ),
+            environmentRouter: environmentRouter
+        )
+
+        let staleOperation = Task {
+            try await useCase.execute(authPrincipal: principal)
+        }
+        guard await repository.waitForMemberRequestCount(1) else { return }
+        staleOperation.cancel()
+        environmentRouter.resetToBaseEnvironment()
+
+        let newerOperation = Task {
+            try await useCase.execute(authPrincipal: principal)
+        }
+        guard await repository.waitForMemberRequestCount(2) else { return }
+        repository.completeMemberRead(at: 1, with: fixture)
+
+        #expect(try await newerOperation.value == .authorized(fixture))
+        #expect(routingRecorder.currentEnvironment == .production)
+
+        repository.completeMemberRead(at: 0, with: fixture)
+        await #expect(throws: CancellationError.self) {
+            try await staleOperation.value
+        }
+        #expect(routingRecorder.currentEnvironment == .production)
+        #expect(routingRecorder.resetCount == 1)
+    }
+}
+
+@MainActor
+private func makeViewModel(
+    member: Member,
+    provider: ControlledSessionAuthProvider,
+    resolver: some AuthorizedMemberResolving,
+    routingRecorder: SessionRoutingRecorder? = nil
+) -> SessionViewModel {
+    let routingRecorder = routingRecorder ?? SessionRoutingRecorder()
+    let repository = FixedSessionMemberRepository(member: member)
+    let environmentRouter = FixedSessionEnvironmentRouter(
+        onApply: { routingRecorder.apply($0) },
+        onReset: { routingRecorder.reset() }
+    )
+    return SessionViewModel(
+        repository: repository,
+        authSessionProvider: provider,
+        resolveAuthorizedSession: ResolveAuthorizedSessionUseCase(
+            repository: repository,
+            resolver: resolver,
+            environmentRouter: environmentRouter
+        ),
+        environmentRouter: environmentRouter,
+        sessionRefreshPolicy: SessionRefreshPolicy(minimumForegroundIntervalMillis: 0),
+        nowMillisProvider: { 1_000 }
+    )
+}
+
+@MainActor
+private func authenticatedMember() -> Member {
+    Member(
+        id: "member_1",
+        displayName: "Member",
+        normalizedEmail: "member@example.com",
+        authUid: "auth_1",
+        roles: [.member],
+        isActive: true,
+        producerCatalogEnabled: true
+    )
+}
+
+private func authenticatedPrincipal(for member: Member) -> AuthPrincipal {
+    AuthPrincipal(uid: member.authUid ?? "", email: member.normalizedEmail)
+}
+
+private func resolution(for member: Member) -> AuthorizedMemberResolution {
+    AuthorizedMemberResolution(
+        memberId: member.id,
+        roles: member.roles,
+        isActive: member.isActive,
+        environment: .develop,
+        firstLoginLinked: false
+    )
+}
+
+private func authorizedMode(member: Member, principal: AuthPrincipal) -> SessionMode {
+    .authorized(
+        AuthorizedSession(
+            principal: principal,
+            authenticatedMember: member,
+            member: member,
+            members: [member]
+        )
+    )
+}
+
+@MainActor
+private final class SessionRoutingRecorder {
+    var appliedEnvironments: [SessionEnvironment] = []
+    var currentEnvironment: SessionEnvironment?
+    var resetCount = 0
+
+    func apply(_ environment: SessionEnvironment) {
+        appliedEnvironments.append(environment)
+        currentEnvironment = environment
+    }
+
+    func reset() {
+        currentEnvironment = nil
+        resetCount += 1
+    }
+}
+
+private actor ControlledAuthorizedMemberResolver: AuthorizedMemberResolving {
+    private var continuation: CheckedContinuation<AuthorizedMemberResolution, any Error>?
+
+    func resolve(
+        authPrincipal _: AuthPrincipal,
+        requestedEnvironment _: SessionEnvironment
+    ) async throws -> AuthorizedMemberResolution {
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func waitForRequest() async -> Bool {
+        for _ in 0 ..< 1_000 {
+            if continuation != nil {
+                return true
+            }
+            await Task.yield()
+        }
+        Issue.record("No se inició la resolución de miembro")
+        return false
+    }
+
+    func complete(with result: AuthorizedMemberResolution) {
+        let continuation = continuation
+        self.continuation = nil
+        continuation?.resume(returning: result)
+    }
+}
+
+nonisolated private struct FixedAuthorizedMemberResolver: AuthorizedMemberResolving {
+    let member: Member
+    let environment: SessionEnvironment?
+
+    func resolve(
+        authPrincipal _: AuthPrincipal,
+        requestedEnvironment: SessionEnvironment
+    ) async throws -> AuthorizedMemberResolution {
+        AuthorizedMemberResolution(
+            memberId: member.id,
+            roles: member.roles,
+            isActive: member.isActive,
+            environment: environment ?? requestedEnvironment,
+            firstLoginLinked: false
+        )
+    }
+}
+
+private extension FixedAuthorizedMemberResolver {
+    init(member: Member, fixedEnvironment: SessionEnvironment? = nil) {
+        self.member = member
+        environment = fixedEnvironment
+    }
+}
+
+nonisolated private struct FixedSessionMemberRepository: MemberRepository {
+    let member: Member
+
+    func member(id: String) async throws -> Member? {
+        id == member.id ? member : nil
+    }
+
+    func members(visibleTo _: Member) async throws -> [Member] {
+        [member]
+    }
+
+    func updateOwnProducerCatalogEnabled(memberId _: String, enabled _: Bool) async throws -> Member {
+        member
+    }
+}


### PR DESCRIPTION
## Summary
- own iOS session operations with cancellation and a monotonic generation
- serialize provider access so stale Firebase completions are signed out before a successor starts
- protect runtime environment routing with per-operation leases
- keep automatic refresh from interrupting interactive sign-in or sign-up
- cover logout races and provider interleavings deterministically

## Validation
- RED: 3 regression tests failed before the implementation
- Xcode MCP build: passed
- P1-04 regressions: 7 passed, 0 failed
- related auth, routing, and startup tests: 16 passed, 0 failed
- full Reguerta-Develop plan: 315 passed, 0 failed, 1 skipped
- SwiftLint: no new warnings; six pre-existing warnings remain
- independent concurrency and testing audits: no blocking findings after fixes
- an initial full run hit the pre-existing P1-05 freshness flake; its isolated rerun and subsequent full plans passed

## Scope
- iOS only; Android parity is not applicable to this session-concurrency defect
- P1-05 freshness and retry work remains separate
- ReguertaUITestsLaunchTests/testLaunch() is the test skipped by the active plan

Closes #202