### PR TITLE
📝 docs(design-system): add generated color catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ All notable changes to this project will be documented in this file.
 
 ### Documentation
 
+- 2026-07-27 | 📝 docs(design-system): add generated color catalog
 - 2026-07-27 | 📝 docs(firebase): record HU-070 rollout state
 - 2026-07-12 | 📝 docs(users): link HU-069 pull request
 - 2026-07-11 | 📝 docs(orders): link HU-068 pull request

--- a/docs-es/design-system/README.md
+++ b/docs-es/design-system/README.md
@@ -15,6 +15,8 @@ Objetivo: dar direccion compartida a Android e iOS sin congelar la evolucion del
 ## Estructura
 
 - `foundations.md`: modelo canonico de tokens y politica de naming.
+- [`color-tokens.json`](../../docs/design-system/color-tokens.json): fuente de verdad legible por maquina para colores semanticos y sus mapeos por plataforma.
+- [`color-catalog.html`](../../docs/design-system/color-catalog.html): catalogo visual generado y autocontenido; no se edita a mano.
 - `components.md`: catalogo de componentes cross-platform y matriz de paridad.
 - `governance.md`: ciclo de vida (`experimental -> candidate -> stable -> deprecated`) y proceso de cambios.
 - `migration-backlog.md`: trabajo priorizado para pasar del estado actual a un design-system limpio.
@@ -26,6 +28,22 @@ Objetivo: dar direccion compartida a Android e iOS sin congelar la evolucion del
 2. Revisar `components.md` antes de crear APIs nuevas de componentes.
 3. Si el cambio es no trivial, actualizar decision log en `governance.md` y el `migration-backlog.md`.
 4. Mantener `docs` y `docs-es` alineados.
+
+## Catalogo de color
+
+El catalogo pertenece a la documentacion, no al bundle de ninguna app. Los colores de produccion siguen viviendo en Assets/Swift en iOS y en los tokens de tema Android; el generador comprueba esas fuentes contra el contrato compartido antes de producir el HTML.
+
+Regenerar despues de cambiar el contrato o un color de produccion mapeado:
+
+```sh
+python3 scripts/design-system/generate_color_catalog.py
+```
+
+Comprobar paridad de fuentes y detectar un HTML desactualizado sin modificarlo:
+
+```sh
+python3 scripts/design-system/generate_color_catalog.py --check
+```
 
 ## Limites de alcance
 

--- a/docs-es/design-system/foundations.md
+++ b/docs-es/design-system/foundations.md
@@ -63,14 +63,9 @@ Guia:
 
 ### 6.1 Paleta canonica de contraste (P1-09)
 
-| Token semantico | iOS Light | iOS Dark | iOS Increased Contrast Light | iOS Increased Contrast Dark | Android Light | Android Dark |
-|---|---|---|---|---|---|---|
-| `color-action-primary-default` (`AccentColor` en iOS) | `#3D681E` | `#6DA239` | `#315815` | `#A8DD75` | `#3D681E` | `#6DA239` |
-| `color-action-on-primary-default` | `#F2F8E1` | `#0F1D0D` | `#F2F8E1` | `#0F1D0D` | `#F2F8E1` | `#0F1D0D` |
-| `color-control-accent-default` | `#3D681E` | `#6DA239` | `#315815` | `#5B8B2D` | Usa el par `primary`/`onPrimary` de Material 3 | Usa el par `primary`/`onPrimary` de Material 3 |
-| `color-feedback-warning-default` | `#843800` | `#FFAA70` | `#6D2B00` | `#FFC093` | `#843800` | `#FFAA70` |
-| `color-feedback-error-default` | `#8D3434` | `#F48787` | `#742222` | `#FFA5A5` | `#8D3434` | `#F48787` |
-| `color-feedback-on-error-default` | `#F2F8E1` | `#0F1D0D` | `#F2F8E1` | `#0F1D0D` | `#F2F8E1` | `#0F1D0D` |
+El contrato canonico legible por maquina es [`color-tokens.json`](../../docs/design-system/color-tokens.json). Su vista generada para personas es [`color-catalog.html`](../../docs/design-system/color-catalog.html), que incluye todos los colores semanticos mapeados, cuatro contextos visuales, procedencia por plataforma y la matriz WCAG calculada.
+
+No duplicar tablas de hexadecimales en documentacion mantenida a mano. Ejecutar `python3 scripts/design-system/generate_color_catalog.py --check` para verificar que contrato, fuentes de produccion y catalogo coinciden.
 
 `AccentColor` y `actionPrimary` deben resolver a los mismos valores en iOS. `controlAccent` se mantiene separado para que los controles nativos conserven el contraste no textual, tambien con Increased Contrast activado.
 

--- a/docs-es/design-system/governance.md
+++ b/docs-es/design-system/governance.md
@@ -37,3 +37,4 @@ Todo cambio no trivial de design-system debe incluir:
 - 2026-03-12: se establece estrategia semantic-first para naming y ciclo de vida.
 - 2026-03-12: se decide mantener implementacion nativa por plataforma alineando intencion compartida.
 - 2026-07-27: se establece como contrato de color estable la paleta WCAG AA de P1-09, sus pares semanticos de contenido, las variantes iOS Increased Contrast y los checks de contraste cross-platform automatizados.
+- 2026-07-27: se establece `color-tokens.json` como contrato de color revisable y `color-catalog.html` como su representacion visual generada, validada contra las fuentes de produccion iOS y Android.

--- a/docs-es/design-system/migration-backlog.md
+++ b/docs-es/design-system/migration-backlog.md
@@ -20,7 +20,8 @@ Trabajo priorizado para pasar del estado actual a un design-system cross-platfor
 
 - [x] Construir splash/welcome/auth solo con primitivas stable/candidate del design-system.
 - Validar responsive en dispositivos compactos y grandes.
-- Anadir un catalogo generado de color/contraste y un sandbox nativo para regresion visual.
+- [x] Anadir un catalogo generado de color/contraste respaldado por validacion de fuentes de produccion.
+- Anadir un sandbox nativo para regresion visual.
 
 ## P3 (Continuo)
 

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -15,6 +15,8 @@ Goal: provide shared direction for Android and iOS without freezing product evol
 ## Structure
 
 - `foundations.md`: canonical token model and naming policy.
+- [`color-tokens.json`](color-tokens.json): machine-readable source of truth for semantic colors and their platform mappings.
+- [`color-catalog.html`](color-catalog.html): generated, self-contained visual catalog; do not edit it by hand.
 - `components.md`: cross-platform component catalog and parity matrix.
 - `governance.md`: lifecycle (`experimental -> candidate -> stable -> deprecated`) and update process.
 - `migration-backlog.md`: prioritized work to move from current state to clean design-system.
@@ -26,6 +28,22 @@ Goal: provide shared direction for Android and iOS without freezing product evol
 2. Check `components.md` before creating new component APIs.
 3. If a change is non-trivial, update `governance.md` decision log and `migration-backlog.md`.
 4. Keep `docs` and `docs-es` aligned.
+
+## Color Catalog
+
+The catalog belongs in documentation, not in either app bundle. Production colors continue to live in iOS Assets/Swift and Android theme tokens; the generator verifies those sources against the shared contract before producing the HTML.
+
+Regenerate after changing the contract or a mapped production color:
+
+```sh
+python3 scripts/design-system/generate_color_catalog.py
+```
+
+Check source parity and detect a stale generated file without modifying it:
+
+```sh
+python3 scripts/design-system/generate_color_catalog.py --check
+```
 
 ## Scope Boundaries
 

--- a/docs/design-system/color-catalog.html
+++ b/docs/design-system/color-catalog.html
@@ -1,0 +1,2429 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="generator" content="Reguerta color catalog 1.0.0">
+  <meta name="contract-digest" content="51d844f3757e">
+  <title>Reguerta / Color &amp; Contrast</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #182315;
+      --muted: #596654;
+      --canvas: #eef3e4;
+      --paper: #fbfdf6;
+      --line: #cbd5bd;
+      --brand: #3d681e;
+      --brand-soft: #dce9c8;
+      --danger: #8d3434;
+      --radius: 22px;
+      --shadow: 0 18px 55px rgba(33, 54, 25, .10);
+      font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    * { box-sizing: border-box; }
+    html { background: var(--canvas); color: var(--ink); }
+    body { margin: 0; }
+    code { font: 500 .78rem ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }
+    .shell { width: min(1440px, calc(100% - 32px)); margin: 0 auto; padding: 48px 0 96px; }
+    .hero { display: grid; grid-template-columns: 1.5fr .9fr; gap: 32px; align-items: end; padding: 48px; border: 1px solid var(--line); border-radius: 32px; background: var(--paper); box-shadow: var(--shadow); }
+    .kicker, .section-kicker, .category, .preview-meta, .mode-card header p { text-transform: uppercase; letter-spacing: .14em; font-size: .7rem; font-weight: 800; }
+    .kicker, .section-kicker { color: var(--brand); }
+    h1 { margin: 10px 0 12px; font-size: clamp(2.5rem, 7vw, 5.8rem); line-height: .92; letter-spacing: -.055em; }
+    .lede { max-width: 760px; margin: 0; color: var(--muted); font-size: 1.08rem; line-height: 1.65; }
+    .hero-meta { display: grid; gap: 10px; }
+    .meta-card { display: flex; justify-content: space-between; gap: 20px; padding: 14px 16px; border: 1px solid var(--line); border-radius: 14px; background: #fff; }
+    .meta-card span { color: var(--muted); }
+    .generated-note { margin: 18px 0 0; padding: 14px 18px; border-left: 4px solid var(--brand); background: var(--brand-soft); border-radius: 0 12px 12px 0; }
+    section.catalog-section { margin-top: 72px; }
+    .section-head { display: flex; align-items: end; justify-content: space-between; gap: 32px; margin-bottom: 22px; }
+    .section-head h2 { margin: 6px 0 0; font-size: clamp(1.8rem, 4vw, 3.3rem); letter-spacing: -.035em; }
+    .section-head p:last-child { max-width: 580px; color: var(--muted); line-height: 1.55; }
+    .mode-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 20px; }
+    .mode-card, .matrix-card, .preview-card, .provenance-card { border: 1px solid var(--line); border-radius: var(--radius); background: var(--paper); box-shadow: var(--shadow); overflow: hidden; }
+    .mode-card > header { display: flex; justify-content: space-between; align-items: center; padding: 22px 24px; border-bottom: 1px solid var(--line); }
+    .mode-card header p, .mode-card h3 { margin: 0; }
+    .mode-card h3 { margin-top: 5px; font-size: 1.35rem; }
+    .mode-dot { width: 44px; height: 44px; border-radius: 50%; border: 1px solid var(--line); box-shadow: inset 0 0 0 8px rgba(255,255,255,.15); }
+    .mode-dot.light { background: #f2f8e1; }
+    .mode-dot.dark { background: #0f1d0d; }
+    .token-list { display: grid; }
+    .token-row { display: grid; grid-template-columns: minmax(190px, 1fr) minmax(220px, 1.25fr); gap: 18px; padding: 16px 24px; border-top: 1px solid color-mix(in srgb, var(--line), transparent 30%); }
+    .token-row:first-child { border-top: 0; }
+    .token-copy { display: grid; align-content: center; gap: 3px; min-width: 0; }
+    .token-copy .category { color: var(--brand); }
+    .token-copy code { color: var(--muted); }
+    .token-values { display: grid; gap: 7px; }
+    .value { display: grid; grid-template-columns: 28px 68px 1fr; gap: 9px; align-items: center; }
+    .value.aligned { grid-template-columns: 28px 100px 1fr; }
+    .chip { width: 28px; height: 28px; border-radius: 8px; background: var(--swatch); border: 1px solid rgba(20,30,18,.18); box-shadow: inset 0 0 0 1px rgba(255,255,255,.15); }
+    .platforms { color: var(--muted); font-size: .76rem; font-weight: 750; }
+    .matrix-grid { display: grid; gap: 18px; }
+    .matrix-card summary { display: flex; justify-content: space-between; gap: 24px; padding: 20px 24px; cursor: pointer; font-weight: 800; }
+    .matrix-card summary span { color: var(--muted); font-weight: 500; }
+    .table-scroll { overflow-x: auto; border-top: 1px solid var(--line); }
+    table { width: 100%; border-collapse: collapse; min-width: 760px; }
+    th, td { padding: 14px 18px; text-align: left; border-bottom: 1px solid var(--line); vertical-align: middle; }
+    thead th { background: #eef3e5; color: var(--muted); font-size: .72rem; text-transform: uppercase; letter-spacing: .1em; }
+    tbody tr:last-child > * { border-bottom: 0; }
+    tbody th { width: 42%; }
+    tbody th small { display: block; margin-top: 4px; color: var(--muted); font-weight: 500; }
+    .ratio-line { display: flex; align-items: center; gap: 10px; white-space: nowrap; }
+    .pair-chips { display: inline-flex; }
+    .pair-chips i { width: 17px; height: 28px; background: var(--swatch); border: 1px solid rgba(0,0,0,.16); }
+    .pair-chips i:first-child { border-radius: 7px 0 0 7px; }
+    .pair-chips i:last-child { border-radius: 0 7px 7px 0; }
+    .badge { padding: 4px 7px; border-radius: 999px; font-size: .67rem; font-weight: 900; letter-spacing: .04em; }
+    .badge.pass { background: #d9edc5; color: #315815; }
+    .badge.fail { background: #f7d4d4; color: #742222; }
+    .preview-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 18px; }
+    .preview-meta { display: flex; justify-content: space-between; gap: 12px; padding: 13px 16px; border-bottom: 1px solid var(--line); color: var(--muted); }
+    .preview-meta strong { color: var(--brand); text-transform: uppercase; }
+    .app-preview { min-height: 425px; padding: 22px; background: var(--surface); color: var(--text); }
+    .app-preview .eyebrow { margin: 0; color: var(--action); font-size: .74rem; font-weight: 900; letter-spacing: .1em; text-transform: uppercase; }
+    .app-preview h3 { margin: 7px 0; font-size: 1.8rem; }
+    .app-preview .secondary { min-height: 42px; color: var(--text-secondary); line-height: 1.45; }
+    .mini-card { display: flex; justify-content: space-between; gap: 14px; margin: 18px 0; padding: 15px; border: 1px solid var(--border); border-radius: 14px; background: var(--surface-secondary); }
+    .feedback { font-size: .82rem; font-weight: 800; }
+    .feedback.warning { color: var(--warning); }
+    .feedback.error { color: var(--error); }
+    .control-row { display: flex; align-items: center; justify-content: space-between; margin: 22px 0; font-weight: 750; }
+    .toggle { width: 50px; height: 30px; padding: 3px; border-radius: 99px; background: var(--control); }
+    .toggle i { display: block; width: 24px; height: 24px; margin-left: auto; border-radius: 50%; background: var(--surface); }
+    .primary-button { padding: 13px 16px; border-radius: 14px; background: var(--action); color: var(--on-action); text-align: center; font-weight: 900; }
+    .provenance-card { overflow-x: auto; }
+    .provenance-card table { min-width: 1100px; }
+    .provenance-card tbody th { width: 20%; }
+    .provenance-card td { color: var(--muted); font-size: .82rem; line-height: 1.45; }
+    .parity { display: inline-block; margin-bottom: 4px; color: var(--ink); font-weight: 900; }
+    .parity.platform-native { color: #6d2b00; }
+    .checklist { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; padding: 0; list-style: none; }
+    .checklist li { position: relative; padding: 18px 18px 18px 48px; border: 1px solid var(--line); border-radius: 16px; background: var(--paper); line-height: 1.45; }
+    .checklist li::before { content: "✓"; position: absolute; left: 18px; top: 18px; width: 20px; height: 20px; border-radius: 50%; background: var(--brand); color: white; text-align: center; line-height: 20px; font-size: .72rem; font-weight: 900; }
+    footer { margin-top: 72px; padding-top: 24px; border-top: 1px solid var(--line); color: var(--muted); display: flex; justify-content: space-between; gap: 24px; }
+    @media (max-width: 1100px) {
+      .preview-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .checklist { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (max-width: 820px) {
+      .shell { width: min(100% - 20px, 720px); padding-top: 10px; }
+      .hero { grid-template-columns: 1fr; padding: 28px; }
+      .mode-grid, .preview-grid { grid-template-columns: 1fr; }
+      .section-head { display: block; }
+      .token-row { grid-template-columns: 1fr; }
+      .checklist { grid-template-columns: 1fr; }
+      footer { display: block; }
+    }
+    @media print {
+      .shell { width: 100%; padding: 0; }
+      .hero, .mode-card, .matrix-card, .preview-card, .provenance-card { box-shadow: none; break-inside: avoid; }
+    }
+    </style>
+</head>
+<body>
+  <main class="shell">
+    <header class="hero">
+      <div>
+        <p class="kicker">Design System · Color</p>
+        <h1>Reguerta / Color &amp; Contrast</h1>
+        <p class="lede">Contrato semántico cross-platform. Paleta efectiva por plataforma, contraste WCAG 2.2 calculado y componentes en contexto.</p>
+        <p class="generated-note"><strong>Artefacto generado.</strong> No editar este HTML. Cambia <code>color-tokens.json</code> y ejecuta el generador.</p>
+      </div>
+      <div class="hero-meta">
+        <div class="meta-card"><span>Estado</span><strong>stable</strong></div>
+        <div class="meta-card"><span>Revisión</span><strong>2026-07-27</strong></div>
+        <div class="meta-card"><span>Contrato</span><strong>12 tokens · 51d844f3757e</strong></div>
+        <div class="meta-card"><span>WCAG</span><strong class="pass">Todas las parejas pasan</strong></div>
+      </div>
+    </header>
+
+    <section class="catalog-section" aria-labelledby="palette-title">
+      <div class="section-head">
+        <div><p class="section-kicker">01 — Palette</p><h2 id="palette-title">Paleta por modo</h2></div>
+        <p>Un solo nombre semántico, con el valor realmente resuelto por iOS y Android. Las diferencias nativas aparecen separadas, nunca ocultas.</p>
+      </div>
+      <div class="mode-grid">
+            <section class="mode-card">
+              <header>
+                <div>
+                  <p>standard contrast</p>
+                  <h3>Light</h3>
+                </div>
+                <span class="mode-dot light" aria-hidden="true"></span>
+              </header>
+              <div class="token-list">
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Action</span>
+                    <strong>Action primary</strong>
+                    <code>color-action-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#3D681E"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#3D681E</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Action</span>
+                    <strong>On action</strong>
+                    <code>color-action-on-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#F2F8E1"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#F2F8E1</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Action</span>
+                    <strong>Control accent</strong>
+                    <code>color-control-accent-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#3D681E"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#3D681E</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Surface</span>
+                    <strong>Surface primary</strong>
+                    <code>color-surface-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#F2F8E1"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#F2F8E1</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Surface</span>
+                    <strong>Surface secondary</strong>
+                    <code>color-surface-secondary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#DDE5C0"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#DDE5C0</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Text</span>
+                    <strong>Text primary</strong>
+                    <code>color-text-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#2A3B2A"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#2A3B2A</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Text</span>
+                    <strong>Text secondary</strong>
+                    <code>color-text-secondary-default</code>
+                  </div>
+                  <div class="token-values">
+                    <div class="value">
+                      <span class="chip" style="--swatch:#4E5D4D"></span>
+                      <span class="platforms">iOS</span>
+                      <code>#4E5D4D</code>
+                    </div>
+                    <div class="value">
+                      <span class="chip" style="--swatch:#2A3B2A"></span>
+                      <span class="platforms">Android</span>
+                      <code>#2A3B2A</code>
+                    </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Surface</span>
+                    <strong>Border subtle</strong>
+                    <code>color-border-subtle-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#B9C8A2"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#B9C8A2</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Feedback</span>
+                    <strong>Warning</strong>
+                    <code>color-feedback-warning-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#843800"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#843800</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Feedback</span>
+                    <strong>Error</strong>
+                    <code>color-feedback-error-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#8D3434"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#8D3434</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Feedback</span>
+                    <strong>On error</strong>
+                    <code>color-feedback-on-error-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#F2F8E1"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#F2F8E1</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Overlay</span>
+                    <strong>Dialog overlay</strong>
+                    <code>color-overlay-dialog-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#938E8E66"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#938E8E66</code>
+                  </div></div>
+                </article></div>
+            </section>
+            <section class="mode-card">
+              <header>
+                <div>
+                  <p>standard contrast</p>
+                  <h3>Dark</h3>
+                </div>
+                <span class="mode-dot dark" aria-hidden="true"></span>
+              </header>
+              <div class="token-list">
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Action</span>
+                    <strong>Action primary</strong>
+                    <code>color-action-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#6DA239"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#6DA239</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Action</span>
+                    <strong>On action</strong>
+                    <code>color-action-on-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#0F1D0D"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#0F1D0D</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Action</span>
+                    <strong>Control accent</strong>
+                    <code>color-control-accent-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#6DA239"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#6DA239</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Surface</span>
+                    <strong>Surface primary</strong>
+                    <code>color-surface-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#0F1D0D"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#0F1D0D</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Surface</span>
+                    <strong>Surface secondary</strong>
+                    <code>color-surface-secondary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#1A2B1B"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#1A2B1B</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Text</span>
+                    <strong>Text primary</strong>
+                    <code>color-text-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#D1E1D1"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#D1E1D1</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Text</span>
+                    <strong>Text secondary</strong>
+                    <code>color-text-secondary-default</code>
+                  </div>
+                  <div class="token-values">
+                    <div class="value">
+                      <span class="chip" style="--swatch:#B5C5B3"></span>
+                      <span class="platforms">iOS</span>
+                      <code>#B5C5B3</code>
+                    </div>
+                    <div class="value">
+                      <span class="chip" style="--swatch:#D1E1D1"></span>
+                      <span class="platforms">Android</span>
+                      <code>#D1E1D1</code>
+                    </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Surface</span>
+                    <strong>Border subtle</strong>
+                    <code>color-border-subtle-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#37513B"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#37513B</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Feedback</span>
+                    <strong>Warning</strong>
+                    <code>color-feedback-warning-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#FFAA70"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#FFAA70</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Feedback</span>
+                    <strong>Error</strong>
+                    <code>color-feedback-error-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#F48787"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#F48787</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Feedback</span>
+                    <strong>On error</strong>
+                    <code>color-feedback-on-error-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#0F1D0D"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#0F1D0D</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Overlay</span>
+                    <strong>Dialog overlay</strong>
+                    <code>color-overlay-dialog-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#FEFFFF21"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#FEFFFF21</code>
+                  </div></div>
+                </article></div>
+            </section>
+            <section class="mode-card">
+              <header>
+                <div>
+                  <p>increased contrast</p>
+                  <h3>Increased Contrast · Light</h3>
+                </div>
+                <span class="mode-dot light" aria-hidden="true"></span>
+              </header>
+              <div class="token-list">
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Action</span>
+                    <strong>Action primary</strong>
+                    <code>color-action-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                    <div class="value">
+                      <span class="chip" style="--swatch:#315815"></span>
+                      <span class="platforms">iOS</span>
+                      <code>#315815</code>
+                    </div>
+                    <div class="value">
+                      <span class="chip" style="--swatch:#3D681E"></span>
+                      <span class="platforms">Android</span>
+                      <code>#3D681E</code>
+                    </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Action</span>
+                    <strong>On action</strong>
+                    <code>color-action-on-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#F2F8E1"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#F2F8E1</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Action</span>
+                    <strong>Control accent</strong>
+                    <code>color-control-accent-default</code>
+                  </div>
+                  <div class="token-values">
+                    <div class="value">
+                      <span class="chip" style="--swatch:#315815"></span>
+                      <span class="platforms">iOS</span>
+                      <code>#315815</code>
+                    </div>
+                    <div class="value">
+                      <span class="chip" style="--swatch:#3D681E"></span>
+                      <span class="platforms">Android</span>
+                      <code>#3D681E</code>
+                    </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Surface</span>
+                    <strong>Surface primary</strong>
+                    <code>color-surface-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#F2F8E1"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#F2F8E1</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Surface</span>
+                    <strong>Surface secondary</strong>
+                    <code>color-surface-secondary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#DDE5C0"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#DDE5C0</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Text</span>
+                    <strong>Text primary</strong>
+                    <code>color-text-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#2A3B2A"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#2A3B2A</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Text</span>
+                    <strong>Text secondary</strong>
+                    <code>color-text-secondary-default</code>
+                  </div>
+                  <div class="token-values">
+                    <div class="value">
+                      <span class="chip" style="--swatch:#4E5D4D"></span>
+                      <span class="platforms">iOS</span>
+                      <code>#4E5D4D</code>
+                    </div>
+                    <div class="value">
+                      <span class="chip" style="--swatch:#2A3B2A"></span>
+                      <span class="platforms">Android</span>
+                      <code>#2A3B2A</code>
+                    </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Surface</span>
+                    <strong>Border subtle</strong>
+                    <code>color-border-subtle-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#B9C8A2"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#B9C8A2</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Feedback</span>
+                    <strong>Warning</strong>
+                    <code>color-feedback-warning-default</code>
+                  </div>
+                  <div class="token-values">
+                    <div class="value">
+                      <span class="chip" style="--swatch:#6D2B00"></span>
+                      <span class="platforms">iOS</span>
+                      <code>#6D2B00</code>
+                    </div>
+                    <div class="value">
+                      <span class="chip" style="--swatch:#843800"></span>
+                      <span class="platforms">Android</span>
+                      <code>#843800</code>
+                    </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Feedback</span>
+                    <strong>Error</strong>
+                    <code>color-feedback-error-default</code>
+                  </div>
+                  <div class="token-values">
+                    <div class="value">
+                      <span class="chip" style="--swatch:#742222"></span>
+                      <span class="platforms">iOS</span>
+                      <code>#742222</code>
+                    </div>
+                    <div class="value">
+                      <span class="chip" style="--swatch:#8D3434"></span>
+                      <span class="platforms">Android</span>
+                      <code>#8D3434</code>
+                    </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Feedback</span>
+                    <strong>On error</strong>
+                    <code>color-feedback-on-error-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#F2F8E1"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#F2F8E1</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Overlay</span>
+                    <strong>Dialog overlay</strong>
+                    <code>color-overlay-dialog-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#938E8E66"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#938E8E66</code>
+                  </div></div>
+                </article></div>
+            </section>
+            <section class="mode-card">
+              <header>
+                <div>
+                  <p>increased contrast</p>
+                  <h3>Increased Contrast · Dark</h3>
+                </div>
+                <span class="mode-dot dark" aria-hidden="true"></span>
+              </header>
+              <div class="token-list">
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Action</span>
+                    <strong>Action primary</strong>
+                    <code>color-action-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                    <div class="value">
+                      <span class="chip" style="--swatch:#A8DD75"></span>
+                      <span class="platforms">iOS</span>
+                      <code>#A8DD75</code>
+                    </div>
+                    <div class="value">
+                      <span class="chip" style="--swatch:#6DA239"></span>
+                      <span class="platforms">Android</span>
+                      <code>#6DA239</code>
+                    </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Action</span>
+                    <strong>On action</strong>
+                    <code>color-action-on-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#0F1D0D"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#0F1D0D</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Action</span>
+                    <strong>Control accent</strong>
+                    <code>color-control-accent-default</code>
+                  </div>
+                  <div class="token-values">
+                    <div class="value">
+                      <span class="chip" style="--swatch:#5B8B2D"></span>
+                      <span class="platforms">iOS</span>
+                      <code>#5B8B2D</code>
+                    </div>
+                    <div class="value">
+                      <span class="chip" style="--swatch:#6DA239"></span>
+                      <span class="platforms">Android</span>
+                      <code>#6DA239</code>
+                    </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Surface</span>
+                    <strong>Surface primary</strong>
+                    <code>color-surface-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#0F1D0D"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#0F1D0D</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Surface</span>
+                    <strong>Surface secondary</strong>
+                    <code>color-surface-secondary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#1A2B1B"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#1A2B1B</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Text</span>
+                    <strong>Text primary</strong>
+                    <code>color-text-primary-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#D1E1D1"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#D1E1D1</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Text</span>
+                    <strong>Text secondary</strong>
+                    <code>color-text-secondary-default</code>
+                  </div>
+                  <div class="token-values">
+                    <div class="value">
+                      <span class="chip" style="--swatch:#B5C5B3"></span>
+                      <span class="platforms">iOS</span>
+                      <code>#B5C5B3</code>
+                    </div>
+                    <div class="value">
+                      <span class="chip" style="--swatch:#D1E1D1"></span>
+                      <span class="platforms">Android</span>
+                      <code>#D1E1D1</code>
+                    </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Surface</span>
+                    <strong>Border subtle</strong>
+                    <code>color-border-subtle-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#37513B"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#37513B</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Feedback</span>
+                    <strong>Warning</strong>
+                    <code>color-feedback-warning-default</code>
+                  </div>
+                  <div class="token-values">
+                    <div class="value">
+                      <span class="chip" style="--swatch:#FFC093"></span>
+                      <span class="platforms">iOS</span>
+                      <code>#FFC093</code>
+                    </div>
+                    <div class="value">
+                      <span class="chip" style="--swatch:#FFAA70"></span>
+                      <span class="platforms">Android</span>
+                      <code>#FFAA70</code>
+                    </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Feedback</span>
+                    <strong>Error</strong>
+                    <code>color-feedback-error-default</code>
+                  </div>
+                  <div class="token-values">
+                    <div class="value">
+                      <span class="chip" style="--swatch:#FFA5A5"></span>
+                      <span class="platforms">iOS</span>
+                      <code>#FFA5A5</code>
+                    </div>
+                    <div class="value">
+                      <span class="chip" style="--swatch:#F48787"></span>
+                      <span class="platforms">Android</span>
+                      <code>#F48787</code>
+                    </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Feedback</span>
+                    <strong>On error</strong>
+                    <code>color-feedback-on-error-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#0F1D0D"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#0F1D0D</code>
+                  </div></div>
+                </article>
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">Overlay</span>
+                    <strong>Dialog overlay</strong>
+                    <code>color-overlay-dialog-default</code>
+                  </div>
+                  <div class="token-values">
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:#FEFFFF21"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>#FEFFFF21</code>
+                  </div></div>
+                </article></div>
+            </section></div>
+    </section>
+
+    <section class="catalog-section" aria-labelledby="contrast-title">
+      <div class="section-head">
+        <div><p class="section-kicker">02 — WCAG 2.2</p><h2 id="contrast-title">Matriz de contraste</h2></div>
+        <p>La decisión PASS/FAIL usa el ratio completo. El valor visible se redondea únicamente para lectura.</p>
+      </div>
+      <div class="matrix-grid">
+            <details class="matrix-card" open>
+              <summary>Light<span>22 comprobaciones</span></summary>
+              <div class="table-scroll">
+                <table>
+                  <thead><tr><th>Par semántico</th><th>iOS</th><th>Android</th></tr></thead>
+                  <tbody>
+                <tr>
+                  <th scope="row">
+                    Texto principal / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#2A3B2A"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>10.98:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#2A3B2A"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>10.98:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Texto secundario / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#4E5D4D"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>6.44:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#2A3B2A"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>10.98:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Acción / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#3D681E"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>6.03:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#3D681E"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>6.03:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Acción / superficie secundaria
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#3D681E"></i>
+                          <i style="--swatch:#DDE5C0"></i>
+                        </span>
+                        <strong>5.02:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#3D681E"></i>
+                          <i style="--swatch:#DDE5C0"></i>
+                        </span>
+                        <strong>5.02:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Contenido / acción
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#F2F8E1"></i>
+                          <i style="--swatch:#3D681E"></i>
+                        </span>
+                        <strong>6.03:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#F2F8E1"></i>
+                          <i style="--swatch:#3D681E"></i>
+                        </span>
+                        <strong>6.03:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Control / superficie principal
+                    <small>non-text · mínimo 3.0:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#3D681E"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>6.03:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#3D681E"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>6.03:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Warning / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#843800"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>7.57:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#843800"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>7.57:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Warning / superficie secundaria
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#843800"></i>
+                          <i style="--swatch:#DDE5C0"></i>
+                        </span>
+                        <strong>6.30:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#843800"></i>
+                          <i style="--swatch:#DDE5C0"></i>
+                        </span>
+                        <strong>6.30:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Error / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#8D3434"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>7.22:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#8D3434"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>7.22:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Error / superficie secundaria
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#8D3434"></i>
+                          <i style="--swatch:#DDE5C0"></i>
+                        </span>
+                        <strong>6.00:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#8D3434"></i>
+                          <i style="--swatch:#DDE5C0"></i>
+                        </span>
+                        <strong>6.00:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Contenido / error
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#F2F8E1"></i>
+                          <i style="--swatch:#8D3434"></i>
+                        </span>
+                        <strong>7.22:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#F2F8E1"></i>
+                          <i style="--swatch:#8D3434"></i>
+                        </span>
+                        <strong>7.22:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr></tbody>
+                </table>
+              </div>
+            </details>
+            <details class="matrix-card" open>
+              <summary>Dark<span>22 comprobaciones</span></summary>
+              <div class="table-scroll">
+                <table>
+                  <thead><tr><th>Par semántico</th><th>iOS</th><th>Android</th></tr></thead>
+                  <tbody>
+                <tr>
+                  <th scope="row">
+                    Texto principal / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#D1E1D1"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>12.81:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#D1E1D1"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>12.81:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Texto secundario / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#B5C5B3"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>9.65:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#D1E1D1"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>12.81:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Acción / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#6DA239"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>5.72:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#6DA239"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>5.72:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Acción / superficie secundaria
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#6DA239"></i>
+                          <i style="--swatch:#1A2B1B"></i>
+                        </span>
+                        <strong>4.89:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#6DA239"></i>
+                          <i style="--swatch:#1A2B1B"></i>
+                        </span>
+                        <strong>4.89:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Contenido / acción
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#0F1D0D"></i>
+                          <i style="--swatch:#6DA239"></i>
+                        </span>
+                        <strong>5.72:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#0F1D0D"></i>
+                          <i style="--swatch:#6DA239"></i>
+                        </span>
+                        <strong>5.72:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Control / superficie principal
+                    <small>non-text · mínimo 3.0:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#6DA239"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>5.72:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#6DA239"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>5.72:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Warning / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#FFAA70"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>9.35:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#FFAA70"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>9.35:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Warning / superficie secundaria
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#FFAA70"></i>
+                          <i style="--swatch:#1A2B1B"></i>
+                        </span>
+                        <strong>8.00:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#FFAA70"></i>
+                          <i style="--swatch:#1A2B1B"></i>
+                        </span>
+                        <strong>8.00:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Error / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#F48787"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>7.21:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#F48787"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>7.21:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Error / superficie secundaria
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#F48787"></i>
+                          <i style="--swatch:#1A2B1B"></i>
+                        </span>
+                        <strong>6.16:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#F48787"></i>
+                          <i style="--swatch:#1A2B1B"></i>
+                        </span>
+                        <strong>6.16:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Contenido / error
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#0F1D0D"></i>
+                          <i style="--swatch:#F48787"></i>
+                        </span>
+                        <strong>7.21:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#0F1D0D"></i>
+                          <i style="--swatch:#F48787"></i>
+                        </span>
+                        <strong>7.21:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr></tbody>
+                </table>
+              </div>
+            </details>
+            <details class="matrix-card" open>
+              <summary>Increased Contrast · Light<span>22 comprobaciones</span></summary>
+              <div class="table-scroll">
+                <table>
+                  <thead><tr><th>Par semántico</th><th>iOS</th><th>Android</th></tr></thead>
+                  <tbody>
+                <tr>
+                  <th scope="row">
+                    Texto principal / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#2A3B2A"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>10.98:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#2A3B2A"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>10.98:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Texto secundario / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#4E5D4D"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>6.44:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#2A3B2A"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>10.98:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Acción / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#315815"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>7.60:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#3D681E"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>6.03:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Acción / superficie secundaria
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#315815"></i>
+                          <i style="--swatch:#DDE5C0"></i>
+                        </span>
+                        <strong>6.32:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#3D681E"></i>
+                          <i style="--swatch:#DDE5C0"></i>
+                        </span>
+                        <strong>5.02:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Contenido / acción
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#F2F8E1"></i>
+                          <i style="--swatch:#315815"></i>
+                        </span>
+                        <strong>7.60:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#F2F8E1"></i>
+                          <i style="--swatch:#3D681E"></i>
+                        </span>
+                        <strong>6.03:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Control / superficie principal
+                    <small>non-text · mínimo 3.0:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#315815"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>7.60:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#3D681E"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>6.03:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Warning / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#6D2B00"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>9.67:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#843800"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>7.57:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Warning / superficie secundaria
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#6D2B00"></i>
+                          <i style="--swatch:#DDE5C0"></i>
+                        </span>
+                        <strong>8.04:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#843800"></i>
+                          <i style="--swatch:#DDE5C0"></i>
+                        </span>
+                        <strong>6.30:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Error / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#742222"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>9.67:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#8D3434"></i>
+                          <i style="--swatch:#F2F8E1"></i>
+                        </span>
+                        <strong>7.22:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Error / superficie secundaria
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#742222"></i>
+                          <i style="--swatch:#DDE5C0"></i>
+                        </span>
+                        <strong>8.04:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#8D3434"></i>
+                          <i style="--swatch:#DDE5C0"></i>
+                        </span>
+                        <strong>6.00:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Contenido / error
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#F2F8E1"></i>
+                          <i style="--swatch:#742222"></i>
+                        </span>
+                        <strong>9.67:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#F2F8E1"></i>
+                          <i style="--swatch:#8D3434"></i>
+                        </span>
+                        <strong>7.22:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr></tbody>
+                </table>
+              </div>
+            </details>
+            <details class="matrix-card" open>
+              <summary>Increased Contrast · Dark<span>22 comprobaciones</span></summary>
+              <div class="table-scroll">
+                <table>
+                  <thead><tr><th>Par semántico</th><th>iOS</th><th>Android</th></tr></thead>
+                  <tbody>
+                <tr>
+                  <th scope="row">
+                    Texto principal / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#D1E1D1"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>12.81:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#D1E1D1"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>12.81:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Texto secundario / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#B5C5B3"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>9.65:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#D1E1D1"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>12.81:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Acción / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#A8DD75"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>11.04:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#6DA239"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>5.72:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Acción / superficie secundaria
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#A8DD75"></i>
+                          <i style="--swatch:#1A2B1B"></i>
+                        </span>
+                        <strong>9.44:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#6DA239"></i>
+                          <i style="--swatch:#1A2B1B"></i>
+                        </span>
+                        <strong>4.89:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Contenido / acción
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#0F1D0D"></i>
+                          <i style="--swatch:#A8DD75"></i>
+                        </span>
+                        <strong>11.04:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#0F1D0D"></i>
+                          <i style="--swatch:#6DA239"></i>
+                        </span>
+                        <strong>5.72:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Control / superficie principal
+                    <small>non-text · mínimo 3.0:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#5B8B2D"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>4.31:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#6DA239"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>5.72:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Warning / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#FFC093"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>10.99:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#FFAA70"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>9.35:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Warning / superficie secundaria
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#FFC093"></i>
+                          <i style="--swatch:#1A2B1B"></i>
+                        </span>
+                        <strong>9.40:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#FFAA70"></i>
+                          <i style="--swatch:#1A2B1B"></i>
+                        </span>
+                        <strong>8.00:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Error / superficie principal
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#FFA5A5"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>9.30:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#F48787"></i>
+                          <i style="--swatch:#0F1D0D"></i>
+                        </span>
+                        <strong>7.21:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Error / superficie secundaria
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#FFA5A5"></i>
+                          <i style="--swatch:#1A2B1B"></i>
+                        </span>
+                        <strong>7.95:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#F48787"></i>
+                          <i style="--swatch:#1A2B1B"></i>
+                        </span>
+                        <strong>6.16:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr>
+                <tr>
+                  <th scope="row">
+                    Contenido / error
+                    <small>text · mínimo 4.5:1</small>
+                  </th>
+                  <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#0F1D0D"></i>
+                          <i style="--swatch:#FFA5A5"></i>
+                        </span>
+                        <strong>9.30:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:#0F1D0D"></i>
+                          <i style="--swatch:#F48787"></i>
+                        </span>
+                        <strong>7.21:1</strong>
+                        <span class="badge pass">✓ PASS</span>
+                      </div>
+                    </td>
+                </tr></tbody>
+                </table>
+              </div>
+            </details></div>
+    </section>
+
+    <section class="catalog-section" aria-labelledby="preview-title">
+      <div class="section-head">
+        <div><p class="section-kicker">03 — Context</p><h2 id="preview-title">Componentes en contexto</h2></div>
+        <p>Ejemplos documentales para detectar combinaciones inesperadas. No sustituyen las previews ni las pruebas de cada plataforma.</p>
+      </div>
+      <div class="preview-grid">
+                <article class="preview-card" style="
+                  --surface:#F2F8E1;
+                  --surface-secondary:#DDE5C0;
+                  --text:#2A3B2A;
+                  --text-secondary:#4E5D4D;
+                  --border:#B9C8A2;
+                  --action:#3D681E;
+                  --on-action:#F2F8E1;
+                  --control:#3D681E;
+                  --warning:#843800;
+                  --error:#8D3434;
+                ">
+                  <div class="preview-meta">
+                    <span>Light</span>
+                    <strong>ios</strong>
+                  </div>
+                  <div class="app-preview">
+                    <p class="eyebrow">Pedido semanal</p>
+                    <h3>Semana 30</h3>
+                    <p class="secondary">Revisa las cantidades antes de confirmar.</p>
+                    <div class="mini-card">
+                      <span>Verduras y hortalizas</span><strong>18,40 €</strong>
+                    </div>
+                    <p class="feedback warning">▲ Quedan cambios pendientes</p>
+                    <p class="feedback error">● Hay un producto no disponible</p>
+                    <div class="control-row">
+                      <span>Pedido ecológico</span>
+                      <span class="toggle" role="img" aria-label="Control activado"><i></i></span>
+                    </div>
+                    <div class="primary-button">Confirmar pedido</div>
+                  </div>
+                </article>
+                <article class="preview-card" style="
+                  --surface:#F2F8E1;
+                  --surface-secondary:#DDE5C0;
+                  --text:#2A3B2A;
+                  --text-secondary:#2A3B2A;
+                  --border:#B9C8A2;
+                  --action:#3D681E;
+                  --on-action:#F2F8E1;
+                  --control:#3D681E;
+                  --warning:#843800;
+                  --error:#8D3434;
+                ">
+                  <div class="preview-meta">
+                    <span>Light</span>
+                    <strong>android</strong>
+                  </div>
+                  <div class="app-preview">
+                    <p class="eyebrow">Pedido semanal</p>
+                    <h3>Semana 30</h3>
+                    <p class="secondary">Revisa las cantidades antes de confirmar.</p>
+                    <div class="mini-card">
+                      <span>Verduras y hortalizas</span><strong>18,40 €</strong>
+                    </div>
+                    <p class="feedback warning">▲ Quedan cambios pendientes</p>
+                    <p class="feedback error">● Hay un producto no disponible</p>
+                    <div class="control-row">
+                      <span>Pedido ecológico</span>
+                      <span class="toggle" role="img" aria-label="Control activado"><i></i></span>
+                    </div>
+                    <div class="primary-button">Confirmar pedido</div>
+                  </div>
+                </article>
+                <article class="preview-card" style="
+                  --surface:#0F1D0D;
+                  --surface-secondary:#1A2B1B;
+                  --text:#D1E1D1;
+                  --text-secondary:#B5C5B3;
+                  --border:#37513B;
+                  --action:#6DA239;
+                  --on-action:#0F1D0D;
+                  --control:#6DA239;
+                  --warning:#FFAA70;
+                  --error:#F48787;
+                ">
+                  <div class="preview-meta">
+                    <span>Dark</span>
+                    <strong>ios</strong>
+                  </div>
+                  <div class="app-preview">
+                    <p class="eyebrow">Pedido semanal</p>
+                    <h3>Semana 30</h3>
+                    <p class="secondary">Revisa las cantidades antes de confirmar.</p>
+                    <div class="mini-card">
+                      <span>Verduras y hortalizas</span><strong>18,40 €</strong>
+                    </div>
+                    <p class="feedback warning">▲ Quedan cambios pendientes</p>
+                    <p class="feedback error">● Hay un producto no disponible</p>
+                    <div class="control-row">
+                      <span>Pedido ecológico</span>
+                      <span class="toggle" role="img" aria-label="Control activado"><i></i></span>
+                    </div>
+                    <div class="primary-button">Confirmar pedido</div>
+                  </div>
+                </article>
+                <article class="preview-card" style="
+                  --surface:#0F1D0D;
+                  --surface-secondary:#1A2B1B;
+                  --text:#D1E1D1;
+                  --text-secondary:#D1E1D1;
+                  --border:#37513B;
+                  --action:#6DA239;
+                  --on-action:#0F1D0D;
+                  --control:#6DA239;
+                  --warning:#FFAA70;
+                  --error:#F48787;
+                ">
+                  <div class="preview-meta">
+                    <span>Dark</span>
+                    <strong>android</strong>
+                  </div>
+                  <div class="app-preview">
+                    <p class="eyebrow">Pedido semanal</p>
+                    <h3>Semana 30</h3>
+                    <p class="secondary">Revisa las cantidades antes de confirmar.</p>
+                    <div class="mini-card">
+                      <span>Verduras y hortalizas</span><strong>18,40 €</strong>
+                    </div>
+                    <p class="feedback warning">▲ Quedan cambios pendientes</p>
+                    <p class="feedback error">● Hay un producto no disponible</p>
+                    <div class="control-row">
+                      <span>Pedido ecológico</span>
+                      <span class="toggle" role="img" aria-label="Control activado"><i></i></span>
+                    </div>
+                    <div class="primary-button">Confirmar pedido</div>
+                  </div>
+                </article>
+                <article class="preview-card" style="
+                  --surface:#F2F8E1;
+                  --surface-secondary:#DDE5C0;
+                  --text:#2A3B2A;
+                  --text-secondary:#4E5D4D;
+                  --border:#B9C8A2;
+                  --action:#315815;
+                  --on-action:#F2F8E1;
+                  --control:#315815;
+                  --warning:#6D2B00;
+                  --error:#742222;
+                ">
+                  <div class="preview-meta">
+                    <span>Increased Contrast · Light</span>
+                    <strong>ios</strong>
+                  </div>
+                  <div class="app-preview">
+                    <p class="eyebrow">Pedido semanal</p>
+                    <h3>Semana 30</h3>
+                    <p class="secondary">Revisa las cantidades antes de confirmar.</p>
+                    <div class="mini-card">
+                      <span>Verduras y hortalizas</span><strong>18,40 €</strong>
+                    </div>
+                    <p class="feedback warning">▲ Quedan cambios pendientes</p>
+                    <p class="feedback error">● Hay un producto no disponible</p>
+                    <div class="control-row">
+                      <span>Pedido ecológico</span>
+                      <span class="toggle" role="img" aria-label="Control activado"><i></i></span>
+                    </div>
+                    <div class="primary-button">Confirmar pedido</div>
+                  </div>
+                </article>
+                <article class="preview-card" style="
+                  --surface:#F2F8E1;
+                  --surface-secondary:#DDE5C0;
+                  --text:#2A3B2A;
+                  --text-secondary:#2A3B2A;
+                  --border:#B9C8A2;
+                  --action:#3D681E;
+                  --on-action:#F2F8E1;
+                  --control:#3D681E;
+                  --warning:#843800;
+                  --error:#8D3434;
+                ">
+                  <div class="preview-meta">
+                    <span>Increased Contrast · Light</span>
+                    <strong>android</strong>
+                  </div>
+                  <div class="app-preview">
+                    <p class="eyebrow">Pedido semanal</p>
+                    <h3>Semana 30</h3>
+                    <p class="secondary">Revisa las cantidades antes de confirmar.</p>
+                    <div class="mini-card">
+                      <span>Verduras y hortalizas</span><strong>18,40 €</strong>
+                    </div>
+                    <p class="feedback warning">▲ Quedan cambios pendientes</p>
+                    <p class="feedback error">● Hay un producto no disponible</p>
+                    <div class="control-row">
+                      <span>Pedido ecológico</span>
+                      <span class="toggle" role="img" aria-label="Control activado"><i></i></span>
+                    </div>
+                    <div class="primary-button">Confirmar pedido</div>
+                  </div>
+                </article>
+                <article class="preview-card" style="
+                  --surface:#0F1D0D;
+                  --surface-secondary:#1A2B1B;
+                  --text:#D1E1D1;
+                  --text-secondary:#B5C5B3;
+                  --border:#37513B;
+                  --action:#A8DD75;
+                  --on-action:#0F1D0D;
+                  --control:#5B8B2D;
+                  --warning:#FFC093;
+                  --error:#FFA5A5;
+                ">
+                  <div class="preview-meta">
+                    <span>Increased Contrast · Dark</span>
+                    <strong>ios</strong>
+                  </div>
+                  <div class="app-preview">
+                    <p class="eyebrow">Pedido semanal</p>
+                    <h3>Semana 30</h3>
+                    <p class="secondary">Revisa las cantidades antes de confirmar.</p>
+                    <div class="mini-card">
+                      <span>Verduras y hortalizas</span><strong>18,40 €</strong>
+                    </div>
+                    <p class="feedback warning">▲ Quedan cambios pendientes</p>
+                    <p class="feedback error">● Hay un producto no disponible</p>
+                    <div class="control-row">
+                      <span>Pedido ecológico</span>
+                      <span class="toggle" role="img" aria-label="Control activado"><i></i></span>
+                    </div>
+                    <div class="primary-button">Confirmar pedido</div>
+                  </div>
+                </article>
+                <article class="preview-card" style="
+                  --surface:#0F1D0D;
+                  --surface-secondary:#1A2B1B;
+                  --text:#D1E1D1;
+                  --text-secondary:#D1E1D1;
+                  --border:#37513B;
+                  --action:#6DA239;
+                  --on-action:#0F1D0D;
+                  --control:#6DA239;
+                  --warning:#FFAA70;
+                  --error:#F48787;
+                ">
+                  <div class="preview-meta">
+                    <span>Increased Contrast · Dark</span>
+                    <strong>android</strong>
+                  </div>
+                  <div class="app-preview">
+                    <p class="eyebrow">Pedido semanal</p>
+                    <h3>Semana 30</h3>
+                    <p class="secondary">Revisa las cantidades antes de confirmar.</p>
+                    <div class="mini-card">
+                      <span>Verduras y hortalizas</span><strong>18,40 €</strong>
+                    </div>
+                    <p class="feedback warning">▲ Quedan cambios pendientes</p>
+                    <p class="feedback error">● Hay un producto no disponible</p>
+                    <div class="control-row">
+                      <span>Pedido ecológico</span>
+                      <span class="toggle" role="img" aria-label="Control activado"><i></i></span>
+                    </div>
+                    <div class="primary-button">Confirmar pedido</div>
+                  </div>
+                </article></div>
+    </section>
+
+    <section class="catalog-section" aria-labelledby="source-title">
+      <div class="section-head">
+        <div><p class="section-kicker">04 — Sources</p><h2 id="source-title">Procedencia y paridad</h2></div>
+        <p>El generador contrasta el contrato con estas fuentes de producción antes de escribir o verificar el catálogo.</p>
+      </div>
+      <div class="provenance-card">
+        <table>
+          <thead><tr><th>Token</th><th>iOS</th><th>Android</th><th>Paridad</th></tr></thead>
+          <tbody>
+        <tr>
+          <th scope="row"><code>color-action-primary-default</code></th>
+          <td>ios/Reguerta/Reguerta/Resources/Assets.xcassets/AccentColor.colorset/Contents.json · ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/actionPrimary.colorset/Contents.json</td>
+          <td>android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt · ColorActionPrimaryDefaultLight / ColorActionPrimaryDefaultDark</td>
+          <td><span class="parity aligned">aligned</span><br>Los modos estándar coinciden; Android conserva la paleta estándar cuando iOS aumenta contraste.</td>
+        </tr>
+        <tr>
+          <th scope="row"><code>color-action-on-primary-default</code></th>
+          <td>alias → color-surface-primary-default · ios/Reguerta/Reguerta/DesignSystem/ReguertaTheme.swift</td>
+          <td>android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt · ColorActionOnPrimaryLight / ColorActionOnPrimaryDark</td>
+          <td><span class="parity aligned">aligned</span><br>Pareja explícita y opaca para contenido de acción.</td>
+        </tr>
+        <tr>
+          <th scope="row"><code>color-control-accent-default</code></th>
+          <td>ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/controlAccent.colorset/Contents.json</td>
+          <td>alias → color-action-primary-default · android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Theme.kt</td>
+          <td><span class="parity platform-native">platform-native</span><br>iOS separa el modo HC oscuro para conservar contraste no textual; Material 3 usa primary.</td>
+        </tr>
+        <tr>
+          <th scope="row"><code>color-surface-primary-default</code></th>
+          <td>ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/mainBack.colorset/Contents.json</td>
+          <td>android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt · ColorSurfacePrimaryDefaultLight / ColorSurfacePrimaryDefaultDark</td>
+          <td><span class="parity aligned">aligned</span><br>Mismo lienzo semántico en ambas plataformas.</td>
+        </tr>
+        <tr>
+          <th scope="row"><code>color-surface-secondary-default</code></th>
+          <td>ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/secBack.colorset/Contents.json</td>
+          <td>android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt · ColorSurfaceSecondaryDefaultLight / ColorSurfaceSecondaryDefaultDark</td>
+          <td><span class="parity aligned">aligned</span><br>Misma superficie secundaria en ambas plataformas.</td>
+        </tr>
+        <tr>
+          <th scope="row"><code>color-text-primary-default</code></th>
+          <td>ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/textColor.colorset/Contents.json</td>
+          <td>android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt · ColorTextPrimaryDefaultLight / ColorTextPrimaryDefaultDark</td>
+          <td><span class="parity aligned">aligned</span><br>Mismo contenido principal en ambas plataformas.</td>
+        </tr>
+        <tr>
+          <th scope="row"><code>color-text-secondary-default</code></th>
+          <td>ios/Reguerta/Reguerta/DesignSystem/ReguertaTheme.swift · textSecondary</td>
+          <td>alias → color-text-primary-default · android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Theme.kt</td>
+          <td><span class="parity platform-native">platform-native</span><br>iOS usa un tono secundario dedicado; Material 3 hereda onSurface en onSurfaceVariant.</td>
+        </tr>
+        <tr>
+          <th scope="row"><code>color-border-subtle-default</code></th>
+          <td>ios/Reguerta/Reguerta/DesignSystem/ReguertaTheme.swift · borderSubtle</td>
+          <td>android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt · ColorBorderSubtleLight / ColorBorderSubtleDark</td>
+          <td><span class="parity aligned">aligned</span><br>Decorativo o auxiliar; los estados esenciales añaden otra señal.</td>
+        </tr>
+        <tr>
+          <th scope="row"><code>color-feedback-warning-default</code></th>
+          <td>ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/warning.colorset/Contents.json</td>
+          <td>android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt · ColorFeedbackWarningDefaultLight / ColorFeedbackWarningDefaultDark</td>
+          <td><span class="parity aligned">aligned</span><br>Valores estándar alineados; iOS añade variantes de contraste aumentado.</td>
+        </tr>
+        <tr>
+          <th scope="row"><code>color-feedback-error-default</code></th>
+          <td>ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/error.colorset/Contents.json</td>
+          <td>android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt · ColorFeedbackErrorDefaultLight / ColorFeedbackErrorDefaultDark</td>
+          <td><span class="parity aligned">aligned</span><br>Valores estándar alineados; iOS añade variantes de contraste aumentado.</td>
+        </tr>
+        <tr>
+          <th scope="row"><code>color-feedback-on-error-default</code></th>
+          <td>alias → color-surface-primary-default · ios/Reguerta/Reguerta/DesignSystem/ReguertaTheme.swift</td>
+          <td>alias → color-action-on-primary-default · android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Theme.kt</td>
+          <td><span class="parity aligned">aligned</span><br>Pareja explícita para botones y superficies destructivas.</td>
+        </tr>
+        <tr>
+          <th scope="row"><code>color-overlay-dialog-default</code></th>
+          <td>ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/dialogBack.colorset/Contents.json</td>
+          <td>android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt · ColorDialogBackLight / ColorDialogBackDark</td>
+          <td><span class="parity aligned">aligned</span><br>RGBA alineado; su contraste depende de la composición final.</td>
+        </tr></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="catalog-section" aria-labelledby="rules-title">
+      <div class="section-head">
+        <div><p class="section-kicker">05 — Contract</p><h2 id="rules-title">Reglas de uso</h2></div>
+      </div>
+      <ul class="checklist">
+        <li>Texto normal esencial: mínimo <strong>4.5:1</strong>.</li>
+        <li>Controles e indicadores esenciales: mínimo <strong>3:1</strong>.</li>
+        <li>Estados pressed se validan tras aplicar el state layer del <strong>12 %</strong>.</li>
+        <li>Glass usa backing explícito y tint máximo del <strong>16 %</strong>.</li>
+        <li>FAB y barras de total emplean contenedores opacos.</li>
+        <li>Color nunca es la única señal de estado o selección.</li>
+      </ul>
+    </section>
+
+    <footer>
+      <span>Issue #212 · WCAG 2.2</span>
+      <span>Generator 1.0.0 · contract 51d844f3757e</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/design-system/color-tokens.json
+++ b/docs/design-system/color-tokens.json
@@ -1,0 +1,621 @@
+{
+  "schemaVersion": 1,
+  "catalog": {
+    "title": "Reguerta / Color & Contrast",
+    "subtitle": "Contrato semántico cross-platform",
+    "status": "stable",
+    "wcagVersion": "2.2",
+    "lastReviewed": "2026-07-27",
+    "issue": "https://github.com/JFrancoG/ReguertaPlus/issues/212"
+  },
+  "modes": [
+    {
+      "id": "light",
+      "label": "Light",
+      "appearance": "light",
+      "contrast": "standard"
+    },
+    {
+      "id": "dark",
+      "label": "Dark",
+      "appearance": "dark",
+      "contrast": "standard"
+    },
+    {
+      "id": "highContrastLight",
+      "label": "Increased Contrast · Light",
+      "appearance": "light",
+      "contrast": "increased"
+    },
+    {
+      "id": "highContrastDark",
+      "label": "Increased Contrast · Dark",
+      "appearance": "dark",
+      "contrast": "increased"
+    }
+  ],
+  "tokens": [
+    {
+      "id": "color-action-primary-default",
+      "label": "Action primary",
+      "category": "Action",
+      "role": "Acciones, enlaces y contenedores primarios.",
+      "platforms": {
+        "ios": {
+          "values": {
+            "light": "#3D681E",
+            "dark": "#6DA239",
+            "highContrastLight": "#315815",
+            "highContrastDark": "#A8DD75"
+          },
+          "source": {
+            "kind": "ios_assets",
+            "paths": [
+              "ios/Reguerta/Reguerta/Resources/Assets.xcassets/AccentColor.colorset/Contents.json",
+              "ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/actionPrimary.colorset/Contents.json"
+            ]
+          }
+        },
+        "android": {
+          "values": {
+            "light": "#3D681E",
+            "dark": "#6DA239",
+            "highContrastLight": "#3D681E",
+            "highContrastDark": "#6DA239"
+          },
+          "source": {
+            "kind": "kotlin_symbols",
+            "path": "android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt",
+            "symbols": {
+              "light": "ColorActionPrimaryDefaultLight",
+              "dark": "ColorActionPrimaryDefaultDark"
+            }
+          }
+        }
+      },
+      "parity": {
+        "status": "aligned",
+        "note": "Los modos estándar coinciden; Android conserva la paleta estándar cuando iOS aumenta contraste."
+      }
+    },
+    {
+      "id": "color-action-on-primary-default",
+      "label": "On action",
+      "category": "Action",
+      "role": "Contenido sobre el contenedor de acción principal.",
+      "platforms": {
+        "ios": {
+          "values": {
+            "light": "#F2F8E1",
+            "dark": "#0F1D0D",
+            "highContrastLight": "#F2F8E1",
+            "highContrastDark": "#0F1D0D"
+          },
+          "source": {
+            "kind": "token_alias",
+            "token": "color-surface-primary-default",
+            "evidencePath": "ios/Reguerta/Reguerta/DesignSystem/ReguertaTheme.swift"
+          }
+        },
+        "android": {
+          "values": {
+            "light": "#F2F8E1",
+            "dark": "#0F1D0D",
+            "highContrastLight": "#F2F8E1",
+            "highContrastDark": "#0F1D0D"
+          },
+          "source": {
+            "kind": "kotlin_symbols",
+            "path": "android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt",
+            "symbols": {
+              "light": "ColorActionOnPrimaryLight",
+              "dark": "ColorActionOnPrimaryDark"
+            }
+          }
+        }
+      },
+      "parity": {
+        "status": "aligned",
+        "note": "Pareja explícita y opaca para contenido de acción."
+      }
+    },
+    {
+      "id": "color-control-accent-default",
+      "label": "Control accent",
+      "category": "Action",
+      "role": "Tint de controles nativos como Toggle y selección.",
+      "platforms": {
+        "ios": {
+          "values": {
+            "light": "#3D681E",
+            "dark": "#6DA239",
+            "highContrastLight": "#315815",
+            "highContrastDark": "#5B8B2D"
+          },
+          "source": {
+            "kind": "ios_assets",
+            "paths": [
+              "ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/controlAccent.colorset/Contents.json"
+            ]
+          }
+        },
+        "android": {
+          "values": {
+            "light": "#3D681E",
+            "dark": "#6DA239",
+            "highContrastLight": "#3D681E",
+            "highContrastDark": "#6DA239"
+          },
+          "source": {
+            "kind": "token_alias",
+            "token": "color-action-primary-default",
+            "evidencePath": "android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Theme.kt"
+          }
+        }
+      },
+      "parity": {
+        "status": "platform-native",
+        "note": "iOS separa el modo HC oscuro para conservar contraste no textual; Material 3 usa primary."
+      }
+    },
+    {
+      "id": "color-surface-primary-default",
+      "label": "Surface primary",
+      "category": "Surface",
+      "role": "Lienzo y superficie principal de la aplicación.",
+      "platforms": {
+        "ios": {
+          "values": {
+            "light": "#F2F8E1",
+            "dark": "#0F1D0D",
+            "highContrastLight": "#F2F8E1",
+            "highContrastDark": "#0F1D0D"
+          },
+          "source": {
+            "kind": "ios_assets",
+            "paths": [
+              "ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/mainBack.colorset/Contents.json"
+            ]
+          }
+        },
+        "android": {
+          "values": {
+            "light": "#F2F8E1",
+            "dark": "#0F1D0D",
+            "highContrastLight": "#F2F8E1",
+            "highContrastDark": "#0F1D0D"
+          },
+          "source": {
+            "kind": "kotlin_symbols",
+            "path": "android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt",
+            "symbols": {
+              "light": "ColorSurfacePrimaryDefaultLight",
+              "dark": "ColorSurfacePrimaryDefaultDark"
+            }
+          }
+        }
+      },
+      "parity": {
+        "status": "aligned",
+        "note": "Mismo lienzo semántico en ambas plataformas."
+      }
+    },
+    {
+      "id": "color-surface-secondary-default",
+      "label": "Surface secondary",
+      "category": "Surface",
+      "role": "Tarjetas, campos y superficies elevadas secundarias.",
+      "platforms": {
+        "ios": {
+          "values": {
+            "light": "#DDE5C0",
+            "dark": "#1A2B1B",
+            "highContrastLight": "#DDE5C0",
+            "highContrastDark": "#1A2B1B"
+          },
+          "source": {
+            "kind": "ios_assets",
+            "paths": [
+              "ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/secBack.colorset/Contents.json"
+            ]
+          }
+        },
+        "android": {
+          "values": {
+            "light": "#DDE5C0",
+            "dark": "#1A2B1B",
+            "highContrastLight": "#DDE5C0",
+            "highContrastDark": "#1A2B1B"
+          },
+          "source": {
+            "kind": "kotlin_symbols",
+            "path": "android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt",
+            "symbols": {
+              "light": "ColorSurfaceSecondaryDefaultLight",
+              "dark": "ColorSurfaceSecondaryDefaultDark"
+            }
+          }
+        }
+      },
+      "parity": {
+        "status": "aligned",
+        "note": "Misma superficie secundaria en ambas plataformas."
+      }
+    },
+    {
+      "id": "color-text-primary-default",
+      "label": "Text primary",
+      "category": "Text",
+      "role": "Texto principal sobre superficies de la aplicación.",
+      "platforms": {
+        "ios": {
+          "values": {
+            "light": "#2A3B2A",
+            "dark": "#D1E1D1",
+            "highContrastLight": "#2A3B2A",
+            "highContrastDark": "#D1E1D1"
+          },
+          "source": {
+            "kind": "ios_assets",
+            "paths": [
+              "ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/textColor.colorset/Contents.json"
+            ]
+          }
+        },
+        "android": {
+          "values": {
+            "light": "#2A3B2A",
+            "dark": "#D1E1D1",
+            "highContrastLight": "#2A3B2A",
+            "highContrastDark": "#D1E1D1"
+          },
+          "source": {
+            "kind": "kotlin_symbols",
+            "path": "android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt",
+            "symbols": {
+              "light": "ColorTextPrimaryDefaultLight",
+              "dark": "ColorTextPrimaryDefaultDark"
+            }
+          }
+        }
+      },
+      "parity": {
+        "status": "aligned",
+        "note": "Mismo contenido principal en ambas plataformas."
+      }
+    },
+    {
+      "id": "color-text-secondary-default",
+      "label": "Text secondary",
+      "category": "Text",
+      "role": "Contenido auxiliar, metadatos y estados deshabilitados.",
+      "platforms": {
+        "ios": {
+          "values": {
+            "light": "#4E5D4D",
+            "dark": "#B5C5B3",
+            "highContrastLight": "#4E5D4D",
+            "highContrastDark": "#B5C5B3"
+          },
+          "source": {
+            "kind": "swift_theme_hex",
+            "path": "ios/Reguerta/Reguerta/DesignSystem/ReguertaTheme.swift",
+            "property": "textSecondary"
+          }
+        },
+        "android": {
+          "values": {
+            "light": "#2A3B2A",
+            "dark": "#D1E1D1",
+            "highContrastLight": "#2A3B2A",
+            "highContrastDark": "#D1E1D1"
+          },
+          "source": {
+            "kind": "token_alias",
+            "token": "color-text-primary-default",
+            "evidencePath": "android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Theme.kt"
+          }
+        }
+      },
+      "parity": {
+        "status": "platform-native",
+        "note": "iOS usa un tono secundario dedicado; Material 3 hereda onSurface en onSurfaceVariant."
+      }
+    },
+    {
+      "id": "color-border-subtle-default",
+      "label": "Border subtle",
+      "category": "Surface",
+      "role": "Bordes auxiliares; no comunica estado por sí solo.",
+      "platforms": {
+        "ios": {
+          "values": {
+            "light": "#B9C8A2",
+            "dark": "#37513B",
+            "highContrastLight": "#B9C8A2",
+            "highContrastDark": "#37513B"
+          },
+          "source": {
+            "kind": "swift_theme_hex",
+            "path": "ios/Reguerta/Reguerta/DesignSystem/ReguertaTheme.swift",
+            "property": "borderSubtle"
+          }
+        },
+        "android": {
+          "values": {
+            "light": "#B9C8A2",
+            "dark": "#37513B",
+            "highContrastLight": "#B9C8A2",
+            "highContrastDark": "#37513B"
+          },
+          "source": {
+            "kind": "kotlin_symbols",
+            "path": "android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt",
+            "symbols": {
+              "light": "ColorBorderSubtleLight",
+              "dark": "ColorBorderSubtleDark"
+            }
+          }
+        }
+      },
+      "parity": {
+        "status": "aligned",
+        "note": "Decorativo o auxiliar; los estados esenciales añaden otra señal."
+      }
+    },
+    {
+      "id": "color-feedback-warning-default",
+      "label": "Warning",
+      "category": "Feedback",
+      "role": "Avisos que requieren atención sin ser destructivos.",
+      "platforms": {
+        "ios": {
+          "values": {
+            "light": "#843800",
+            "dark": "#FFAA70",
+            "highContrastLight": "#6D2B00",
+            "highContrastDark": "#FFC093"
+          },
+          "source": {
+            "kind": "ios_assets",
+            "paths": [
+              "ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/warning.colorset/Contents.json"
+            ]
+          }
+        },
+        "android": {
+          "values": {
+            "light": "#843800",
+            "dark": "#FFAA70",
+            "highContrastLight": "#843800",
+            "highContrastDark": "#FFAA70"
+          },
+          "source": {
+            "kind": "kotlin_symbols",
+            "path": "android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt",
+            "symbols": {
+              "light": "ColorFeedbackWarningDefaultLight",
+              "dark": "ColorFeedbackWarningDefaultDark"
+            }
+          }
+        }
+      },
+      "parity": {
+        "status": "aligned",
+        "note": "Valores estándar alineados; iOS añade variantes de contraste aumentado."
+      }
+    },
+    {
+      "id": "color-feedback-error-default",
+      "label": "Error",
+      "category": "Feedback",
+      "role": "Errores, peligro y acciones destructivas.",
+      "platforms": {
+        "ios": {
+          "values": {
+            "light": "#8D3434",
+            "dark": "#F48787",
+            "highContrastLight": "#742222",
+            "highContrastDark": "#FFA5A5"
+          },
+          "source": {
+            "kind": "ios_assets",
+            "paths": [
+              "ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/error.colorset/Contents.json"
+            ]
+          }
+        },
+        "android": {
+          "values": {
+            "light": "#8D3434",
+            "dark": "#F48787",
+            "highContrastLight": "#8D3434",
+            "highContrastDark": "#F48787"
+          },
+          "source": {
+            "kind": "kotlin_symbols",
+            "path": "android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt",
+            "symbols": {
+              "light": "ColorFeedbackErrorDefaultLight",
+              "dark": "ColorFeedbackErrorDefaultDark"
+            }
+          }
+        }
+      },
+      "parity": {
+        "status": "aligned",
+        "note": "Valores estándar alineados; iOS añade variantes de contraste aumentado."
+      }
+    },
+    {
+      "id": "color-feedback-on-error-default",
+      "label": "On error",
+      "category": "Feedback",
+      "role": "Contenido sobre contenedores destructivos opacos.",
+      "platforms": {
+        "ios": {
+          "values": {
+            "light": "#F2F8E1",
+            "dark": "#0F1D0D",
+            "highContrastLight": "#F2F8E1",
+            "highContrastDark": "#0F1D0D"
+          },
+          "source": {
+            "kind": "token_alias",
+            "token": "color-surface-primary-default",
+            "evidencePath": "ios/Reguerta/Reguerta/DesignSystem/ReguertaTheme.swift"
+          }
+        },
+        "android": {
+          "values": {
+            "light": "#F2F8E1",
+            "dark": "#0F1D0D",
+            "highContrastLight": "#F2F8E1",
+            "highContrastDark": "#0F1D0D"
+          },
+          "source": {
+            "kind": "token_alias",
+            "token": "color-action-on-primary-default",
+            "evidencePath": "android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Theme.kt"
+          }
+        }
+      },
+      "parity": {
+        "status": "aligned",
+        "note": "Pareja explícita para botones y superficies destructivas."
+      }
+    },
+    {
+      "id": "color-overlay-dialog-default",
+      "label": "Dialog overlay",
+      "category": "Overlay",
+      "role": "Scrim translúcido detrás de diálogos; no se usa como contenido.",
+      "platforms": {
+        "ios": {
+          "values": {
+            "light": "#938E8E66",
+            "dark": "#FEFFFF21",
+            "highContrastLight": "#938E8E66",
+            "highContrastDark": "#FEFFFF21"
+          },
+          "source": {
+            "kind": "ios_assets",
+            "paths": [
+              "ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/dialogBack.colorset/Contents.json"
+            ]
+          }
+        },
+        "android": {
+          "values": {
+            "light": "#938E8E66",
+            "dark": "#FEFFFF21",
+            "highContrastLight": "#938E8E66",
+            "highContrastDark": "#FEFFFF21"
+          },
+          "source": {
+            "kind": "kotlin_symbols",
+            "path": "android/Reguerta/app/src/main/java/com/reguerta/user/ui/theme/Color.kt",
+            "symbols": {
+              "light": "ColorDialogBackLight",
+              "dark": "ColorDialogBackDark"
+            }
+          }
+        }
+      },
+      "parity": {
+        "status": "aligned",
+        "note": "RGBA alineado; su contraste depende de la composición final."
+      }
+    }
+  ],
+  "pairs": [
+    {
+      "id": "primary-text-on-primary-surface",
+      "label": "Texto principal / superficie principal",
+      "foreground": "color-text-primary-default",
+      "background": "color-surface-primary-default",
+      "kind": "text",
+      "minimum": 4.5
+    },
+    {
+      "id": "secondary-text-on-primary-surface",
+      "label": "Texto secundario / superficie principal",
+      "foreground": "color-text-secondary-default",
+      "background": "color-surface-primary-default",
+      "kind": "text",
+      "minimum": 4.5
+    },
+    {
+      "id": "action-on-primary-surface",
+      "label": "Acción / superficie principal",
+      "foreground": "color-action-primary-default",
+      "background": "color-surface-primary-default",
+      "kind": "text",
+      "minimum": 4.5
+    },
+    {
+      "id": "action-on-secondary-surface",
+      "label": "Acción / superficie secundaria",
+      "foreground": "color-action-primary-default",
+      "background": "color-surface-secondary-default",
+      "kind": "text",
+      "minimum": 4.5
+    },
+    {
+      "id": "content-on-action",
+      "label": "Contenido / acción",
+      "foreground": "color-action-on-primary-default",
+      "background": "color-action-primary-default",
+      "kind": "text",
+      "minimum": 4.5
+    },
+    {
+      "id": "control-on-primary-surface",
+      "label": "Control / superficie principal",
+      "foreground": "color-control-accent-default",
+      "background": "color-surface-primary-default",
+      "kind": "non-text",
+      "minimum": 3.0
+    },
+    {
+      "id": "warning-on-primary-surface",
+      "label": "Warning / superficie principal",
+      "foreground": "color-feedback-warning-default",
+      "background": "color-surface-primary-default",
+      "kind": "text",
+      "minimum": 4.5
+    },
+    {
+      "id": "warning-on-secondary-surface",
+      "label": "Warning / superficie secundaria",
+      "foreground": "color-feedback-warning-default",
+      "background": "color-surface-secondary-default",
+      "kind": "text",
+      "minimum": 4.5
+    },
+    {
+      "id": "error-on-primary-surface",
+      "label": "Error / superficie principal",
+      "foreground": "color-feedback-error-default",
+      "background": "color-surface-primary-default",
+      "kind": "text",
+      "minimum": 4.5
+    },
+    {
+      "id": "error-on-secondary-surface",
+      "label": "Error / superficie secundaria",
+      "foreground": "color-feedback-error-default",
+      "background": "color-surface-secondary-default",
+      "kind": "text",
+      "minimum": 4.5
+    },
+    {
+      "id": "content-on-error",
+      "label": "Contenido / error",
+      "foreground": "color-feedback-on-error-default",
+      "background": "color-feedback-error-default",
+      "kind": "text",
+      "minimum": 4.5
+    }
+  ]
+}

--- a/docs/design-system/foundations.md
+++ b/docs/design-system/foundations.md
@@ -63,14 +63,9 @@ Guideline:
 
 ### 6.1 Canonical contrast palette (P1-09)
 
-| Semantic token | iOS Light | iOS Dark | iOS Increased Contrast Light | iOS Increased Contrast Dark | Android Light | Android Dark |
-|---|---|---|---|---|---|---|
-| `color-action-primary-default` (`AccentColor` on iOS) | `#3D681E` | `#6DA239` | `#315815` | `#A8DD75` | `#3D681E` | `#6DA239` |
-| `color-action-on-primary-default` | `#F2F8E1` | `#0F1D0D` | `#F2F8E1` | `#0F1D0D` | `#F2F8E1` | `#0F1D0D` |
-| `color-control-accent-default` | `#3D681E` | `#6DA239` | `#315815` | `#5B8B2D` | Uses the Material 3 `primary`/`onPrimary` pair | Uses the Material 3 `primary`/`onPrimary` pair |
-| `color-feedback-warning-default` | `#843800` | `#FFAA70` | `#6D2B00` | `#FFC093` | `#843800` | `#FFAA70` |
-| `color-feedback-error-default` | `#8D3434` | `#F48787` | `#742222` | `#FFA5A5` | `#8D3434` | `#F48787` |
-| `color-feedback-on-error-default` | `#F2F8E1` | `#0F1D0D` | `#F2F8E1` | `#0F1D0D` | `#F2F8E1` | `#0F1D0D` |
+The canonical machine-readable contract is [`color-tokens.json`](color-tokens.json). Its generated human-readable view is [`color-catalog.html`](color-catalog.html), which includes all mapped semantic colors, four visual contexts, platform provenance, and the computed WCAG matrix.
+
+Do not duplicate hexadecimal tables in manually maintained documentation. Run `python3 scripts/design-system/generate_color_catalog.py --check` to verify that the contract, production sources, and catalog agree.
 
 `AccentColor` and `actionPrimary` must resolve to the same iOS values. `controlAccent` remains separate so native controls retain non-text contrast, including with Increased Contrast enabled.
 

--- a/docs/design-system/governance.md
+++ b/docs/design-system/governance.md
@@ -37,3 +37,4 @@ Any non-trivial design-system change should include:
 - 2026-03-12: established semantic-first naming strategy and lifecycle governance.
 - 2026-03-12: decided to keep platform-native implementations while aligning shared intent.
 - 2026-07-27: established the P1-09 WCAG AA palette, explicit semantic content pairs, iOS Increased Contrast variants, and automated cross-platform contrast checks as the stable color contract.
+- 2026-07-27: made `color-tokens.json` the reviewable color contract and `color-catalog.html` its generated visual representation, validated against production iOS and Android sources.

--- a/docs/design-system/migration-backlog.md
+++ b/docs/design-system/migration-backlog.md
@@ -20,7 +20,8 @@ Prioritized tasks to move from current state to a cleaner cross-platform design-
 
 - [x] Build splash/welcome/auth screens only with stable/candidate design-system primitives.
 - Validate responsive behavior in compact and large devices.
-- Add a generated color/contrast catalog plus a native UI sandbox for visual regression checks.
+- [x] Add a generated color/contrast catalog backed by production-source validation.
+- Add a native UI sandbox for visual regression checks.
 
 ## P3 (Continuous)
 

--- a/scripts/design-system/generate_color_catalog.py
+++ b/scripts/design-system/generate_color_catalog.py
@@ -1,0 +1,747 @@
+#!/usr/bin/env python3
+"""Generate and verify Reguerta's self-contained color catalog."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_PATH = REPO_ROOT / "docs/design-system/color-tokens.json"
+OUTPUT_PATH = REPO_ROOT / "docs/design-system/color-catalog.html"
+GENERATOR_VERSION = "1.0.0"
+PLATFORMS = ("ios", "android")
+HEX_PATTERN = re.compile(r"^#[0-9A-F]{6}(?:[0-9A-F]{2})?$")
+
+
+class CatalogError(RuntimeError):
+    """Raised when the contract or a production source is inconsistent."""
+
+
+def load_contract() -> dict[str, Any]:
+    try:
+        return json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise CatalogError(f"Cannot load {CONTRACT_PATH.relative_to(REPO_ROOT)}: {error}") from error
+
+
+def normalized_hex(value: str) -> str:
+    value = value.upper()
+    if not HEX_PATTERN.fullmatch(value):
+        raise CatalogError(f"Invalid color value: {value}")
+    return value
+
+
+def color_component(value: str) -> int:
+    if value.lower().startswith("0x"):
+        return int(value, 16)
+    numeric = float(value)
+    return round(numeric * 255) if numeric <= 1 else round(numeric)
+
+
+def rgba_hex(red: int, green: int, blue: int, alpha: int = 255) -> str:
+    rgb = f"#{red:02X}{green:02X}{blue:02X}"
+    return rgb if alpha == 255 else f"{rgb}{alpha:02X}"
+
+
+def parse_ios_asset(relative_path: str) -> dict[str, str]:
+    path = REPO_ROOT / relative_path
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise CatalogError(f"Cannot parse iOS asset {relative_path}: {error}") from error
+
+    variants: dict[tuple[bool, bool], str] = {}
+    for entry in payload.get("colors", []):
+        components = entry.get("color", {}).get("components", {})
+        if not {"red", "green", "blue"}.issubset(components):
+            continue
+        appearances = {
+            item.get("appearance"): item.get("value")
+            for item in entry.get("appearances", [])
+        }
+        is_dark = appearances.get("luminosity") == "dark"
+        is_high_contrast = appearances.get("contrast") == "high"
+        variants[(is_dark, is_high_contrast)] = rgba_hex(
+            color_component(components["red"]),
+            color_component(components["green"]),
+            color_component(components["blue"]),
+            color_component(components.get("alpha", "1")),
+        )
+
+    if (False, False) not in variants:
+        raise CatalogError(f"iOS asset has no default color: {relative_path}")
+
+    light = variants[(False, False)]
+    dark = variants.get((True, False), light)
+    return {
+        "light": light,
+        "dark": dark,
+        "highContrastLight": variants.get((False, True), light),
+        "highContrastDark": variants.get((True, True), dark),
+    }
+
+
+def parse_kotlin_symbols(source: dict[str, Any]) -> dict[str, str]:
+    relative_path = source["path"]
+    path = REPO_ROOT / relative_path
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise CatalogError(f"Cannot read Kotlin source {relative_path}: {error}") from error
+
+    values: dict[str, str] = {}
+    for mode in ("light", "dark"):
+        symbol = source["symbols"][mode]
+        match = re.search(
+            rf"\bval\s+{re.escape(symbol)}\s*=\s*Color\(0x([0-9A-Fa-f]{{8}})\)",
+            content,
+        )
+        if match is None:
+            raise CatalogError(f"Kotlin color symbol not found: {symbol} in {relative_path}")
+        argb = match.group(1).upper()
+        alpha, red, green, blue = (
+            int(argb[0:2], 16),
+            int(argb[2:4], 16),
+            int(argb[4:6], 16),
+            int(argb[6:8], 16),
+        )
+        values[mode] = rgba_hex(red, green, blue, alpha)
+
+    values["highContrastLight"] = values["light"]
+    values["highContrastDark"] = values["dark"]
+    return values
+
+
+def parse_swift_theme_hex(source: dict[str, Any]) -> dict[str, str]:
+    relative_path = source["path"]
+    path = REPO_ROOT / relative_path
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as error:
+        raise CatalogError(f"Cannot read Swift source {relative_path}: {error}") from error
+
+    light_match = re.search(r"static var light:.*?(?=static var dark:)", content, re.DOTALL)
+    dark_match = re.search(r"static var dark:.*", content, re.DOTALL)
+    if light_match is None or dark_match is None:
+        raise CatalogError(f"Cannot locate light/dark token blocks in {relative_path}")
+
+    property_name = source["property"]
+
+    def find_value(block: str, mode: str) -> str:
+        match = re.search(
+            rf"\b{re.escape(property_name)}\s*:\s*Color\(hex:\s*0x([0-9A-Fa-f]{{6}})\)",
+            block,
+        )
+        if match is None:
+            raise CatalogError(
+                f"Swift token {property_name} ({mode}) not found in {relative_path}"
+            )
+        return f"#{match.group(1).upper()}"
+
+    light = find_value(light_match.group(0), "light")
+    dark = find_value(dark_match.group(0), "dark")
+    return {
+        "light": light,
+        "dark": dark,
+        "highContrastLight": light,
+        "highContrastDark": dark,
+    }
+
+
+def validate_contract(contract: dict[str, Any]) -> tuple[list[str], dict[str, dict[str, Any]]]:
+    if contract.get("schemaVersion") != 1:
+        raise CatalogError("color-tokens.json must use schemaVersion 1")
+
+    modes = contract.get("modes", [])
+    mode_ids = [mode.get("id") for mode in modes]
+    if len(mode_ids) != len(set(mode_ids)) or len(mode_ids) != 4:
+        raise CatalogError("The contract must define four unique visual modes")
+
+    tokens = contract.get("tokens", [])
+    token_index = {token.get("id"): token for token in tokens}
+    if None in token_index or len(token_index) != len(tokens):
+        raise CatalogError("Every token must have a unique id")
+
+    for token_id, token in token_index.items():
+        for platform in PLATFORMS:
+            platform_data = token.get("platforms", {}).get(platform)
+            if platform_data is None:
+                raise CatalogError(f"{token_id} has no {platform} definition")
+            values = platform_data.get("values", {})
+            if set(values) != set(mode_ids):
+                raise CatalogError(f"{token_id}/{platform} must define every visual mode")
+            for value in values.values():
+                normalized_hex(value)
+            if "kind" not in platform_data.get("source", {}):
+                raise CatalogError(f"{token_id}/{platform} has no verifiable source")
+
+    pair_ids: set[str] = set()
+    for pair in contract.get("pairs", []):
+        pair_id = pair.get("id")
+        if not pair_id or pair_id in pair_ids:
+            raise CatalogError("Every contrast pair must have a unique id")
+        pair_ids.add(pair_id)
+        if pair.get("foreground") not in token_index or pair.get("background") not in token_index:
+            raise CatalogError(f"Contrast pair references an unknown token: {pair_id}")
+        if not isinstance(pair.get("minimum"), (int, float)) or pair["minimum"] <= 0:
+            raise CatalogError(f"Contrast pair has an invalid minimum: {pair_id}")
+
+    return mode_ids, token_index
+
+
+def validate_production_sources(
+    contract: dict[str, Any],
+    mode_ids: list[str],
+    token_index: dict[str, dict[str, Any]],
+) -> None:
+    errors: list[str] = []
+    for token in contract["tokens"]:
+        token_id = token["id"]
+        for platform in PLATFORMS:
+            platform_data = token["platforms"][platform]
+            source = platform_data["source"]
+            kind = source["kind"]
+            try:
+                if kind == "ios_assets":
+                    parsed_sets = [parse_ios_asset(path) for path in source["paths"]]
+                    actual = parsed_sets[0]
+                    for path, parsed in zip(source["paths"][1:], parsed_sets[1:]):
+                        if parsed != actual:
+                            errors.append(
+                                f"{token_id}/{platform}: {path} differs from the first declared asset"
+                            )
+                elif kind == "kotlin_symbols":
+                    actual = parse_kotlin_symbols(source)
+                elif kind == "swift_theme_hex":
+                    actual = parse_swift_theme_hex(source)
+                elif kind == "token_alias":
+                    alias_id = source["token"]
+                    if alias_id not in token_index:
+                        raise CatalogError(f"Unknown alias target: {alias_id}")
+                    actual = token_index[alias_id]["platforms"][platform]["values"]
+                else:
+                    raise CatalogError(f"Unsupported source kind: {kind}")
+            except (CatalogError, KeyError) as error:
+                errors.append(f"{token_id}/{platform}: {error}")
+                continue
+
+            expected = platform_data["values"]
+            for mode_id in mode_ids:
+                if normalized_hex(actual[mode_id]) != normalized_hex(expected[mode_id]):
+                    errors.append(
+                        f"{token_id}/{platform}/{mode_id}: source is {actual[mode_id]}, "
+                        f"contract says {expected[mode_id]}"
+                    )
+
+    if errors:
+        raise CatalogError("Production source drift:\n- " + "\n- ".join(errors))
+
+
+def rgba(value: str) -> tuple[float, float, float, float]:
+    value = normalized_hex(value)[1:]
+    alpha = int(value[6:8], 16) / 255 if len(value) == 8 else 1.0
+    return (
+        int(value[0:2], 16) / 255,
+        int(value[2:4], 16) / 255,
+        int(value[4:6], 16) / 255,
+        alpha,
+    )
+
+
+def relative_luminance(value: str) -> float:
+    red, green, blue, alpha = rgba(value)
+    if alpha != 1:
+        raise CatalogError(f"Translucent colors require a rendered background: {value}")
+
+    def linearize(component: float) -> float:
+        return component / 12.92 if component <= 0.04045 else ((component + 0.055) / 1.055) ** 2.4
+
+    return 0.2126 * linearize(red) + 0.7152 * linearize(green) + 0.0722 * linearize(blue)
+
+
+def contrast_ratio(first: str, second: str) -> float:
+    lighter, darker = sorted(
+        (relative_luminance(first), relative_luminance(second)), reverse=True
+    )
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def source_label(source: dict[str, Any]) -> str:
+    kind = source["kind"]
+    if kind == "ios_assets":
+        return " · ".join(source["paths"])
+    if kind == "kotlin_symbols":
+        symbols = " / ".join(source["symbols"].values())
+        return f"{source['path']} · {symbols}"
+    if kind == "swift_theme_hex":
+        return f"{source['path']} · {source['property']}"
+    return f"alias → {source['token']} · {source['evidencePath']}"
+
+
+def evaluation_rows(
+    contract: dict[str, Any], token_index: dict[str, dict[str, Any]]
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for mode in contract["modes"]:
+        mode_id = mode["id"]
+        for pair in contract["pairs"]:
+            results: dict[str, dict[str, Any]] = {}
+            for platform in PLATFORMS:
+                foreground = token_index[pair["foreground"]]["platforms"][platform]["values"][mode_id]
+                background = token_index[pair["background"]]["platforms"][platform]["values"][mode_id]
+                ratio = contrast_ratio(foreground, background)
+                results[platform] = {
+                    "foreground": foreground,
+                    "background": background,
+                    "ratio": ratio,
+                    "passes": ratio >= pair["minimum"],
+                }
+            rows.append({"mode": mode, "pair": pair, "results": results})
+    return rows
+
+
+def validate_contrast_pairs(
+    contract: dict[str, Any], token_index: dict[str, dict[str, Any]]
+) -> None:
+    failures: list[str] = []
+    for row in evaluation_rows(contract, token_index):
+        for platform in PLATFORMS:
+            result = row["results"][platform]
+            if not result["passes"]:
+                failures.append(
+                    f"{row['mode']['id']}/{platform}/{row['pair']['id']}: "
+                    f"{result['ratio']:.6f}:1 < {row['pair']['minimum']:.1f}:1"
+                )
+    if failures:
+        raise CatalogError("WCAG contrast failures:\n- " + "\n- ".join(failures))
+
+
+def render_catalog(
+    contract: dict[str, Any],
+    token_index: dict[str, dict[str, Any]],
+) -> str:
+    canonical = json.dumps(contract, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:12]
+    evaluations = evaluation_rows(contract, token_index)
+    failed = [
+        (row, platform)
+        for row in evaluations
+        for platform in PLATFORMS
+        if not row["results"][platform]["passes"]
+    ]
+
+    mode_sections: list[str] = []
+    for mode in contract["modes"]:
+        mode_id = mode["id"]
+        token_rows: list[str] = []
+        for token in contract["tokens"]:
+            ios_value = token["platforms"]["ios"]["values"][mode_id]
+            android_value = token["platforms"]["android"]["values"][mode_id]
+            if ios_value == android_value:
+                values_markup = f"""
+                  <div class="value aligned">
+                    <span class="chip" style="--swatch:{ios_value}"></span>
+                    <span class="platforms">iOS · Android</span>
+                    <code>{ios_value}</code>
+                  </div>"""
+            else:
+                values_markup = "".join(
+                    f"""
+                    <div class="value">
+                      <span class="chip" style="--swatch:{platform_data['values'][mode_id]}"></span>
+                      <span class="platforms">{platform_label}</span>
+                      <code>{platform_data['values'][mode_id]}</code>
+                    </div>"""
+                    for platform_label, platform_data in (
+                        ("iOS", token["platforms"]["ios"]),
+                        ("Android", token["platforms"]["android"]),
+                    )
+                )
+            token_rows.append(
+                f"""
+                <article class="token-row">
+                  <div class="token-copy">
+                    <span class="category">{html.escape(token['category'])}</span>
+                    <strong>{html.escape(token['label'])}</strong>
+                    <code>{html.escape(token['id'])}</code>
+                  </div>
+                  <div class="token-values">{values_markup}</div>
+                </article>"""
+            )
+        mode_sections.append(
+            f"""
+            <section class="mode-card">
+              <header>
+                <div>
+                  <p>{html.escape(mode['contrast'])} contrast</p>
+                  <h3>{html.escape(mode['label'])}</h3>
+                </div>
+                <span class="mode-dot {html.escape(mode['appearance'])}" aria-hidden="true"></span>
+              </header>
+              <div class="token-list">{''.join(token_rows)}</div>
+            </section>"""
+        )
+
+    contrast_sections: list[str] = []
+    for mode in contract["modes"]:
+        rows = [row for row in evaluations if row["mode"]["id"] == mode["id"]]
+        table_rows: list[str] = []
+        for row in rows:
+            pair = row["pair"]
+            result_cells: list[str] = []
+            for platform in PLATFORMS:
+                result = row["results"][platform]
+                status = "pass" if result["passes"] else "fail"
+                status_text = "✓ PASS" if result["passes"] else "✕ FAIL"
+                result_cells.append(
+                    f"""
+                    <td>
+                      <div class="ratio-line">
+                        <span class="pair-chips" aria-hidden="true">
+                          <i style="--swatch:{result['foreground']}"></i>
+                          <i style="--swatch:{result['background']}"></i>
+                        </span>
+                        <strong>{result['ratio']:.2f}:1</strong>
+                        <span class="badge {status}">{status_text}</span>
+                      </div>
+                    </td>"""
+                )
+            table_rows.append(
+                f"""
+                <tr>
+                  <th scope="row">
+                    {html.escape(pair['label'])}
+                    <small>{html.escape(pair['kind'])} · mínimo {pair['minimum']:.1f}:1</small>
+                  </th>
+                  {''.join(result_cells).lstrip()}
+                </tr>"""
+            )
+        contrast_sections.append(
+            f"""
+            <details class="matrix-card" open>
+              <summary>{html.escape(mode['label'])}<span>{len(rows) * 2} comprobaciones</span></summary>
+              <div class="table-scroll">
+                <table>
+                  <thead><tr><th>Par semántico</th><th>iOS</th><th>Android</th></tr></thead>
+                  <tbody>{''.join(table_rows)}</tbody>
+                </table>
+              </div>
+            </details>"""
+        )
+
+    preview_cards: list[str] = []
+    for mode in contract["modes"]:
+        mode_id = mode["id"]
+        for platform in PLATFORMS:
+            values = {
+                token_id: token["platforms"][platform]["values"][mode_id]
+                for token_id, token in token_index.items()
+            }
+            preview_cards.append(
+                f"""
+                <article class="preview-card" style="
+                  --surface:{values['color-surface-primary-default']};
+                  --surface-secondary:{values['color-surface-secondary-default']};
+                  --text:{values['color-text-primary-default']};
+                  --text-secondary:{values['color-text-secondary-default']};
+                  --border:{values['color-border-subtle-default']};
+                  --action:{values['color-action-primary-default']};
+                  --on-action:{values['color-action-on-primary-default']};
+                  --control:{values['color-control-accent-default']};
+                  --warning:{values['color-feedback-warning-default']};
+                  --error:{values['color-feedback-error-default']};
+                ">
+                  <div class="preview-meta">
+                    <span>{html.escape(mode['label'])}</span>
+                    <strong>{platform}</strong>
+                  </div>
+                  <div class="app-preview">
+                    <p class="eyebrow">Pedido semanal</p>
+                    <h3>Semana 30</h3>
+                    <p class="secondary">Revisa las cantidades antes de confirmar.</p>
+                    <div class="mini-card">
+                      <span>Verduras y hortalizas</span><strong>18,40 €</strong>
+                    </div>
+                    <p class="feedback warning">▲ Quedan cambios pendientes</p>
+                    <p class="feedback error">● Hay un producto no disponible</p>
+                    <div class="control-row">
+                      <span>Pedido ecológico</span>
+                      <span class="toggle" role="img" aria-label="Control activado"><i></i></span>
+                    </div>
+                    <div class="primary-button">Confirmar pedido</div>
+                  </div>
+                </article>"""
+            )
+
+    provenance_rows = "".join(
+        f"""
+        <tr>
+          <th scope="row"><code>{html.escape(token['id'])}</code></th>
+          <td>{html.escape(source_label(token['platforms']['ios']['source']))}</td>
+          <td>{html.escape(source_label(token['platforms']['android']['source']))}</td>
+          <td><span class="parity {html.escape(token['parity']['status'])}">{html.escape(token['parity']['status'])}</span><br>{html.escape(token['parity']['note'])}</td>
+        </tr>"""
+        for token in contract["tokens"]
+    )
+
+    status_class = "pass" if not failed else "fail"
+    status_text = "Todas las parejas pasan" if not failed else f"{len(failed)} parejas fallan"
+    catalog = contract["catalog"]
+    css = """
+    :root {
+      color-scheme: light;
+      --ink: #182315;
+      --muted: #596654;
+      --canvas: #eef3e4;
+      --paper: #fbfdf6;
+      --line: #cbd5bd;
+      --brand: #3d681e;
+      --brand-soft: #dce9c8;
+      --danger: #8d3434;
+      --radius: 22px;
+      --shadow: 0 18px 55px rgba(33, 54, 25, .10);
+      font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    * { box-sizing: border-box; }
+    html { background: var(--canvas); color: var(--ink); }
+    body { margin: 0; }
+    code { font: 500 .78rem ui-monospace, SFMono-Regular, Menlo, monospace; overflow-wrap: anywhere; }
+    .shell { width: min(1440px, calc(100% - 32px)); margin: 0 auto; padding: 48px 0 96px; }
+    .hero { display: grid; grid-template-columns: 1.5fr .9fr; gap: 32px; align-items: end; padding: 48px; border: 1px solid var(--line); border-radius: 32px; background: var(--paper); box-shadow: var(--shadow); }
+    .kicker, .section-kicker, .category, .preview-meta, .mode-card header p { text-transform: uppercase; letter-spacing: .14em; font-size: .7rem; font-weight: 800; }
+    .kicker, .section-kicker { color: var(--brand); }
+    h1 { margin: 10px 0 12px; font-size: clamp(2.5rem, 7vw, 5.8rem); line-height: .92; letter-spacing: -.055em; }
+    .lede { max-width: 760px; margin: 0; color: var(--muted); font-size: 1.08rem; line-height: 1.65; }
+    .hero-meta { display: grid; gap: 10px; }
+    .meta-card { display: flex; justify-content: space-between; gap: 20px; padding: 14px 16px; border: 1px solid var(--line); border-radius: 14px; background: #fff; }
+    .meta-card span { color: var(--muted); }
+    .generated-note { margin: 18px 0 0; padding: 14px 18px; border-left: 4px solid var(--brand); background: var(--brand-soft); border-radius: 0 12px 12px 0; }
+    section.catalog-section { margin-top: 72px; }
+    .section-head { display: flex; align-items: end; justify-content: space-between; gap: 32px; margin-bottom: 22px; }
+    .section-head h2 { margin: 6px 0 0; font-size: clamp(1.8rem, 4vw, 3.3rem); letter-spacing: -.035em; }
+    .section-head p:last-child { max-width: 580px; color: var(--muted); line-height: 1.55; }
+    .mode-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 20px; }
+    .mode-card, .matrix-card, .preview-card, .provenance-card { border: 1px solid var(--line); border-radius: var(--radius); background: var(--paper); box-shadow: var(--shadow); overflow: hidden; }
+    .mode-card > header { display: flex; justify-content: space-between; align-items: center; padding: 22px 24px; border-bottom: 1px solid var(--line); }
+    .mode-card header p, .mode-card h3 { margin: 0; }
+    .mode-card h3 { margin-top: 5px; font-size: 1.35rem; }
+    .mode-dot { width: 44px; height: 44px; border-radius: 50%; border: 1px solid var(--line); box-shadow: inset 0 0 0 8px rgba(255,255,255,.15); }
+    .mode-dot.light { background: #f2f8e1; }
+    .mode-dot.dark { background: #0f1d0d; }
+    .token-list { display: grid; }
+    .token-row { display: grid; grid-template-columns: minmax(190px, 1fr) minmax(220px, 1.25fr); gap: 18px; padding: 16px 24px; border-top: 1px solid color-mix(in srgb, var(--line), transparent 30%); }
+    .token-row:first-child { border-top: 0; }
+    .token-copy { display: grid; align-content: center; gap: 3px; min-width: 0; }
+    .token-copy .category { color: var(--brand); }
+    .token-copy code { color: var(--muted); }
+    .token-values { display: grid; gap: 7px; }
+    .value { display: grid; grid-template-columns: 28px 68px 1fr; gap: 9px; align-items: center; }
+    .value.aligned { grid-template-columns: 28px 100px 1fr; }
+    .chip { width: 28px; height: 28px; border-radius: 8px; background: var(--swatch); border: 1px solid rgba(20,30,18,.18); box-shadow: inset 0 0 0 1px rgba(255,255,255,.15); }
+    .platforms { color: var(--muted); font-size: .76rem; font-weight: 750; }
+    .matrix-grid { display: grid; gap: 18px; }
+    .matrix-card summary { display: flex; justify-content: space-between; gap: 24px; padding: 20px 24px; cursor: pointer; font-weight: 800; }
+    .matrix-card summary span { color: var(--muted); font-weight: 500; }
+    .table-scroll { overflow-x: auto; border-top: 1px solid var(--line); }
+    table { width: 100%; border-collapse: collapse; min-width: 760px; }
+    th, td { padding: 14px 18px; text-align: left; border-bottom: 1px solid var(--line); vertical-align: middle; }
+    thead th { background: #eef3e5; color: var(--muted); font-size: .72rem; text-transform: uppercase; letter-spacing: .1em; }
+    tbody tr:last-child > * { border-bottom: 0; }
+    tbody th { width: 42%; }
+    tbody th small { display: block; margin-top: 4px; color: var(--muted); font-weight: 500; }
+    .ratio-line { display: flex; align-items: center; gap: 10px; white-space: nowrap; }
+    .pair-chips { display: inline-flex; }
+    .pair-chips i { width: 17px; height: 28px; background: var(--swatch); border: 1px solid rgba(0,0,0,.16); }
+    .pair-chips i:first-child { border-radius: 7px 0 0 7px; }
+    .pair-chips i:last-child { border-radius: 0 7px 7px 0; }
+    .badge { padding: 4px 7px; border-radius: 999px; font-size: .67rem; font-weight: 900; letter-spacing: .04em; }
+    .badge.pass { background: #d9edc5; color: #315815; }
+    .badge.fail { background: #f7d4d4; color: #742222; }
+    .preview-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 18px; }
+    .preview-meta { display: flex; justify-content: space-between; gap: 12px; padding: 13px 16px; border-bottom: 1px solid var(--line); color: var(--muted); }
+    .preview-meta strong { color: var(--brand); text-transform: uppercase; }
+    .app-preview { min-height: 425px; padding: 22px; background: var(--surface); color: var(--text); }
+    .app-preview .eyebrow { margin: 0; color: var(--action); font-size: .74rem; font-weight: 900; letter-spacing: .1em; text-transform: uppercase; }
+    .app-preview h3 { margin: 7px 0; font-size: 1.8rem; }
+    .app-preview .secondary { min-height: 42px; color: var(--text-secondary); line-height: 1.45; }
+    .mini-card { display: flex; justify-content: space-between; gap: 14px; margin: 18px 0; padding: 15px; border: 1px solid var(--border); border-radius: 14px; background: var(--surface-secondary); }
+    .feedback { font-size: .82rem; font-weight: 800; }
+    .feedback.warning { color: var(--warning); }
+    .feedback.error { color: var(--error); }
+    .control-row { display: flex; align-items: center; justify-content: space-between; margin: 22px 0; font-weight: 750; }
+    .toggle { width: 50px; height: 30px; padding: 3px; border-radius: 99px; background: var(--control); }
+    .toggle i { display: block; width: 24px; height: 24px; margin-left: auto; border-radius: 50%; background: var(--surface); }
+    .primary-button { padding: 13px 16px; border-radius: 14px; background: var(--action); color: var(--on-action); text-align: center; font-weight: 900; }
+    .provenance-card { overflow-x: auto; }
+    .provenance-card table { min-width: 1100px; }
+    .provenance-card tbody th { width: 20%; }
+    .provenance-card td { color: var(--muted); font-size: .82rem; line-height: 1.45; }
+    .parity { display: inline-block; margin-bottom: 4px; color: var(--ink); font-weight: 900; }
+    .parity.platform-native { color: #6d2b00; }
+    .checklist { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; padding: 0; list-style: none; }
+    .checklist li { position: relative; padding: 18px 18px 18px 48px; border: 1px solid var(--line); border-radius: 16px; background: var(--paper); line-height: 1.45; }
+    .checklist li::before { content: "✓"; position: absolute; left: 18px; top: 18px; width: 20px; height: 20px; border-radius: 50%; background: var(--brand); color: white; text-align: center; line-height: 20px; font-size: .72rem; font-weight: 900; }
+    footer { margin-top: 72px; padding-top: 24px; border-top: 1px solid var(--line); color: var(--muted); display: flex; justify-content: space-between; gap: 24px; }
+    @media (max-width: 1100px) {
+      .preview-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .checklist { grid-template-columns: repeat(2, 1fr); }
+    }
+    @media (max-width: 820px) {
+      .shell { width: min(100% - 20px, 720px); padding-top: 10px; }
+      .hero { grid-template-columns: 1fr; padding: 28px; }
+      .mode-grid, .preview-grid { grid-template-columns: 1fr; }
+      .section-head { display: block; }
+      .token-row { grid-template-columns: 1fr; }
+      .checklist { grid-template-columns: 1fr; }
+      footer { display: block; }
+    }
+    @media print {
+      .shell { width: 100%; padding: 0; }
+      .hero, .mode-card, .matrix-card, .preview-card, .provenance-card { box-shadow: none; break-inside: avoid; }
+    }
+    """
+
+    return f"""<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="generator" content="Reguerta color catalog {GENERATOR_VERSION}">
+  <meta name="contract-digest" content="{digest}">
+  <title>{html.escape(catalog['title'])}</title>
+  <style>{css}</style>
+</head>
+<body>
+  <main class="shell">
+    <header class="hero">
+      <div>
+        <p class="kicker">Design System · Color</p>
+        <h1>{html.escape(catalog['title'])}</h1>
+        <p class="lede">{html.escape(catalog['subtitle'])}. Paleta efectiva por plataforma, contraste WCAG {html.escape(catalog['wcagVersion'])} calculado y componentes en contexto.</p>
+        <p class="generated-note"><strong>Artefacto generado.</strong> No editar este HTML. Cambia <code>color-tokens.json</code> y ejecuta el generador.</p>
+      </div>
+      <div class="hero-meta">
+        <div class="meta-card"><span>Estado</span><strong>{html.escape(catalog['status'])}</strong></div>
+        <div class="meta-card"><span>Revisión</span><strong>{html.escape(catalog['lastReviewed'])}</strong></div>
+        <div class="meta-card"><span>Contrato</span><strong>{len(contract['tokens'])} tokens · {digest}</strong></div>
+        <div class="meta-card"><span>WCAG</span><strong class="{status_class}">{html.escape(status_text)}</strong></div>
+      </div>
+    </header>
+
+    <section class="catalog-section" aria-labelledby="palette-title">
+      <div class="section-head">
+        <div><p class="section-kicker">01 — Palette</p><h2 id="palette-title">Paleta por modo</h2></div>
+        <p>Un solo nombre semántico, con el valor realmente resuelto por iOS y Android. Las diferencias nativas aparecen separadas, nunca ocultas.</p>
+      </div>
+      <div class="mode-grid">{''.join(mode_sections)}</div>
+    </section>
+
+    <section class="catalog-section" aria-labelledby="contrast-title">
+      <div class="section-head">
+        <div><p class="section-kicker">02 — WCAG 2.2</p><h2 id="contrast-title">Matriz de contraste</h2></div>
+        <p>La decisión PASS/FAIL usa el ratio completo. El valor visible se redondea únicamente para lectura.</p>
+      </div>
+      <div class="matrix-grid">{''.join(contrast_sections)}</div>
+    </section>
+
+    <section class="catalog-section" aria-labelledby="preview-title">
+      <div class="section-head">
+        <div><p class="section-kicker">03 — Context</p><h2 id="preview-title">Componentes en contexto</h2></div>
+        <p>Ejemplos documentales para detectar combinaciones inesperadas. No sustituyen las previews ni las pruebas de cada plataforma.</p>
+      </div>
+      <div class="preview-grid">{''.join(preview_cards)}</div>
+    </section>
+
+    <section class="catalog-section" aria-labelledby="source-title">
+      <div class="section-head">
+        <div><p class="section-kicker">04 — Sources</p><h2 id="source-title">Procedencia y paridad</h2></div>
+        <p>El generador contrasta el contrato con estas fuentes de producción antes de escribir o verificar el catálogo.</p>
+      </div>
+      <div class="provenance-card">
+        <table>
+          <thead><tr><th>Token</th><th>iOS</th><th>Android</th><th>Paridad</th></tr></thead>
+          <tbody>{provenance_rows}</tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="catalog-section" aria-labelledby="rules-title">
+      <div class="section-head">
+        <div><p class="section-kicker">05 — Contract</p><h2 id="rules-title">Reglas de uso</h2></div>
+      </div>
+      <ul class="checklist">
+        <li>Texto normal esencial: mínimo <strong>4.5:1</strong>.</li>
+        <li>Controles e indicadores esenciales: mínimo <strong>3:1</strong>.</li>
+        <li>Estados pressed se validan tras aplicar el state layer del <strong>12 %</strong>.</li>
+        <li>Glass usa backing explícito y tint máximo del <strong>16 %</strong>.</li>
+        <li>FAB y barras de total emplean contenedores opacos.</li>
+        <li>Color nunca es la única señal de estado o selección.</li>
+      </ul>
+    </section>
+
+    <footer>
+      <span>Issue #212 · WCAG {html.escape(catalog['wcagVersion'])}</span>
+      <span>Generator {GENERATOR_VERSION} · contract {digest}</span>
+    </footer>
+  </main>
+</body>
+</html>
+"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify production sources and fail when the generated HTML is stale.",
+    )
+    args = parser.parse_args()
+
+    try:
+        contract = load_contract()
+        mode_ids, token_index = validate_contract(contract)
+        validate_production_sources(contract, mode_ids, token_index)
+        validate_contrast_pairs(contract, token_index)
+        rendered = render_catalog(contract, token_index)
+    except CatalogError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    if args.check:
+        if not OUTPUT_PATH.exists():
+            print(
+                f"error: missing generated catalog {OUTPUT_PATH.relative_to(REPO_ROOT)}; "
+                "run scripts/design-system/generate_color_catalog.py",
+                file=sys.stderr,
+            )
+            return 1
+        current = OUTPUT_PATH.read_text(encoding="utf-8")
+        if current != rendered:
+            print(
+                f"error: stale generated catalog {OUTPUT_PATH.relative_to(REPO_ROOT)}; "
+                "run scripts/design-system/generate_color_catalog.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"OK: {len(contract['tokens'])} tokens, {len(contract['pairs'])} pairs, "
+            f"{len(contract['modes'])} modes, production sources and HTML are in sync."
+        )
+        return 0
+
+    OUTPUT_PATH.write_text(rendered, encoding="utf-8")
+    print(f"Generated {OUTPUT_PATH.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/design-system/test_generate_color_catalog.py
+++ b/scripts/design-system/test_generate_color_catalog.py
@@ -1,0 +1,54 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("generate_color_catalog.py")
+SPEC = importlib.util.spec_from_file_location("generate_color_catalog", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+catalog = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(catalog)
+
+
+class ColorCatalogTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = catalog.load_contract()
+        cls.mode_ids, cls.token_index = catalog.validate_contract(cls.contract)
+
+    def test_contract_matches_production_sources(self) -> None:
+        catalog.validate_production_sources(
+            self.contract,
+            self.mode_ids,
+            self.token_index,
+        )
+
+    def test_all_declared_pairs_meet_their_unrounded_threshold(self) -> None:
+        catalog.validate_contrast_pairs(self.contract, self.token_index)
+        borderline = catalog.contrast_ratio("#777777", "#FFFFFF")
+        self.assertLess(borderline, 4.5)
+        self.assertEqual(f"{borderline:.2f}", "4.48")
+
+    def test_wcag_reference_black_and_white_ratio_is_twenty_one(self) -> None:
+        self.assertAlmostEqual(catalog.contrast_ratio("#000000", "#FFFFFF"), 21.0)
+
+    def test_ios_asset_parser_reads_increased_contrast_variants(self) -> None:
+        values = catalog.parse_ios_asset(
+            "ios/Reguerta/Reguerta/Resources/Assets.xcassets/Colors/"
+            "actionPrimary.colorset/Contents.json"
+        )
+        self.assertEqual(values["highContrastLight"], "#315815")
+        self.assertEqual(values["highContrastDark"], "#A8DD75")
+
+    def test_render_is_deterministic_self_contained_and_current(self) -> None:
+        first = catalog.render_catalog(self.contract, self.token_index)
+        second = catalog.render_catalog(self.contract, self.token_index)
+        self.assertEqual(first, second)
+        self.assertNotIn("<script src=", first)
+        self.assertNotIn("<link rel=", first)
+        self.assertIn("@media (max-width: 820px)", first)
+        self.assertEqual(catalog.OUTPUT_PATH.read_text(encoding="utf-8"), first)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Resumen

- añade `docs/design-system/color-tokens.json` como contrato semántico cross-platform verificable
- genera un catálogo HTML autocontenido con cuatro modos, previews iOS/Android y matriz WCAG
- comprueba deriva contra Assets y Swift de iOS, y contra los tokens Kotlin de Android
- documenta autoridad, regeneración y gobernanza en EN/ES

## Validación

- `python3 -m unittest discover -s scripts/design-system -p 'test_*.py' -v` — 5/5 tests
- `python3 scripts/design-system/generate_color_catalog.py --check` — 12 tokens, 11 pares y 4 modos sincronizados
- `git diff --check` — limpio
- revisión visual del HTML confirmada por el propietario

No se ejecutaron builds móviles porque el cambio solo afecta documentación y herramientas de verificación; no modifica código de las apps.

Closes #212
