### PR TITLE
✅ test(ios): harden home news regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,10 @@ All notable changes to this project will be documented in this file.
 - 2026-04-05 | 🐛 fix(shifts): refine imported schedule board and aliases
 - 2026-03-19 | 🐛 fix(firestore): use plus-collections paths
 
+### Tests
+
+- 2026-07-27 | ✅ test(ios): harden home news regression
+
 ### Documentation
 
 - 2026-07-27 | 📝 docs(firebase): record HU-070 rollout state

--- a/ios/Reguerta/Reguerta/App/ReguertaAppEnvironment.swift
+++ b/ios/Reguerta/Reguerta/App/ReguertaAppEnvironment.swift
@@ -68,6 +68,7 @@ struct ReguertaAppEnvironment {
 
     static func uiTesting() -> ReguertaAppEnvironment {
         let memberRepository = InMemoryMemberRepository()
+        let newsRepository = InMemoryNewsRepository.uiTesting()
         let notificationRepository = InMemoryNotificationRepository()
         let feedbackCenter = GlobalFeedbackCenter()
         let nowMillisProvider: @MainActor () -> Int64 = {
@@ -102,6 +103,7 @@ struct ReguertaAppEnvironment {
                 nowMillisProvider: nowMillisProvider
             ),
             newsNotificationsFeatureDependencies: .preview(
+                newsRepository: newsRepository,
                 notificationRepository: notificationRepository,
                 nowMillisProvider: nowMillisProvider
             ),

--- a/ios/Reguerta/Reguerta/Data/News/InMemoryNewsRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/News/InMemoryNewsRepository.swift
@@ -54,6 +54,42 @@ actor InMemoryNewsRepository: NewsRepository {
     }
 }
 
+extension InMemoryNewsRepository {
+    static func uiTesting() -> InMemoryNewsRepository {
+        InMemoryNewsRepository(
+            items: [
+                NewsArticle(
+                    id: "news_ui_testing_brief",
+                    title: "Community garden update",
+                    body: "The irrigation review is complete.",
+                    active: true,
+                    publishedBy: "Ana Admin",
+                    publishedAtMillis: 1_711_849_800_000,
+                    urlImage: "reguerta-ui-test://news/brief"
+                ),
+                NewsArticle(
+                    id: "news_ui_testing_medium",
+                    title: "Saturday work group changes and updated meeting point",
+                    body: "The next work group will meet at the north gate before walking to the shared plots together.",
+                    active: true,
+                    publishedBy: "Ana Admin",
+                    publishedAtMillis: 1_711_849_700_000,
+                    urlImage: "reguerta-ui-test://news/medium"
+                ),
+                NewsArticle(
+                    id: "news_ui_testing_overflow_target",
+                    title: "Important cooperative assembly information for members and producer families",
+                    body: "Please review the agenda, accessibility notes, voting schedule, and arrival instructions before the assembly begins.",
+                    active: true,
+                    publishedBy: "Ana Admin",
+                    publishedAtMillis: 1_711_849_600_000,
+                    urlImage: "reguerta-ui-test://news/overflow-target"
+                )
+            ]
+        )
+    }
+}
+
 private func localizedSeedNews(_ article: NewsArticle) async -> NewsArticle {
     let title = await MainActor.run {
         NSLocalizedString(article.title, comment: "")

--- a/ios/Reguerta/ReguertaUITests/ReguertaUITests.swift
+++ b/ios/Reguerta/ReguertaUITests/ReguertaUITests.swift
@@ -23,6 +23,9 @@ final class ReguertaUITests: XCTestCase {
     private let latestNewsTitleIdPrefix = "home.latestNews.article."
     private let latestNewsCardIdPrefix = "home.latestNews.articleCard."
     private let latestNewsScrollId = "home.latestNews.scroll"
+    private let latestNewsExpectedCount = 3
+    private let latestNewsOverflowTargetId = "news_ui_testing_overflow_target"
+    private let latestNewsMaxScrollAttempts = 4
     private let deterministicNowMillis = "1778760000000"
 
     override func setUpWithError() throws {
@@ -101,29 +104,50 @@ final class ReguertaUITests: XCTestCase {
             NSPredicate(format: "identifier BEGINSWITH %@", latestNewsTitleIdPrefix)
         )
         XCTAssertTrue(
-            waitForElementCount(latestNewsTitles, minimumCount: 1, timeout: 8),
-            "Latest news title not found"
+            waitForElementCount(latestNewsTitles, minimumCount: latestNewsExpectedCount, timeout: 8),
+            "Expected three deterministic latest news titles"
         )
+        XCTAssertEqual(latestNewsTitles.count, latestNewsExpectedCount)
 
         let latestNewsCards = app.otherElements.matching(
             NSPredicate(format: "identifier BEGINSWITH %@", latestNewsCardIdPrefix)
         )
         XCTAssertTrue(
-            waitForElementCount(latestNewsCards, minimumCount: 1, timeout: 3),
-            "Latest news card not found"
+            waitForElementCount(latestNewsCards, minimumCount: latestNewsExpectedCount, timeout: 3),
+            "Expected three deterministic latest news cards"
         )
+        XCTAssertEqual(latestNewsCards.count, latestNewsExpectedCount)
+
+        let targetTitle = app.staticTexts[latestNewsTitleId(for: latestNewsOverflowTargetId)]
+        let targetCard = app.otherElements[latestNewsCardId(for: latestNewsOverflowTargetId)]
+        XCTAssertTrue(targetTitle.waitForExistence(timeout: 3), "Overflow target title not found")
+        XCTAssertTrue(targetCard.waitForExistence(timeout: 3), "Overflow target card not found")
+
         let latestNewsScroll = app.scrollViews[latestNewsScrollId]
-        for _ in 0 ..< 4 {
+        XCTAssertTrue(latestNewsScroll.waitForExistence(timeout: 3), "Latest news scroll not found")
+
+        var scrollAttempts = 0
+        var keepsBottomBreathingRoom = targetCard.frame.maxY <= app.frame.maxY - 24
+        while (!targetTitle.isHittable || !keepsBottomBreathingRoom),
+              scrollAttempts < latestNewsMaxScrollAttempts {
             latestNewsScroll.swipeUp()
+            scrollAttempts += 1
+            keepsBottomBreathingRoom = targetCard.frame.maxY <= app.frame.maxY - 24
         }
 
-        let latestNewsTitle = latestNewsTitles.element(boundBy: latestNewsTitles.count - 1)
-        let latestNewsCard = latestNewsCards.element(boundBy: latestNewsCards.count - 1)
-        XCTAssertTrue(latestNewsTitle.isHittable, "Latest news title should be visible and hittable")
+        if !targetTitle.isHittable || !keepsBottomBreathingRoom {
+            let screenshot = XCTAttachment(screenshot: app.screenshot())
+            screenshot.name = "P1-06 latest news overflow"
+            screenshot.lifetime = .keepAlways
+            add(screenshot)
+            print(app.debugDescription)
+        }
+
+        XCTAssertTrue(targetTitle.isHittable, "Latest news overflow target should be visible and hittable")
         XCTAssertLessThanOrEqual(
-            latestNewsCard.frame.maxY,
+            targetCard.frame.maxY,
             app.frame.maxY - 24,
-            "Latest news card should keep visible bottom breathing room"
+            "Latest news overflow target should keep visible bottom breathing room"
         )
     }
 
@@ -240,6 +264,14 @@ final class ReguertaUITests: XCTestCase {
             "-reguerta_dev_time_machine.override_now_millis", deterministicNowMillis
         ]
         return app
+    }
+
+    private func latestNewsTitleId(for articleId: String) -> String {
+        "\(latestNewsTitleIdPrefix)\(articleId).title"
+    }
+
+    private func latestNewsCardId(for articleId: String) -> String {
+        "\(latestNewsCardIdPrefix)\(articleId)"
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- seed exactly three deterministic latest-news items in the iOS UI-testing environment
- exercise image-shaped card geometry without Firebase or real network access
- harden the existing regression around the exact third card, bounded scrolling, hittability, and safe viewport geometry
- preserve the current SwiftUI layout because the historical P1-06 failure is not reproducible with isolated representative data

## Validation

- focused UI regression: 3/3 passed with one real swipe per run
- full `Reguerta-Develop` plan: 321 passed, 0 failed, 1 launch test skipped by configuration
- Xcode diagnostics: 0 in all modified Swift files
- `git diff --check`: clean
- independent iOS audit: GO, no findings

## Delivery note

The historical failure occurred against the former Firebase-live UI-test environment. Both the hardened exact-ID test and the historical four-swipe/index strategy pass against the deterministic three-news fixture, so this PR intentionally does not modify layout or safe-area behavior.

Closes #206