### PR TITLE
🐛 fix(auth): bound session operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-28 | 🐛 fix(android-auth): preserve cleanup quarantine
 - 2026-07-28 | 🐛 fix(auth): bound session operations
 - 2026-07-28 | 🐛 fix(android-auth): shorten credential lifetime
 - 2026-07-28 | 🐛 fix(security): harden device credential storage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-28 | 🐛 fix(auth): bound session operations
 - 2026-07-28 | 🐛 fix(android-auth): shorten credential lifetime
 - 2026-07-28 | 🐛 fix(security): harden device credential storage
 - 2026-07-28 | 🐛 fix(app): harden startup and freshness gates

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/data/access/FirebaseAuthSessionProvider.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/data/access/FirebaseAuthSessionProvider.kt
@@ -13,7 +13,10 @@ import com.reguerta.user.domain.access.AuthSessionRefreshResult
 import com.reguerta.user.domain.access.AuthSessionProvider
 import com.reguerta.user.domain.access.AuthSignInFailureReason
 import com.reguerta.user.domain.access.AuthSignInResult
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 
 class FirebaseAuthSessionProvider internal constructor(
@@ -23,21 +26,31 @@ class FirebaseAuthSessionProvider internal constructor(
 
     override suspend fun signIn(email: String, password: String): AuthSignInResult = withContext(Dispatchers.IO) {
         val trimmedEmail = email.trim()
+        var authenticationMutated = false
         return@withContext try {
             gateway.signIn(trimmedEmail, password)
+            authenticationMutated = true
+            currentCoroutineContext().ensureActive()
             val user = gateway.reloadCurrentUser()
-                ?: return@withContext AuthSignInResult.Failure(AuthSignInFailureReason.UNKNOWN)
-            if (!user.emailVerified) {
-                try {
-                    gateway.sendCurrentUserVerificationEmail()
-                    return@withContext AuthSignInResult.Failure(
-                        AuthSignInFailureReason.EMAIL_NOT_VERIFIED,
-                    )
-                } finally {
-                    gateway.signOut()
+            currentCoroutineContext().ensureActive()
+            if (user == null) {
+                if (!gateway.signOutBestEffort()) {
+                    throw FirebaseAuthCleanupNotConfirmedException()
                 }
+                return@withContext AuthSignInResult.Failure(AuthSignInFailureReason.UNKNOWN)
+            }
+            if (!user.emailVerified) {
+                gateway.sendCurrentUserVerificationEmail()
+                currentCoroutineContext().ensureActive()
+                if (!gateway.signOutBestEffort()) {
+                    throw FirebaseAuthCleanupNotConfirmedException()
+                }
+                return@withContext AuthSignInResult.Failure(
+                    AuthSignInFailureReason.EMAIL_NOT_VERIFIED,
+                )
             }
             gateway.refreshCurrentUserToken(forceRefresh = true)
+            currentCoroutineContext().ensureActive()
 
             AuthSignInResult.Success(
                 principal = AuthPrincipal(
@@ -45,23 +58,47 @@ class FirebaseAuthSessionProvider internal constructor(
                     email = (user.email ?: trimmedEmail).trim().lowercase(),
                 ),
             )
+        } catch (exception: CancellationException) {
+            if (!gateway.signOutBestEffort()) {
+                throw FirebaseAuthCleanupNotConfirmedException(exception)
+            }
+            throw exception
         } catch (exception: Exception) {
+            if (authenticationMutated && !gateway.signOutBestEffort()) {
+                throw FirebaseAuthCleanupNotConfirmedException(exception)
+            }
             AuthSignInResult.Failure(exception.toFailureReason())
         }
     }
 
     override suspend fun signUp(email: String, password: String): AuthSignInResult = withContext(Dispatchers.IO) {
         val trimmedEmail = email.trim()
+        var authenticationMutated = false
         return@withContext try {
-            gateway.signUp(trimmedEmail, password)
-                ?: return@withContext AuthSignInResult.Failure(AuthSignInFailureReason.UNKNOWN)
-            try {
-                gateway.sendCurrentUserVerificationEmail()
-                AuthSignInResult.Failure(AuthSignInFailureReason.EMAIL_NOT_VERIFIED)
-            } finally {
-                gateway.signOut()
+            val user = gateway.signUp(trimmedEmail, password)
+            authenticationMutated = true
+            currentCoroutineContext().ensureActive()
+            if (user == null) {
+                if (!gateway.signOutBestEffort()) {
+                    throw FirebaseAuthCleanupNotConfirmedException()
+                }
+                return@withContext AuthSignInResult.Failure(AuthSignInFailureReason.UNKNOWN)
             }
+            gateway.sendCurrentUserVerificationEmail()
+            currentCoroutineContext().ensureActive()
+            if (!gateway.signOutBestEffort()) {
+                throw FirebaseAuthCleanupNotConfirmedException()
+            }
+            AuthSignInResult.Failure(AuthSignInFailureReason.EMAIL_NOT_VERIFIED)
+        } catch (exception: CancellationException) {
+            if (!gateway.signOutBestEffort()) {
+                throw FirebaseAuthCleanupNotConfirmedException(exception)
+            }
+            throw exception
         } catch (exception: Exception) {
+            if (authenticationMutated && !gateway.signOutBestEffort()) {
+                throw FirebaseAuthCleanupNotConfirmedException(exception)
+            }
             AuthSignInResult.Failure(exception.toFailureReason())
         }
     }
@@ -82,11 +119,20 @@ class FirebaseAuthSessionProvider internal constructor(
             uid = user.uid,
             email = (user.email ?: "").trim().lowercase(),
         )
+        var reloadCompleted = false
 
         return@withContext try {
             val refreshedUser = gateway.reloadCurrentUser()
-                ?: return@withContext AuthSessionRefreshResult.Expired
+            reloadCompleted = true
+            currentCoroutineContext().ensureActive()
+            if (refreshedUser == null) {
+                if (!gateway.signOutBestEffort()) {
+                    throw FirebaseAuthCleanupNotConfirmedException()
+                }
+                return@withContext AuthSessionRefreshResult.Expired
+            }
             gateway.refreshCurrentUserToken(forceRefresh = refreshedUser.emailVerified)
+            currentCoroutineContext().ensureActive()
 
             AuthSessionRefreshResult.Active(
                 principal = AuthPrincipal(
@@ -94,13 +140,26 @@ class FirebaseAuthSessionProvider internal constructor(
                     email = (refreshedUser.email ?: fallbackPrincipal.email).trim().lowercase(),
                 ),
             )
+        } catch (exception: CancellationException) {
+            if (!gateway.signOutBestEffort()) {
+                throw FirebaseAuthCleanupNotConfirmedException(exception)
+            }
+            throw exception
         } catch (exception: Exception) {
+            if (reloadCompleted) {
+                if (!gateway.signOutBestEffort()) {
+                    throw FirebaseAuthCleanupNotConfirmedException(exception)
+                }
+                throw exception
+            }
             when (exception.toFailureReason()) {
                 AuthSignInFailureReason.USER_DISABLED,
                 AuthSignInFailureReason.USER_NOT_FOUND,
                 AuthSignInFailureReason.INVALID_CREDENTIALS,
                     -> {
-                        gateway.signOut()
+                        if (!gateway.signOutBestEffort()) {
+                            throw FirebaseAuthCleanupNotConfirmedException(exception)
+                        }
                         AuthSessionRefreshResult.Expired
                     }
 
@@ -120,6 +179,19 @@ class FirebaseAuthSessionProvider internal constructor(
         gateway.signOut()
     }
 }
+
+internal class FirebaseAuthCleanupNotConfirmedException(
+    cause: Throwable? = null,
+) : IllegalStateException("Firebase Auth cleanup could not be confirmed", cause)
+
+private fun FirebaseAuthGateway.signOutBestEffort(): Boolean =
+    try {
+        signOut()
+        true
+    } catch (_: Exception) {
+        // Presentation remains fail-closed even if Firebase cannot confirm local sign-out.
+        false
+    }
 
 internal data class FirebaseAuthUserSnapshot(
     val uid: String,

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/auth/SessionAuthActions.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/auth/SessionAuthActions.kt
@@ -558,16 +558,9 @@ internal class SessionAuthActions(
                 publishDrainingSessionOperationError(kind)
                 return false
             }
-            if (kind in INTERACTIVE_SESSION_OPERATION_KINDS && sessionOperationJob != null) {
-                return false
-            }
-            val refreshWouldSupersedeInteractive =
-                sessionOperationKind in INTERACTIVE_SESSION_OPERATION_KINDS
-            val refreshWasCapturedBeforeCleanup =
-                sessionOperationKind == SessionAuthOperationKind.CLEANUP && expectedPrincipalUid != null
             if (
-                kind == SessionAuthOperationKind.REFRESH &&
-                (refreshWouldSupersedeInteractive || refreshWasCapturedBeforeCleanup)
+                sessionOperationJob != null &&
+                (kind in INTERACTIVE_SESSION_OPERATION_KINDS || kind == SessionAuthOperationKind.REFRESH)
             ) {
                 return false
             }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/auth/SessionAuthActions.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/auth/SessionAuthActions.kt
@@ -39,18 +39,23 @@ import com.reguerta.user.domain.notifications.NotificationRepository
 import com.reguerta.user.domain.products.ProductRepository
 import com.reguerta.user.domain.profiles.SharedProfileRepository
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 import java.util.UUID
+
+internal const val SESSION_AUTH_OPERATION_TIMEOUT_MILLIS = 30_000L
 
 internal class SessionAuthActions(
     private val uiState: MutableStateFlow<SessionUiState>,
@@ -73,7 +78,14 @@ internal class SessionAuthActions(
     private val nowMillisProvider: () -> Long,
     private val refreshShifts: () -> Unit,
     private val refreshDeliveryCalendar: () -> Unit,
+    private val sessionOperationTimeoutMillis: Long = SESSION_AUTH_OPERATION_TIMEOUT_MILLIS,
 ) {
+    init {
+        require(sessionOperationTimeoutMillis > 0L) {
+            "Session operation timeout must be positive"
+        }
+    }
+
     private val sessionOperationLock = Any()
     private var sessionOperationGeneration = 0L
     private var sessionOperationOwner: Any? = null
@@ -305,12 +317,12 @@ internal class SessionAuthActions(
     fun signOut() {
         cancelMyOrderFreshness()
         val cleanupJob = ownSessionTerminationCleanup {
-            clearAuthorizedDeviceSession()
-            criticalDataFreshnessLocalRepository.clear()
+            val authenticationAndRoutingClosed = closeAuthenticationAndRoutingSafely()
+            val privateContextClosed = clearPrivateSessionContext()
+            authenticationAndRoutingClosed && privateContextClosed
         }
-        authSessionProvider.signOut()
+        closeAuthenticationAndRoutingSafely()
         clearSessionRefreshTracking()
-        sessionEnvironmentRouter.resetToBaseEnvironment()
         uiState.update { state -> state.toSignedOutSessionState(showSessionExpiredDialog = false) }
         cleanupJob.start()
     }
@@ -337,6 +349,7 @@ internal class SessionAuthActions(
             kind = SessionAuthOperationKind.REFRESH,
             expectedPrincipalUid = expectedPrincipalUid,
         ) { operation ->
+            var completedSuccessfully = false
             try {
                 operation.providerWasInvoked.set(true)
                 val result = authSessionProvider.refreshCurrentSession()
@@ -356,7 +369,6 @@ internal class SessionAuthActions(
                             operation.expectedPrincipalUid != null &&
                             result.principal.uid != operation.expectedPrincipalUid
                         ) {
-                            closeStaleFirebaseAuthentication(operation)
                             handleExpiredSession(operation)
                             return@launchSessionOperation
                         }
@@ -382,8 +394,12 @@ internal class SessionAuthActions(
                         handleExpiredSession(operation)
                     }
                 }
+                completedSuccessfully = true
             } finally {
-                finishRefreshIfCurrent(operation)
+                finishRefreshIfCurrent(
+                    operation = operation,
+                    completedSuccessfully = completedSuccessfully,
+                )
             }
         }
         if (!didLaunch) {
@@ -538,6 +554,13 @@ internal class SessionAuthActions(
         lateinit var operation: SessionAuthOperation
         lateinit var job: Job
         synchronized(sessionOperationLock) {
+            if (sessionOperationKind == SessionAuthOperationKind.DRAINING) {
+                publishDrainingSessionOperationError(kind)
+                return false
+            }
+            if (kind in INTERACTIVE_SESSION_OPERATION_KINDS && sessionOperationJob != null) {
+                return false
+            }
             val refreshWouldSupersedeInteractive =
                 sessionOperationKind in INTERACTIVE_SESSION_OPERATION_KINDS
             val refreshWasCapturedBeforeCleanup =
@@ -567,24 +590,36 @@ internal class SessionAuthActions(
                         predecessor?.join()
                     }
                     if (!isCurrentSessionOperation(operation)) return@launch
+                    startSessionOperationDeadline(operation, job)
                     block(operation)
-                } catch (error: Exception) {
-                    if (
-                        operation.providerWasInvoked.get() &&
-                        !isCurrentSessionOperation(operation) &&
-                        !operation.terminalSessionApplied.get()
-                    ) {
-                        closeStaleFirebaseAuthentication(operation)
-                        return@launch
+                    claimSessionOperationResult(operation)
+                } catch (_: CancellationException) {
+                    // Cancellation from a successor or the deadline is stale by definition.
+                    // Definitive cleanup runs below without publishing from the cancelled owner.
+                } catch (_: Exception) {
+                    if (isCurrentSessionOperation(operation)) {
+                        recoverCurrentSessionOperation(operation, job)
                     }
-                    throw error
                 } finally {
+                    if (!operation.deadlineTriggered.get()) {
+                        operation.deadlineJob.getAndSet(null)?.cancel()
+                    }
+                    if (operation.deadlineClaim.outcome == SessionOperationDeadlineOutcome.DRAINING) {
+                        withContext(NonCancellable) {
+                            operation.drainCleanupCompleted.await()
+                        }
+                    }
+                    if (!operation.providerWasInvoked.get()) {
+                        operation.definitiveCleanupConfirmed.set(true)
+                    }
                     if (
                         operation.providerWasInvoked.get() &&
                         !isCurrentSessionOperation(operation) &&
                         !operation.terminalSessionApplied.get()
                     ) {
-                        closeStaleFirebaseAuthentication(operation)
+                        withContext(NonCancellable) {
+                            closeStaleFirebaseAuthentication(operation)
+                        }
                     }
                 }
             }
@@ -600,8 +635,150 @@ internal class SessionAuthActions(
         return true
     }
 
-    private fun ownSessionTerminationCleanup(block: suspend () -> Unit): Job {
+    private fun startSessionOperationDeadline(
+        operation: SessionAuthOperation,
+        operationJob: Job,
+    ) {
+        val deadlineJob = scope.launch {
+            delay(sessionOperationTimeoutMillis)
+            handleSessionOperationDeadline(operation, operationJob)
+        }
+        operation.deadlineJob.set(deadlineJob)
+    }
+
+    private fun claimSessionOperationResult(operation: SessionAuthOperation) {
+        synchronized(sessionOperationLock) {
+            operation.deadlineClaim.claimResult()
+        }
+    }
+
+    private suspend fun handleSessionOperationDeadline(
+        operation: SessionAuthOperation,
+        operationJob: Job,
+    ) {
+        val drainingOperation = synchronized(sessionOperationLock) {
+            val activeKind = sessionOperationKind
+            val activeJob = sessionOperationJob
+            if (
+                operationJob.isCompleted ||
+                activeKind == null ||
+                activeKind !in ACTIVE_SESSION_OPERATION_KINDS ||
+                activeJob !== operationJob ||
+                sessionOperationGeneration != operation.generation ||
+                sessionOperationOwner !== operation.owner ||
+                !operation.deadlineClaim.claimDraining()
+            ) {
+                null
+            } else {
+                operation.deadlineTriggered.set(true)
+                sessionOperationGeneration += 1
+                sessionOperationOwner = null
+                sessionOperationKind = SessionAuthOperationKind.DRAINING
+                isSessionRefreshInFlight.set(false)
+                SessionOperationDrain(
+                    kind = checkNotNull(activeKind),
+                    laneJob = activeJob,
+                )
+            }
+        } ?: return
+
+        recoverSessionUi(drainingOperation.kind)
+        drainingOperation.laneJob.cancel(
+            CancellationException("Session operation exceeded its UI deadline"),
+        )
+        performPreliminarySessionCleanup(operation)
+    }
+
+    private suspend fun recoverCurrentSessionOperation(
+        operation: SessionAuthOperation,
+        operationJob: Job,
+    ) {
+        val didBeginDraining = synchronized(sessionOperationLock) {
+            if (
+                sessionOperationGeneration != operation.generation ||
+                sessionOperationOwner !== operation.owner ||
+                sessionOperationJob !== operationJob ||
+                !operation.deadlineClaim.claimDraining()
+            ) {
+                false
+            } else {
+                sessionOperationGeneration += 1
+                sessionOperationOwner = null
+                sessionOperationKind = SessionAuthOperationKind.DRAINING
+                isSessionRefreshInFlight.set(false)
+                true
+            }
+        }
+        if (!didBeginDraining) return
+
+        recoverSessionUi(operation.kind)
+        performPreliminarySessionCleanup(operation)
+    }
+
+    private fun recoverSessionUi(kind: SessionAuthOperationKind) {
+        cancelMyOrderFreshness()
+        clearSessionRefreshTracking()
+        uiState.update { state ->
+            val knownEmail = (state.mode as? SessionMode.Authorized)
+                ?.principal
+                ?.email
+                ?.takeIf(String::isNotBlank)
+                ?: state.emailInput
+            val registrationEmail = state.registerEmailInput
+            state.toSignedOutSessionState(showSessionExpiredDialog = false).copy(
+                emailInput = knownEmail,
+                emailErrorRes = if (kind == SessionAuthOperationKind.SIGN_UP) {
+                    null
+                } else {
+                    R.string.auth_error_unknown
+                },
+                registerEmailInput = if (kind == SessionAuthOperationKind.SIGN_UP) {
+                    registrationEmail
+                } else {
+                    ""
+                },
+                registerEmailErrorRes = if (kind == SessionAuthOperationKind.SIGN_UP) {
+                    R.string.auth_error_register_generic
+                } else {
+                    null
+                },
+            )
+        }
+    }
+
+    private fun publishDrainingSessionOperationError(kind: SessionAuthOperationKind) {
+        uiState.update { state ->
+            when (kind) {
+                SessionAuthOperationKind.SIGN_IN -> state.copy(
+                    emailErrorRes = R.string.auth_error_unknown,
+                )
+
+                SessionAuthOperationKind.SIGN_UP -> state.copy(
+                    registerEmailErrorRes = R.string.auth_error_register_generic,
+                )
+
+                SessionAuthOperationKind.REFRESH,
+                SessionAuthOperationKind.DRAINING,
+                SessionAuthOperationKind.CLEANUP,
+                    -> state
+            }
+        }
+    }
+
+    private suspend fun performPreliminarySessionCleanup(operation: SessionAuthOperation) {
+        try {
+            withContext(NonCancellable) {
+                closeAuthenticationAndRoutingSafely()
+                clearPrivateSessionContext()
+            }
+        } finally {
+            operation.drainCleanupCompleted.complete(Unit)
+        }
+    }
+
+    private fun ownSessionTerminationCleanup(block: suspend () -> Boolean): Job {
         lateinit var cleanupJob: Job
+        val cleanupConfirmed = AtomicBoolean(false)
         synchronized(sessionOperationLock) {
             val predecessor = sessionOperationJob
             if (sessionOperationKind != SessionAuthOperationKind.CLEANUP) {
@@ -613,8 +790,8 @@ internal class SessionAuthActions(
             cleanupJob = scope.launch(start = CoroutineStart.LAZY) {
                 withContext(NonCancellable) {
                     predecessor?.join()
+                    cleanupConfirmed.set(block())
                 }
-                block()
             }
             sessionOperationJob = cleanupJob
             sessionOperationKind = SessionAuthOperationKind.CLEANUP
@@ -622,8 +799,12 @@ internal class SessionAuthActions(
         cleanupJob.invokeOnCompletion {
             synchronized(sessionOperationLock) {
                 if (sessionOperationJob === cleanupJob) {
-                    sessionOperationJob = null
-                    sessionOperationKind = null
+                    if (cleanupConfirmed.get()) {
+                        sessionOperationJob = null
+                        sessionOperationKind = null
+                    } else {
+                        sessionOperationKind = SessionAuthOperationKind.DRAINING
+                    }
                 }
             }
         }
@@ -632,7 +813,10 @@ internal class SessionAuthActions(
 
     private fun releaseSessionOperation(operation: SessionAuthOperation, job: Job) {
         synchronized(sessionOperationLock) {
-            if (sessionOperationJob === job) {
+            val mustRemainQuarantined =
+                sessionOperationKind == SessionAuthOperationKind.DRAINING &&
+                    !operation.definitiveCleanupConfirmed.get()
+            if (sessionOperationJob === job && !mustRemainQuarantined) {
                 sessionOperationJob = null
                 sessionOperationKind = null
             }
@@ -666,7 +850,10 @@ internal class SessionAuthActions(
         }
     }
 
-    private fun invalidateSessionOperationIfCurrent(operation: SessionAuthOperation): Boolean =
+    private fun completeTerminalSessionOperationIfCurrent(
+        operation: SessionAuthOperation,
+        cleanupConfirmed: Boolean,
+    ): Boolean =
         synchronized(sessionOperationLock) {
             if (
                 sessionOperationGeneration != operation.generation ||
@@ -675,9 +862,15 @@ internal class SessionAuthActions(
                 false
             } else {
                 operation.terminalSessionApplied.set(true)
+                operation.definitiveCleanupConfirmed.set(cleanupConfirmed)
                 sessionOperationGeneration += 1
                 sessionOperationOwner = null
                 isSessionRefreshInFlight.set(false)
+                if (!cleanupConfirmed) {
+                    operation.deadlineClaim.claimDraining()
+                    operation.drainCleanupCompleted.complete(Unit)
+                    sessionOperationKind = SessionAuthOperationKind.DRAINING
+                }
                 true
             }
         }
@@ -692,13 +885,18 @@ internal class SessionAuthActions(
         return isCurrentSessionOperation(operation)
     }
 
-    private fun finishRefreshIfCurrent(operation: SessionAuthOperation) {
+    private fun finishRefreshIfCurrent(
+        operation: SessionAuthOperation,
+        completedSuccessfully: Boolean,
+    ) {
         synchronized(sessionOperationLock) {
             if (
                 sessionOperationGeneration == operation.generation &&
                 sessionOperationOwner === operation.owner
             ) {
-                setLastSessionRefreshAtMillis(nowMillisProvider())
+                if (completedSuccessfully) {
+                    setLastSessionRefreshAtMillis(nowMillisProvider())
+                }
                 isSessionRefreshInFlight.set(false)
             }
         }
@@ -709,11 +907,92 @@ internal class SessionAuthActions(
     }
 
     private suspend fun closeStaleFirebaseAuthentication(operation: SessionAuthOperation) {
-        if (operation.staleAuthenticationClosed.compareAndSet(false, true)) {
-            clearAuthorizedDeviceSession()
-            authSessionProvider.signOut()
-            sessionEnvironmentRouter.resetToBaseEnvironment()
+        if (operation.staleAuthenticationClosed.get()) return
+        withContext(NonCancellable) {
+            if (operation.staleAuthenticationClosed.get()) return@withContext
+            val authenticationAndRoutingClosed = closeAuthenticationAndRoutingSafely()
+            val privateContextClosed = clearPrivateSessionContext()
+            val cleanupConfirmed = authenticationAndRoutingClosed && privateContextClosed
+            operation.definitiveCleanupConfirmed.set(cleanupConfirmed)
+            if (cleanupConfirmed) {
+                operation.staleAuthenticationClosed.set(true)
+            }
         }
+    }
+
+    private fun closeAuthenticationAndRoutingSafely(): Boolean {
+        val authenticationClosed = try {
+            authSessionProvider.signOut()
+            true
+        } catch (_: Exception) {
+            false
+        }
+        val routingReset = try {
+            sessionEnvironmentRouter.resetToBaseEnvironment()
+            true
+        } catch (_: Exception) {
+            false
+        }
+        return authenticationClosed && routingReset
+    }
+
+    private suspend fun clearPrivateSessionContext(): Boolean {
+        val deviceContextClosed = try {
+            authorizedDeviceRegistrar.clearAuthorizedSession()
+            true
+        } catch (_: Exception) {
+            false
+        }
+        val localFreshnessClosed = try {
+            criticalDataFreshnessLocalRepository.clear()
+            true
+        } catch (_: Exception) {
+            false
+        }
+        return deviceContextClosed && localFreshnessClosed
+    }
+
+    private fun resetSessionRoutingSafely(): Boolean =
+        try {
+            sessionEnvironmentRouter.resetToBaseEnvironment()
+            true
+        } catch (_: Exception) {
+            false
+        }
+
+    private suspend fun terminateCurrentSession(
+        operation: SessionAuthOperation,
+        closeAuthentication: Boolean,
+        transformUiState: (SessionUiState) -> SessionUiState,
+    ): AuthorizedSessionApplication {
+        if (!isCurrentSessionOperation(operation)) {
+            return abandonStaleAuthorizedSession()
+        }
+
+        cancelMyOrderFreshness()
+        clearSessionRefreshTracking()
+        if (!updateUiStateIfCurrent(operation, transformUiState)) {
+            return abandonStaleAuthorizedSession()
+        }
+
+        val cleanupConfirmed = withContext(NonCancellable) {
+            val authenticationAndRoutingClosed = if (closeAuthentication) {
+                closeAuthenticationAndRoutingSafely()
+            } else {
+                resetSessionRoutingSafely()
+            }
+            val privateContextClosed = clearPrivateSessionContext()
+            authenticationAndRoutingClosed && privateContextClosed
+        }
+
+        if (!completeTerminalSessionOperationIfCurrent(operation, cleanupConfirmed)) {
+            if (cleanupConfirmed && closeAuthentication) {
+                operation.definitiveCleanupConfirmed.set(true)
+                operation.staleAuthenticationClosed.set(true)
+            }
+            return abandonStaleAuthorizedSession()
+        }
+        return AuthorizedSessionApplication.TERMINATED
     }
 
     private suspend fun applyAuthorizedSession(
@@ -837,60 +1116,45 @@ internal class SessionAuthActions(
             }
 
             is AccessResolutionResult.Unauthorized -> {
-                if (!invalidateSessionOperationIfCurrent(operation)) {
-                    return abandonStaleAuthorizedSession()
-                }
-                cancelMyOrderFreshness()
-                clearAuthorizedDeviceSession()
-                clearSessionRefreshTracking()
-                sessionEnvironmentRouter.resetToBaseEnvironment()
                 if (result.reason == UnauthorizedReason.EMAIL_NOT_VERIFIED) {
-                    authSessionProvider.signOut()
-                    uiState.update { state ->
+                    return terminateCurrentSession(
+                        operation = operation,
+                        closeAuthentication = true,
+                    ) { state ->
                         state.toSignedOutSessionState(showSessionExpiredDialog = false).copy(
                             emailInput = principal.email,
                             emailErrorRes = R.string.auth_error_email_not_verified,
                         )
                     }
-                    return AuthorizedSessionApplication.TERMINATED
                 }
                 val showUnauthorizedDialog = shouldShowUnauthorizedDialog(
                     currentMode = uiState.value.mode,
                     email = principal.email,
                     reason = result.reason,
                 )
-                uiState.update { state ->
+                terminateCurrentSession(
+                    operation = operation,
+                    closeAuthentication = false,
+                ) { state ->
                     state.toUnauthorizedSessionState(
                         email = principal.email,
                         reason = result.reason,
                         showUnauthorizedDialog = showUnauthorizedDialog,
                     )
                 }
-                AuthorizedSessionApplication.TERMINATED
             }
         }
     }
 
     private suspend fun handleExpiredSession(operation: SessionAuthOperation) {
-        if (!isCurrentSessionOperation(operation)) {
-            closeStaleFirebaseAuthentication(operation)
-            return
+        val result = terminateCurrentSession(
+            operation = operation,
+            closeAuthentication = true,
+        ) { state ->
+            state.toSignedOutSessionState(showSessionExpiredDialog = true)
         }
-        if (!invalidateSessionOperationIfCurrent(operation)) {
+        if (result == AuthorizedSessionApplication.STALE) {
             closeStaleFirebaseAuthentication(operation)
-            return
-        }
-        cancelMyOrderFreshness()
-        clearAuthorizedDeviceSession()
-        clearSessionRefreshTracking()
-        sessionEnvironmentRouter.resetToBaseEnvironment()
-        uiState.update { state -> state.toSignedOutSessionState(showSessionExpiredDialog = true) }
-        try {
-            withContext(NonCancellable) {
-                criticalDataFreshnessLocalRepository.clear()
-            }
-        } catch (_: Exception) {
-            // Local cleanup must never delay or undo an already applied session termination.
         }
     }
 
@@ -919,15 +1183,6 @@ internal class SessionAuthActions(
         return isCurrentSessionOperation(operation)
     }
 
-    private suspend fun clearAuthorizedDeviceSession() {
-        try {
-            authorizedDeviceRegistrar.clearAuthorizedSession()
-        } catch (error: CancellationException) {
-            throw error
-        } catch (error: Exception) {
-            Log.e("SessionAuthActions", "Unable to clear authorized device state")
-        }
-    }
 }
 
 private data class SessionAuthOperation(
@@ -939,6 +1194,39 @@ private data class SessionAuthOperation(
     val providerWasInvoked: AtomicBoolean = AtomicBoolean(false),
     val staleAuthenticationClosed: AtomicBoolean = AtomicBoolean(false),
     val terminalSessionApplied: AtomicBoolean = AtomicBoolean(false),
+    val deadlineClaim: SessionOperationDeadlineClaim = SessionOperationDeadlineClaim(),
+    val deadlineTriggered: AtomicBoolean = AtomicBoolean(false),
+    val deadlineJob: AtomicReference<Job?> = AtomicReference(null),
+    val drainCleanupCompleted: CompletableDeferred<Unit> = CompletableDeferred(),
+    val definitiveCleanupConfirmed: AtomicBoolean = AtomicBoolean(false),
+)
+
+internal class SessionOperationDeadlineClaim {
+    private val state = AtomicReference(SessionOperationDeadlineOutcome.ACTIVE)
+
+    val outcome: SessionOperationDeadlineOutcome
+        get() = state.get()
+
+    fun claimResult(): Boolean = state.compareAndSet(
+        SessionOperationDeadlineOutcome.ACTIVE,
+        SessionOperationDeadlineOutcome.RESULT,
+    )
+
+    fun claimDraining(): Boolean = state.compareAndSet(
+        SessionOperationDeadlineOutcome.ACTIVE,
+        SessionOperationDeadlineOutcome.DRAINING,
+    )
+}
+
+internal enum class SessionOperationDeadlineOutcome {
+    ACTIVE,
+    RESULT,
+    DRAINING,
+}
+
+private data class SessionOperationDrain(
+    val kind: SessionAuthOperationKind,
+    val laneJob: Job,
 )
 
 private data class FreshnessOperation(
@@ -952,12 +1240,19 @@ private enum class SessionAuthOperationKind {
     SIGN_IN,
     SIGN_UP,
     REFRESH,
+    DRAINING,
     CLEANUP,
 }
 
 private val INTERACTIVE_SESSION_OPERATION_KINDS = setOf(
     SessionAuthOperationKind.SIGN_IN,
     SessionAuthOperationKind.SIGN_UP,
+)
+
+private val ACTIVE_SESSION_OPERATION_KINDS = setOf(
+    SessionAuthOperationKind.SIGN_IN,
+    SessionAuthOperationKind.SIGN_UP,
+    SessionAuthOperationKind.REFRESH,
 )
 
 private enum class AuthorizedSessionApplication {

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/data/access/FirebaseAuthSessionProviderTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/data/access/FirebaseAuthSessionProviderTest.kt
@@ -2,12 +2,348 @@ package com.reguerta.user.data.access
 
 import com.reguerta.user.domain.access.AuthSignInFailureReason
 import com.reguerta.user.domain.access.AuthSignInResult
+import com.reguerta.user.domain.access.AuthSessionRefreshResult
+import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class FirebaseAuthSessionProviderTest {
+    @Test
+    fun `initial sign in failure does not sign out an unrelated auth state`() = runBlocking {
+        val gateway = RecordingFirebaseAuthGateway(
+            signInError = IOException("credentials request failed"),
+        )
+
+        val result = FirebaseAuthSessionProvider(gateway).signIn(
+            email = "member@reguerta.app",
+            password = "secret123",
+        )
+
+        assertTrue(result is AuthSignInResult.Failure)
+        assertEquals(0, gateway.signOutCalls)
+        assertEquals(0, gateway.reloadCalls)
+    }
+
+    @Test
+    fun `reload failure after sign in mutation closes auth before returning failure`() = runBlocking {
+        val gateway = RecordingFirebaseAuthGateway(
+            signInUser = verifiedUser("mutated-sign-in"),
+            reloadError = IOException("reload failed"),
+        )
+
+        val result = FirebaseAuthSessionProvider(gateway).signIn(
+            email = "member@reguerta.app",
+            password = "secret123",
+        )
+
+        assertTrue(result is AuthSignInResult.Failure)
+        assertEquals(1, gateway.signOutCalls)
+        assertEquals(1, gateway.reloadCalls)
+    }
+
+    @Test
+    fun `post mutation failure propagates when firebase sign out cannot be confirmed`() = runBlocking {
+        val gateway = RecordingFirebaseAuthGateway(
+            signInUser = verifiedUser("unconfirmed-cleanup"),
+            reloadError = IOException("reload failed"),
+            signOutError = IOException("sign out failed"),
+        )
+        var thrown: Throwable? = null
+
+        try {
+            FirebaseAuthSessionProvider(gateway).signIn(
+                email = "member@reguerta.app",
+                password = "secret123",
+            )
+        } catch (error: Throwable) {
+            thrown = error
+        }
+
+        assertTrue(thrown is FirebaseAuthCleanupNotConfirmedException)
+        assertEquals(1, gateway.signOutCalls)
+    }
+
+    @Test
+    fun `missing user after completed sign in closes auth before returning failure`() = runBlocking {
+        val gateway = RecordingFirebaseAuthGateway()
+
+        val result = FirebaseAuthSessionProvider(gateway).signIn(
+            email = "member@reguerta.app",
+            password = "secret123",
+        )
+
+        assertTrue(result is AuthSignInResult.Failure)
+        assertEquals(1, gateway.signOutCalls)
+        assertEquals(1, gateway.reloadCalls)
+    }
+
+    @Test
+    fun `initial sign up failure does not sign out an unrelated auth state`() = runBlocking {
+        val gateway = RecordingFirebaseAuthGateway(
+            signUpError = IOException("create request failed"),
+        )
+
+        val result = FirebaseAuthSessionProvider(gateway).signUp(
+            email = "new@reguerta.app",
+            password = "secret123",
+        )
+
+        assertTrue(result is AuthSignInResult.Failure)
+        assertEquals(0, gateway.signOutCalls)
+        assertEquals(0, gateway.verificationEmailCalls)
+    }
+
+    @Test
+    fun `verification failure after sign up mutation closes auth before returning failure`() = runBlocking {
+        val gateway = RecordingFirebaseAuthGateway(
+            signUpUser = verifiedUser("mutated-sign-up"),
+            verificationError = IOException("verification failed"),
+        )
+
+        val result = FirebaseAuthSessionProvider(gateway).signUp(
+            email = "new@reguerta.app",
+            password = "secret123",
+        )
+
+        assertTrue(result is AuthSignInResult.Failure)
+        assertEquals(1, gateway.signOutCalls)
+        assertEquals(1, gateway.verificationEmailCalls)
+    }
+
+    @Test
+    fun `missing user after completed sign up closes auth before returning failure`() = runBlocking {
+        val gateway = RecordingFirebaseAuthGateway()
+
+        val result = FirebaseAuthSessionProvider(gateway).signUp(
+            email = "new@reguerta.app",
+            password = "secret123",
+        )
+
+        assertTrue(result is AuthSignInResult.Failure)
+        assertEquals(1, gateway.signOutCalls)
+        assertEquals(0, gateway.verificationEmailCalls)
+    }
+
+    @Test
+    fun `refresh failure before a successful reload keeps the known active session`() = runBlocking {
+        val currentUser = verifiedUser("offline-refresh")
+        val gateway = RecordingFirebaseAuthGateway(
+            currentUser = currentUser,
+            reloadError = IOException("offline"),
+        )
+
+        val result = FirebaseAuthSessionProvider(gateway).refreshCurrentSession()
+
+        val active = result as AuthSessionRefreshResult.Active
+        assertEquals(currentUser.uid, active.principal.uid)
+        assertEquals(0, gateway.signOutCalls)
+    }
+
+    @Test
+    fun `token failure after successful reload closes auth and propagates for fail closed recovery`() = runBlocking {
+        val currentUser = verifiedUser("token-failure")
+        val gateway = RecordingFirebaseAuthGateway(
+            currentUser = currentUser,
+            reloadedUser = currentUser,
+            tokenRefreshError = IOException("token refresh failed"),
+        )
+        var thrown: Throwable? = null
+
+        try {
+            FirebaseAuthSessionProvider(gateway).refreshCurrentSession()
+        } catch (error: Throwable) {
+            thrown = error
+        }
+
+        assertTrue(thrown is IOException)
+        assertEquals(1, gateway.signOutCalls)
+        assertEquals(listOf(true), gateway.tokenRefreshRequests)
+    }
+
+    @Test
+    fun `cancellation after firebase sign in closes auth before reload`() = runBlocking {
+        val signInStarted = CompletableDeferred<Unit>()
+        val signInRelease = CompletableDeferred<Unit>()
+        val gateway = CancellationCheckpointFirebaseAuthGateway(
+            signInStarted = signInStarted,
+            signInRelease = signInRelease,
+        )
+        val provider = FirebaseAuthSessionProvider(gateway)
+        val job = launch {
+            provider.signIn(
+                email = "member@reguerta.app",
+                password = "secret123",
+            )
+        }
+
+        signInStarted.await()
+        job.cancel()
+        signInRelease.complete(Unit)
+        job.join()
+
+        assertEquals(1, gateway.signOutCalls)
+        assertEquals(0, gateway.reloadCalls)
+    }
+
+    @Test
+    fun `cancellation after firebase sign up closes auth before verification`() = runBlocking {
+        val signUpStarted = CompletableDeferred<Unit>()
+        val signUpRelease = CompletableDeferred<Unit>()
+        val gateway = CancellationCheckpointSignUpGateway(
+            signUpStarted = signUpStarted,
+            signUpRelease = signUpRelease,
+        )
+        val provider = FirebaseAuthSessionProvider(gateway)
+        val job = launch {
+            provider.signUp(
+                email = "new@reguerta.app",
+                password = "secret123",
+            )
+        }
+
+        signUpStarted.await()
+        job.cancel()
+        signUpRelease.complete(Unit)
+        job.join()
+
+        assertEquals(1, gateway.signOutCalls)
+        assertEquals(0, gateway.verificationEmailCalls)
+    }
+
+    @Test
+    fun `cancellation while sign in reload returns closes auth before token refresh`() = runBlocking {
+        val reloadStarted = CompletableDeferred<Unit>()
+        val reloadRelease = CompletableDeferred<Unit>()
+        val user = verifiedUser("cancelled-sign-in-reload")
+        val gateway = RecordingFirebaseAuthGateway(
+            signInUser = user,
+            reloadedUser = user,
+            reloadStarted = reloadStarted,
+            reloadRelease = reloadRelease,
+        )
+        val job = launch {
+            FirebaseAuthSessionProvider(gateway).signIn(
+                email = user.email.orEmpty(),
+                password = "secret123",
+            )
+        }
+
+        reloadStarted.await()
+        job.cancel()
+        reloadRelease.complete(Unit)
+        job.join()
+
+        assertEquals(1, gateway.signOutCalls)
+        assertTrue(gateway.tokenRefreshRequests.isEmpty())
+    }
+
+    @Test
+    fun `cancellation while sign in token refresh returns closes auth`() = runBlocking {
+        val tokenStarted = CompletableDeferred<Unit>()
+        val tokenRelease = CompletableDeferred<Unit>()
+        val user = verifiedUser("cancelled-sign-in-token")
+        val gateway = RecordingFirebaseAuthGateway(
+            signInUser = user,
+            reloadedUser = user,
+            tokenStarted = tokenStarted,
+            tokenRelease = tokenRelease,
+        )
+        val job = launch {
+            FirebaseAuthSessionProvider(gateway).signIn(
+                email = user.email.orEmpty(),
+                password = "secret123",
+            )
+        }
+
+        tokenStarted.await()
+        job.cancel()
+        tokenRelease.complete(Unit)
+        job.join()
+
+        assertEquals(1, gateway.signOutCalls)
+        assertEquals(listOf(true), gateway.tokenRefreshRequests)
+    }
+
+    @Test
+    fun `cancellation while sign up verification returns closes auth`() = runBlocking {
+        val verificationStarted = CompletableDeferred<Unit>()
+        val verificationRelease = CompletableDeferred<Unit>()
+        val user = verifiedUser("cancelled-sign-up-verification")
+        val gateway = RecordingFirebaseAuthGateway(
+            signUpUser = user,
+            verificationStarted = verificationStarted,
+            verificationRelease = verificationRelease,
+        )
+        val job = launch {
+            FirebaseAuthSessionProvider(gateway).signUp(
+                email = user.email.orEmpty(),
+                password = "secret123",
+            )
+        }
+
+        verificationStarted.await()
+        job.cancel()
+        verificationRelease.complete(Unit)
+        job.join()
+
+        assertEquals(1, gateway.signOutCalls)
+        assertEquals(1, gateway.verificationEmailCalls)
+    }
+
+    @Test
+    fun `cancellation while refresh reload returns closes auth before token refresh`() = runBlocking {
+        val reloadStarted = CompletableDeferred<Unit>()
+        val reloadRelease = CompletableDeferred<Unit>()
+        val user = verifiedUser("cancelled-refresh-reload")
+        val gateway = RecordingFirebaseAuthGateway(
+            currentUser = user,
+            reloadedUser = user,
+            reloadStarted = reloadStarted,
+            reloadRelease = reloadRelease,
+        )
+        val job = launch {
+            FirebaseAuthSessionProvider(gateway).refreshCurrentSession()
+        }
+
+        reloadStarted.await()
+        job.cancel()
+        reloadRelease.complete(Unit)
+        job.join()
+
+        assertEquals(1, gateway.signOutCalls)
+        assertTrue(gateway.tokenRefreshRequests.isEmpty())
+    }
+
+    @Test
+    fun `cancellation while refresh token returns closes auth`() = runBlocking {
+        val tokenStarted = CompletableDeferred<Unit>()
+        val tokenRelease = CompletableDeferred<Unit>()
+        val user = verifiedUser("cancelled-refresh-token")
+        val gateway = RecordingFirebaseAuthGateway(
+            currentUser = user,
+            reloadedUser = user,
+            tokenStarted = tokenStarted,
+            tokenRelease = tokenRelease,
+        )
+        val job = launch {
+            FirebaseAuthSessionProvider(gateway).refreshCurrentSession()
+        }
+
+        tokenStarted.await()
+        job.cancel()
+        tokenRelease.complete(Unit)
+        job.join()
+
+        assertEquals(1, gateway.signOutCalls)
+        assertEquals(listOf(true), gateway.tokenRefreshRequests)
+    }
+
     @Test
     fun `maps credential related firebase error codes`() {
         assertEquals(
@@ -117,23 +453,125 @@ class FirebaseAuthSessionProviderTest {
     }
 }
 
+private class CancellationCheckpointFirebaseAuthGateway(
+    private val signInStarted: CompletableDeferred<Unit>,
+    private val signInRelease: CompletableDeferred<Unit>,
+) : FirebaseAuthGateway {
+    var reloadCalls = 0
+    var signOutCalls = 0
+
+    override suspend fun signIn(email: String, password: String): FirebaseAuthUserSnapshot =
+        withContext(NonCancellable) {
+            signInStarted.complete(Unit)
+            signInRelease.await()
+            FirebaseAuthUserSnapshot(
+                uid = "cancelled_uid",
+                email = email,
+                emailVerified = true,
+            )
+        }
+
+    override suspend fun signUp(email: String, password: String): FirebaseAuthUserSnapshot? =
+        error("Unexpected signUp")
+
+    override suspend fun sendCurrentUserVerificationEmail() = error("Unexpected verification")
+
+    override suspend fun sendPasswordReset(email: String) = error("Unexpected password reset")
+
+    override fun currentUserSnapshot(): FirebaseAuthUserSnapshot? = null
+
+    override suspend fun reloadCurrentUser(): FirebaseAuthUserSnapshot? {
+        reloadCalls += 1
+        return null
+    }
+
+    override suspend fun refreshCurrentUserToken(forceRefresh: Boolean) = error("Unexpected token refresh")
+
+    override fun signOut() {
+        signOutCalls += 1
+    }
+}
+
+private class CancellationCheckpointSignUpGateway(
+    private val signUpStarted: CompletableDeferred<Unit>,
+    private val signUpRelease: CompletableDeferred<Unit>,
+) : FirebaseAuthGateway {
+    var verificationEmailCalls = 0
+    var signOutCalls = 0
+
+    override suspend fun signIn(email: String, password: String): FirebaseAuthUserSnapshot? =
+        error("Unexpected signIn")
+
+    override suspend fun signUp(email: String, password: String): FirebaseAuthUserSnapshot =
+        withContext(NonCancellable) {
+            signUpStarted.complete(Unit)
+            signUpRelease.await()
+            FirebaseAuthUserSnapshot(
+                uid = "cancelled_new_uid",
+                email = email,
+                emailVerified = false,
+            )
+        }
+
+    override suspend fun sendCurrentUserVerificationEmail() {
+        verificationEmailCalls += 1
+    }
+
+    override suspend fun sendPasswordReset(email: String) = error("Unexpected password reset")
+
+    override fun currentUserSnapshot(): FirebaseAuthUserSnapshot? = null
+
+    override suspend fun reloadCurrentUser(): FirebaseAuthUserSnapshot? = error("Unexpected reload")
+
+    override suspend fun refreshCurrentUserToken(forceRefresh: Boolean) = error("Unexpected token refresh")
+
+    override fun signOut() {
+        signOutCalls += 1
+    }
+}
+
 private class RecordingFirebaseAuthGateway(
     private val signInUser: FirebaseAuthUserSnapshot? = null,
     private val signUpUser: FirebaseAuthUserSnapshot? = null,
     private val reloadedUser: FirebaseAuthUserSnapshot? = null,
     private val currentUser: FirebaseAuthUserSnapshot? = null,
+    private val signInError: Exception? = null,
+    private val signUpError: Exception? = null,
+    private val verificationError: Exception? = null,
+    private val reloadError: Exception? = null,
+    private val tokenRefreshError: Exception? = null,
+    private val signOutError: Exception? = null,
+    private val reloadStarted: CompletableDeferred<Unit>? = null,
+    private val reloadRelease: CompletableDeferred<Unit>? = null,
+    private val tokenStarted: CompletableDeferred<Unit>? = null,
+    private val tokenRelease: CompletableDeferred<Unit>? = null,
+    private val verificationStarted: CompletableDeferred<Unit>? = null,
+    private val verificationRelease: CompletableDeferred<Unit>? = null,
 ) : FirebaseAuthGateway {
     var verificationEmailCalls: Int = 0
     var reloadCalls: Int = 0
     var signOutCalls: Int = 0
     val tokenRefreshRequests = mutableListOf<Boolean>()
 
-    override suspend fun signIn(email: String, password: String): FirebaseAuthUserSnapshot? = signInUser
+    override suspend fun signIn(email: String, password: String): FirebaseAuthUserSnapshot? {
+        signInError?.let { throw it }
+        return signInUser
+    }
 
-    override suspend fun signUp(email: String, password: String): FirebaseAuthUserSnapshot? = signUpUser
+    override suspend fun signUp(email: String, password: String): FirebaseAuthUserSnapshot? {
+        signUpError?.let { throw it }
+        return signUpUser
+    }
 
     override suspend fun sendCurrentUserVerificationEmail() {
         verificationEmailCalls += 1
+        verificationStarted?.complete(Unit)
+        verificationRelease?.let { release ->
+            withContext(NonCancellable) {
+                release.await()
+            }
+        }
+        verificationError?.let { throw it }
     }
 
     override suspend fun sendPasswordReset(email: String) = Unit
@@ -142,14 +580,35 @@ private class RecordingFirebaseAuthGateway(
 
     override suspend fun reloadCurrentUser(): FirebaseAuthUserSnapshot? {
         reloadCalls += 1
+        reloadStarted?.complete(Unit)
+        reloadRelease?.let { release ->
+            withContext(NonCancellable) {
+                release.await()
+            }
+        }
+        reloadError?.let { throw it }
         return reloadedUser
     }
 
     override suspend fun refreshCurrentUserToken(forceRefresh: Boolean) {
         tokenRefreshRequests += forceRefresh
+        tokenStarted?.complete(Unit)
+        tokenRelease?.let { release ->
+            withContext(NonCancellable) {
+                release.await()
+            }
+        }
+        tokenRefreshError?.let { throw it }
     }
 
     override fun signOut() {
         signOutCalls += 1
+        signOutError?.let { throw it }
     }
 }
+
+private fun verifiedUser(id: String) = FirebaseAuthUserSnapshot(
+    uid = "uid-$id",
+    email = "$id@reguerta.app",
+    emailVerified = true,
+)

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/auth/SessionAuthActionsConcurrencyTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/auth/SessionAuthActionsConcurrencyTest.kt
@@ -38,7 +38,9 @@ import com.reguerta.user.presentation.root.MY_ORDER_FRESHNESS_TIMEOUT_MILLIS
 import com.reguerta.user.presentation.root.SessionMode
 import com.reguerta.user.presentation.root.SessionUiState
 import java.io.IOException
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -46,6 +48,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
@@ -56,6 +59,331 @@ import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SessionAuthActionsConcurrencyTest {
+    @Test
+    fun `result and deadline claims have exactly one winner under concurrent execution`() {
+        repeat(50) {
+            val claim = SessionOperationDeadlineClaim()
+            val ready = CountDownLatch(2)
+            val start = CountDownLatch(1)
+            val resultWon = AtomicBoolean(false)
+            val deadlineWon = AtomicBoolean(false)
+            val resultThread = thread(isDaemon = true) {
+                ready.countDown()
+                start.await()
+                resultWon.set(claim.claimResult())
+            }
+            val deadlineThread = thread(isDaemon = true) {
+                ready.countDown()
+                start.await()
+                deadlineWon.set(claim.claimDraining())
+            }
+
+            ready.await()
+            start.countDown()
+            resultThread.join()
+            deadlineThread.join()
+
+            assertEquals(1, listOf(resultWon.get(), deadlineWon.get()).count { it })
+            assertEquals(
+                if (resultWon.get()) {
+                    SessionOperationDeadlineOutcome.RESULT
+                } else {
+                    SessionOperationDeadlineOutcome.DRAINING
+                },
+                claim.outcome,
+            )
+        }
+    }
+
+    @Test
+    fun `current sign in exception recovers the login instead of escaping`() = runTest {
+        val providerError = CompletableDeferred<Throwable>()
+        val authProvider = ControlledAuthSessionProvider(lateSignInError = providerError)
+        val fixture = fixture(scope = this, authProvider = authProvider)
+
+        assertTrue(fixture.actions.signIn("secret123"))
+        runCurrent()
+
+        providerError.complete(IOException("current provider failure"))
+        advanceUntilIdle()
+
+        assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
+        assertFalse(fixture.state.value.isAuthenticating)
+        assertEquals(
+            com.reguerta.user.R.string.auth_error_unknown,
+            fixture.state.value.emailErrorRes,
+        )
+        assertEquals("member@reguerta.app", fixture.state.value.emailInput)
+        assertEquals(2, authProvider.signOutRequests)
+    }
+
+    @Test
+    fun `interactive submit is rejected while another session operation owns the lane`() = runTest {
+        val predecessorResult = CompletableDeferred<AuthSignInResult>()
+        val authProvider = ControlledAuthSessionProvider(
+            signInResults = listOf(predecessorResult),
+        )
+        val fixture = fixture(scope = this, authProvider = authProvider)
+
+        assertTrue(fixture.actions.signIn("secret123"))
+        runCurrent()
+
+        fixture.state.value = fixture.state.value.copy(emailInput = "waiting@reguerta.app")
+        assertFalse(fixture.actions.signIn("waiting-secret"))
+        runCurrent()
+        assertEquals(1, authProvider.signInRequests.size)
+
+        predecessorResult.complete(AuthSignInResult.Failure(AuthSignInFailureReason.NETWORK))
+        advanceUntilIdle()
+        assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
+    }
+
+    @Test
+    fun `sign in deadline drains non cancellable work before accepting a later login`() = runTest {
+        val timedOutResult = CompletableDeferred<AuthSignInResult>()
+        val cleanupStarted = CompletableDeferred<Unit>()
+        val cleanupRelease = CompletableDeferred<Unit>()
+        val localFreshnessRepository = TestCriticalDataFreshnessLocalRepository(
+            clearStarted = cleanupStarted,
+            clearRelease = cleanupRelease,
+        )
+        val laterResult = CompletableDeferred<AuthSignInResult>(
+            AuthSignInResult.Success(principal("after-timeout")),
+        )
+        val authProvider = ControlledAuthSessionProvider(
+            signInResults = listOf(timedOutResult, laterResult),
+        )
+        val fixture = fixture(
+            scope = this,
+            authProvider = authProvider,
+            localFreshnessRepository = localFreshnessRepository,
+        )
+
+        assertTrue(fixture.actions.signIn("secret123"))
+        runCurrent()
+
+        advanceTimeBy(TEST_SESSION_OPERATION_TIMEOUT_MILLIS - 1)
+        runCurrent()
+        assertTrue(fixture.state.value.isAuthenticating)
+        assertEquals(0, authProvider.signOutRequests)
+
+        advanceTimeBy(1)
+        runCurrent()
+        cleanupStarted.await()
+
+        assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
+        assertFalse(fixture.state.value.isAuthenticating)
+        assertFalse(fixture.state.value.showSessionExpiredDialog)
+        assertEquals(
+            com.reguerta.user.R.string.auth_error_unknown,
+            fixture.state.value.emailErrorRes,
+        )
+        assertEquals(1, authProvider.signOutRequests)
+        assertEquals(1, fixture.deviceRegistrar.clearRequests)
+        assertEquals(1, fixture.localFreshnessRepository.clearRequests)
+        assertEquals(0, fixture.localFreshnessRepository.completedClearRequests)
+
+        fixture.state.value = fixture.state.value.copy(
+            emailInput = "later@reguerta.app",
+            emailErrorRes = null,
+        )
+        assertFalse(fixture.actions.signIn("later-secret"))
+        assertEquals(
+            com.reguerta.user.R.string.auth_error_unknown,
+            fixture.state.value.emailErrorRes,
+        )
+        assertEquals(1, authProvider.signInRequests.size)
+
+        timedOutResult.complete(AuthSignInResult.Success(principal("too-late")))
+        runCurrent()
+
+        assertFalse(fixture.actions.signIn("still-draining-secret"))
+        cleanupRelease.complete(Unit)
+        advanceUntilIdle()
+
+        assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
+        assertEquals(2, authProvider.signOutRequests)
+        assertEquals(2, fixture.deviceRegistrar.clearRequests)
+        assertEquals(2, fixture.localFreshnessRepository.clearRequests)
+        assertEquals(2, fixture.localFreshnessRepository.completedClearRequests)
+
+        assertTrue(fixture.actions.signIn("later-secret"))
+        advanceUntilIdle()
+
+        val mode = fixture.state.value.mode as SessionMode.Authorized
+        assertEquals("uid-after-timeout", mode.principal.uid)
+        assertEquals(listOf("member", "later"), authProvider.signInRequests.map { it.email.substringBefore('@') })
+    }
+
+    @Test
+    fun `refresh deadline fails closed without expired dialog or success timestamp`() = runTest {
+        val principal = principal("refresh-timeout")
+        val refreshResult = CompletableDeferred<AuthSessionRefreshResult>()
+        val authProvider = ControlledAuthSessionProvider(refreshResult = refreshResult)
+        val fixture = fixture(
+            scope = this,
+            state = authorizedState(principal, member(principal)).copy(emailInput = principal.email),
+            authProvider = authProvider,
+        )
+
+        fixture.actions.refreshSession(SessionRefreshTrigger.STARTUP)
+        runCurrent()
+
+        advanceTimeBy(TEST_SESSION_OPERATION_TIMEOUT_MILLIS)
+        runCurrent()
+
+        assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
+        assertFalse(fixture.state.value.showSessionExpiredDialog)
+        assertEquals(principal.email, fixture.state.value.emailInput)
+        assertEquals(
+            com.reguerta.user.R.string.auth_error_unknown,
+            fixture.state.value.emailErrorRes,
+        )
+        assertFalse(fixture.isRefreshInFlight)
+        assertEquals(null, fixture.lastRefreshAtMillis)
+
+        fixture.actions.refreshSession(SessionRefreshTrigger.STARTUP)
+        runCurrent()
+        assertEquals(1, authProvider.refreshRequests)
+
+        refreshResult.complete(AuthSessionRefreshResult.Active(principal))
+        advanceUntilIdle()
+
+        assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
+        assertEquals(null, fixture.lastRefreshAtMillis)
+        assertEquals(2, authProvider.signOutRequests)
+    }
+
+    @Test
+    fun `sign up deadline recovers registration and preserves its email`() = runTest {
+        val signUpResult = CompletableDeferred<AuthSignInResult>()
+        val authProvider = ControlledAuthSessionProvider(signUpResults = listOf(signUpResult))
+        val fixture = fixture(
+            scope = this,
+            state = registrationState(),
+            authProvider = authProvider,
+        )
+
+        assertTrue(fixture.actions.signUp("secret123", "secret123"))
+        runCurrent()
+        advanceTimeBy(TEST_SESSION_OPERATION_TIMEOUT_MILLIS)
+        runCurrent()
+
+        assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
+        assertEquals("member@reguerta.app", fixture.state.value.registerEmailInput)
+        assertEquals(
+            com.reguerta.user.R.string.auth_error_register_generic,
+            fixture.state.value.registerEmailErrorRes,
+        )
+        assertFalse(fixture.state.value.isRegistering)
+        assertEquals(1, authProvider.signOutRequests)
+
+        signUpResult.complete(AuthSignInResult.Success(principal("late-sign-up-timeout")))
+        advanceUntilIdle()
+
+        assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
+        assertEquals(2, authProvider.signOutRequests)
+    }
+
+    @Test
+    fun `failed definitive sign out keeps the completed operation quarantined`() = runTest {
+        val timedOutResult = CompletableDeferred<AuthSignInResult>()
+        val rejectedResult = CompletableDeferred<AuthSignInResult>(
+            AuthSignInResult.Failure(AuthSignInFailureReason.NETWORK),
+        )
+        val authProvider = ControlledAuthSessionProvider(
+            signInResults = listOf(timedOutResult, rejectedResult),
+            signOutErrors = listOf(
+                null,
+                IOException("definitive sign out failed"),
+                IOException("definitive sign out retry failed"),
+            ),
+        )
+        val fixture = fixture(scope = this, authProvider = authProvider)
+
+        assertTrue(fixture.actions.signIn("secret123"))
+        runCurrent()
+        advanceTimeBy(TEST_SESSION_OPERATION_TIMEOUT_MILLIS)
+        runCurrent()
+
+        timedOutResult.complete(AuthSignInResult.Success(principal("late-after-failed-cleanup")))
+        advanceUntilIdle()
+
+        assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
+        assertEquals(3, authProvider.signOutRequests)
+        fixture.state.value = fixture.state.value.copy(emailInput = "blocked@reguerta.app")
+        assertFalse(fixture.actions.signIn("blocked-secret"))
+        assertEquals(1, authProvider.signInRequests.size)
+    }
+
+    @Test
+    fun `failed definitive private cleanup keeps the completed operation quarantined`() = runTest {
+        val timedOutResult = CompletableDeferred<AuthSignInResult>()
+        val rejectedResult = CompletableDeferred<AuthSignInResult>(
+            AuthSignInResult.Failure(AuthSignInFailureReason.NETWORK),
+        )
+        val authProvider = ControlledAuthSessionProvider(
+            signInResults = listOf(timedOutResult, rejectedResult),
+        )
+        val deviceRegistrar = TestAuthorizedDeviceRegistrar(
+            clearErrors = listOf(
+                null,
+                IOException("definitive device cleanup failed"),
+                IOException("definitive device cleanup retry failed"),
+            ),
+        )
+        val fixture = fixture(
+            scope = this,
+            authProvider = authProvider,
+            deviceRegistrar = deviceRegistrar,
+        )
+
+        assertTrue(fixture.actions.signIn("secret123"))
+        runCurrent()
+        advanceTimeBy(TEST_SESSION_OPERATION_TIMEOUT_MILLIS)
+        runCurrent()
+
+        timedOutResult.complete(AuthSignInResult.Success(principal("late-after-private-cleanup")))
+        advanceUntilIdle()
+
+        assertEquals(3, authProvider.signOutRequests)
+        assertEquals(3, deviceRegistrar.clearRequests)
+        assertEquals(3, fixture.localFreshnessRepository.completedClearRequests)
+        fixture.state.value = fixture.state.value.copy(emailInput = "blocked@reguerta.app")
+        assertFalse(fixture.actions.signIn("blocked-secret"))
+        assertEquals(1, authProvider.signInRequests.size)
+    }
+
+    @Test
+    fun `sign out failure still clears local state and retains quarantine`() = runTest {
+        val principal = principal("manual-sign-out-failure")
+        val authProvider = ControlledAuthSessionProvider(
+            signInResults = listOf(
+                CompletableDeferred(AuthSignInResult.Failure(AuthSignInFailureReason.NETWORK)),
+            ),
+            signOutErrors = listOf(
+                IOException("preliminary sign out failed"),
+                IOException("definitive sign out failed"),
+            ),
+        )
+        val fixture = fixture(
+            scope = this,
+            state = authorizedState(principal, member(principal)),
+            authProvider = authProvider,
+        )
+
+        fixture.actions.signOut()
+        advanceUntilIdle()
+
+        assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
+        assertEquals(2, authProvider.signOutRequests)
+        assertTrue(fixture.deviceRegistrar.clearRequests >= 1)
+        assertTrue(fixture.localFreshnessRepository.completedClearRequests >= 1)
+        fixture.state.value = fixture.state.value.copy(emailInput = "blocked@reguerta.app")
+        assertFalse(fixture.actions.signIn("blocked-secret"))
+        assertTrue(authProvider.signInRequests.isEmpty())
+    }
+
     @Test
     fun `valid sign in forwards the route password snapshot`() = runTest {
         val signInResult = CompletableDeferred<AuthSignInResult>()
@@ -162,7 +490,7 @@ class SessionAuthActionsConcurrencyTest {
         advanceUntilIdle()
 
         assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
-        assertEquals(2, authProvider.signOutRequests)
+        assertEquals(3, authProvider.signOutRequests)
         assertEquals(0, fixture.deviceRegistrations)
     }
 
@@ -194,40 +522,37 @@ class SessionAuthActionsConcurrencyTest {
         advanceUntilIdle()
 
         assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
-        assertEquals(2, authProvider.signOutRequests)
+        assertEquals(3, authProvider.signOutRequests)
         assertEquals(0, fixture.deviceRegistrations)
         assertEquals(0, fixture.shiftRefreshes)
     }
 
     @Test
-    fun `new auth operation waits for stale predecessor cleanup and is sole publisher`() = runTest {
+    fun `new auth operation is accepted only after the current owner releases the lane`() = runTest {
         val firstResult = CompletableDeferred<AuthSignInResult>()
         val secondResult = CompletableDeferred<AuthSignInResult>()
         val authProvider = ControlledAuthSessionProvider(signInResults = listOf(firstResult, secondResult))
         val fixture = fixture(scope = this, authProvider = authProvider)
 
-        fixture.actions.signIn("secret123")
+        assertTrue(fixture.actions.signIn("secret123"))
         runCurrent()
         fixture.state.value = fixture.state.value.copy(
             emailInput = "new@reguerta.app",
         )
-        fixture.actions.signIn("new-secret")
+        assertFalse(fixture.actions.signIn("new-secret"))
         runCurrent()
 
-        val requestsBeforePredecessorCompletion = authProvider.signInRequests.size
+        assertEquals(1, authProvider.signInRequests.size)
+        firstResult.complete(AuthSignInResult.Failure(AuthSignInFailureReason.NETWORK))
+        advanceUntilIdle()
 
-        firstResult.complete(AuthSignInResult.Success(principal("old")))
+        assertTrue(fixture.actions.signIn("new-secret"))
         runCurrent()
-
-        val staleCleanupSignOuts = authProvider.signOutRequests
-        val requestOrder = authProvider.signInRequests.map { it.email.substringBefore('@') }
         secondResult.complete(AuthSignInResult.Success(principal("new")))
         advanceUntilIdle()
 
         val mode = fixture.state.value.mode as SessionMode.Authorized
-        assertEquals(1, requestsBeforePredecessorCompletion)
-        assertEquals(1, staleCleanupSignOuts)
-        assertEquals(listOf("member", "new"), requestOrder)
+        assertEquals(listOf("member", "new"), authProvider.signInRequests.map { it.email.substringBefore('@') })
         assertEquals("uid-new", mode.principal.uid)
         assertEquals(1, fixture.deviceRegistrations)
     }
@@ -289,7 +614,7 @@ class SessionAuthActionsConcurrencyTest {
         advanceUntilIdle()
 
         assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
-        assertEquals(2, authProvider.signOutRequests)
+        assertEquals(3, authProvider.signOutRequests)
         assertEquals(null, fixture.state.value.registerEmailErrorRes)
         assertEquals("", fixture.state.value.registerEmailInput)
         assertEquals(0, fixture.deviceRegistrations)
@@ -383,35 +708,33 @@ class SessionAuthActionsConcurrencyTest {
     }
 
     @Test
-    fun `three operation chain preserves predecessor cleanup before final sign in`() = runTest {
+    fun `repeated interactive submits are rejected until the current owner finishes`() = runTest {
         val firstResult = CompletableDeferred<AuthSignInResult>()
         val finalResult = CompletableDeferred<AuthSignInResult>()
         val authProvider = ControlledAuthSessionProvider(signInResults = listOf(firstResult, finalResult))
         val fixture = fixture(scope = this, authProvider = authProvider)
 
-        fixture.actions.signIn("secret123")
+        assertTrue(fixture.actions.signIn("secret123"))
         runCurrent()
         fixture.state.value = fixture.state.value.copy(
             emailInput = "middle@reguerta.app",
         )
-        fixture.actions.signIn("middle-secret")
+        assertFalse(fixture.actions.signIn("middle-secret"))
         runCurrent()
         fixture.state.value = fixture.state.value.copy(
             emailInput = "final@reguerta.app",
         )
-        fixture.actions.signIn("final-secret")
+        assertFalse(fixture.actions.signIn("final-secret"))
         runCurrent()
 
         assertEquals(listOf("member"), authProvider.signInRequests.map { it.email.substringBefore('@') })
 
-        firstResult.complete(AuthSignInResult.Success(principal("first")))
-        runCurrent()
+        firstResult.complete(AuthSignInResult.Failure(AuthSignInFailureReason.NETWORK))
+        advanceUntilIdle()
 
-        assertEquals(
-            listOf("member", "final"),
-            authProvider.signInRequests.map { it.email.substringBefore('@') },
-        )
-        assertEquals(1, authProvider.signOutRequests)
+        assertTrue(fixture.actions.signIn("final-secret"))
+        runCurrent()
+        assertEquals(listOf("member", "final"), authProvider.signInRequests.map { it.email.substringBefore('@') })
 
         finalResult.complete(AuthSignInResult.Success(principal("final")))
         advanceUntilIdle()
@@ -661,7 +984,7 @@ class SessionAuthActionsConcurrencyTest {
         assertTrue(environmentRouter.appliedEnvironments.isEmpty())
         assertEquals(null, environmentRouter.currentEnvironment)
         assertEquals(0, memberRepository.findByAuthUidRequests)
-        assertEquals(2, authProvider.signOutRequests)
+        assertEquals(3, authProvider.signOutRequests)
     }
 
     @Test
@@ -719,7 +1042,44 @@ class SessionAuthActionsConcurrencyTest {
         assertEquals(listOf("develop"), deviceRegistrar.requestedEnvironments)
         assertEquals(0, deviceRegistrar.completedRegistrations)
         assertTrue(deviceRegistrar.clearRequests >= 1)
-        assertEquals(2, authProvider.signOutRequests)
+        assertEquals(3, authProvider.signOutRequests)
+    }
+
+    @Test
+    fun `email verification rejection stays quarantined when firebase sign out fails`() = runTest {
+        val principal = principal("verification-required")
+        val authProvider = ControlledAuthSessionProvider(
+            signInResults = listOf(
+                CompletableDeferred(AuthSignInResult.Success(principal)),
+            ),
+            signOutErrors = listOf(IOException("firebase sign out failed")),
+        )
+        val fixture = fixture(
+            scope = this,
+            authProvider = authProvider,
+            authorizedMemberResolver = EmailVerificationRequiredMemberResolver,
+        )
+
+        assertTrue(fixture.actions.signIn("secret123"))
+        advanceUntilIdle()
+
+        assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
+        assertFalse(fixture.state.value.showSessionExpiredDialog)
+        assertEquals(principal.email, fixture.state.value.emailInput)
+        assertEquals(
+            com.reguerta.user.R.string.auth_error_email_not_verified,
+            fixture.state.value.emailErrorRes,
+        )
+        assertEquals(1, authProvider.signOutRequests)
+        assertEquals(1, fixture.deviceRegistrar.clearRequests)
+        assertEquals(1, fixture.localFreshnessRepository.clearRequests)
+
+        assertFalse(fixture.actions.signIn("secret123"))
+        assertEquals(1, authProvider.signInRequests.size)
+        assertEquals(
+            com.reguerta.user.R.string.auth_error_unknown,
+            fixture.state.value.emailErrorRes,
+        )
     }
 
     @Test
@@ -754,6 +1114,34 @@ class SessionAuthActionsConcurrencyTest {
     }
 
     @Test
+    fun `expired refresh stays quarantined when private cleanup fails`() = runTest {
+        val principal = principal("expired-cleanup-failure")
+        val authProvider = ControlledAuthSessionProvider(
+            refreshResult = CompletableDeferred(AuthSessionRefreshResult.Expired),
+        )
+        val fixture = fixture(
+            scope = this,
+            state = authorizedState(principal, member(principal)).copy(emailInput = principal.email),
+            authProvider = authProvider,
+            deviceRegistrar = TestAuthorizedDeviceRegistrar(
+                clearErrors = listOf(IOException("device cleanup failed")),
+            ),
+        )
+
+        fixture.actions.refreshSession(SessionRefreshTrigger.STARTUP)
+        advanceUntilIdle()
+
+        assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
+        assertTrue(fixture.state.value.showSessionExpiredDialog)
+        assertEquals(1, authProvider.signOutRequests)
+        assertEquals(1, fixture.deviceRegistrar.clearRequests)
+        assertEquals(1, fixture.localFreshnessRepository.clearRequests)
+
+        assertFalse(fixture.actions.signIn("secret123"))
+        assertEquals(0, authProvider.signInRequests.size)
+    }
+
+    @Test
     fun `late non cancellation exception cleans stale authentication`() = runTest {
         val lateError = CompletableDeferred<Throwable>()
         val authProvider = ControlledAuthSessionProvider(lateSignInError = lateError)
@@ -766,12 +1154,14 @@ class SessionAuthActionsConcurrencyTest {
         advanceUntilIdle()
 
         assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
-        assertEquals(2, authProvider.signOutRequests)
+        assertEquals(3, authProvider.signOutRequests)
         assertEquals(null, fixture.environmentRouter.currentEnvironment)
         assertEquals(null, fixture.state.value.emailErrorRes)
         assertTrue(fixture.deviceRegistrar.clearRequests >= 1)
     }
 }
+
+private const val TEST_SESSION_OPERATION_TIMEOUT_MILLIS = 30_000L
 
 private data class AuthFixture(
     val actions: SessionAuthActions,
@@ -807,6 +1197,7 @@ private fun fixture(
     deviceRegistrar: TestAuthorizedDeviceRegistrar = TestAuthorizedDeviceRegistrar(),
     localFreshnessRepository: TestCriticalDataFreshnessLocalRepository =
         TestCriticalDataFreshnessLocalRepository(),
+    sessionOperationTimeoutMillis: Long = TEST_SESSION_OPERATION_TIMEOUT_MILLIS,
 ): AuthFixture {
     val stateFlow = MutableStateFlow(state)
     var lastRefreshAtMillis: Long? = null
@@ -839,6 +1230,7 @@ private fun fixture(
         nowMillisProvider = { 1_000L },
         refreshShifts = { shiftRefreshes += 1 },
         refreshDeliveryCalendar = {},
+        sessionOperationTimeoutMillis = sessionOperationTimeoutMillis,
     )
     return AuthFixture(
         actions = actions,
@@ -859,6 +1251,7 @@ private class ControlledAuthSessionProvider(
     refreshResult: CompletableDeferred<AuthSessionRefreshResult>? = null,
     private val refreshResults: List<CompletableDeferred<AuthSessionRefreshResult>> = refreshResult?.let(::listOf)
         ?: listOf(CompletableDeferred(AuthSessionRefreshResult.NoSession)),
+    private val signOutErrors: List<Throwable?> = emptyList(),
 ) : AuthSessionProvider {
     class SignInRequest(
         val email: String,
@@ -898,13 +1291,16 @@ private class ControlledAuthSessionProvider(
     }
 
     override fun signOut() {
+        val error = signOutErrors.getOrNull(signOutRequests)
         signOutRequests += 1
+        error?.let { throw it }
     }
 }
 
 private class TestAuthorizedDeviceRegistrar(
     private val started: CompletableDeferred<Unit>? = null,
     private val release: CompletableDeferred<Unit>? = null,
+    private val clearErrors: List<Throwable?> = emptyList(),
 ) : AuthorizedDeviceRegistrar {
     var registerRequests = 0
     var completedRegistrations = 0
@@ -930,7 +1326,9 @@ private class TestAuthorizedDeviceRegistrar(
     }
 
     override suspend fun clearAuthorizedSession() {
+        val error = clearErrors.getOrNull(clearRequests)
         clearRequests += 1
+        error?.let { throw it }
     }
 }
 
@@ -976,6 +1374,13 @@ private object ProductionAuthorizedMemberResolver : AuthorizedMemberResolver {
         isActive = true,
         environment = "production",
         firstLoginLinked = false,
+    )
+}
+
+private object EmailVerificationRequiredMemberResolver : AuthorizedMemberResolver {
+    override suspend fun resolve(): AuthorizedMemberResolution = AuthorizedMemberResolution.Unauthorized(
+        isActive = null,
+        emailVerificationRequired = true,
     )
 }
 
@@ -1092,6 +1497,7 @@ private open class TestCriticalDataFreshnessLocalRepository(
     private val clearRelease: CompletableDeferred<Unit>? = null,
 ) : CriticalDataFreshnessLocalRepository {
     var clearRequests = 0
+    var completedClearRequests = 0
     var saveRequests = 0
     var storedMetadata: CriticalDataFreshnessMetadata? = null
     private var currentWriteId: String? = null
@@ -1123,6 +1529,7 @@ private open class TestCriticalDataFreshnessLocalRepository(
                 gate.await()
             }
         }
+        completedClearRequests += 1
     }
 }
 

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/auth/SessionAuthActionsConcurrencyTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/auth/SessionAuthActionsConcurrencyTest.kt
@@ -385,6 +385,50 @@ class SessionAuthActionsConcurrencyTest {
     }
 
     @Test
+    fun `refresh during failing sign out cleanup is ignored and quarantine remains`() = runTest {
+        val cleanupStarted = CompletableDeferred<Unit>()
+        val cleanupRelease = CompletableDeferred<Unit>()
+        val principal = principal("cleanup-refresh")
+        val authProvider = ControlledAuthSessionProvider(
+            signInResults = listOf(
+                CompletableDeferred(AuthSignInResult.Failure(AuthSignInFailureReason.NETWORK)),
+            ),
+            refreshResults = listOf(
+                CompletableDeferred(AuthSessionRefreshResult.Active(principal)),
+            ),
+            signOutErrors = listOf(
+                IOException("preliminary sign out failed"),
+                IOException("definitive sign out failed"),
+            ),
+        )
+        val fixture = fixture(
+            scope = this,
+            state = authorizedState(principal, member(principal)),
+            authProvider = authProvider,
+            localFreshnessRepository = TestCriticalDataFreshnessLocalRepository(
+                clearStarted = cleanupStarted,
+                clearRelease = cleanupRelease,
+            ),
+        )
+
+        fixture.actions.signOut()
+        cleanupStarted.await()
+        fixture.actions.refreshSession(SessionRefreshTrigger.FOREGROUND)
+        runCurrent()
+
+        assertEquals(0, authProvider.refreshRequests)
+
+        cleanupRelease.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(0, authProvider.refreshRequests)
+        assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
+        fixture.state.value = fixture.state.value.copy(emailInput = "blocked@reguerta.app")
+        assertFalse(fixture.actions.signIn("blocked-secret"))
+        assertTrue(authProvider.signInRequests.isEmpty())
+    }
+
+    @Test
     fun `valid sign in forwards the route password snapshot`() = runTest {
         val signInResult = CompletableDeferred<AuthSignInResult>()
         val authProvider = ControlledAuthSessionProvider(signInResults = listOf(signInResult))
@@ -558,9 +602,11 @@ class SessionAuthActionsConcurrencyTest {
     }
 
     @Test
-    fun `stale refresh finalizer cannot clear ownership or timestamp of newer refresh`() = runTest {
+    fun `refresh requested while sign out owns cleanup is ignored`() = runTest {
         val firstRefresh = CompletableDeferred<AuthSessionRefreshResult>()
-        val secondRefresh = CompletableDeferred<AuthSessionRefreshResult>()
+        val secondRefresh = CompletableDeferred<AuthSessionRefreshResult>(
+            AuthSessionRefreshResult.NoSession,
+        )
         val authProvider = ControlledAuthSessionProvider(refreshResults = listOf(firstRefresh, secondRefresh))
         val principal = principal("refresh-owner")
         val fixture = fixture(
@@ -574,24 +620,13 @@ class SessionAuthActionsConcurrencyTest {
         fixture.actions.signOut()
         fixture.actions.refreshSession(SessionRefreshTrigger.STARTUP)
         runCurrent()
-        val requestsBeforePredecessorCompletion = authProvider.refreshRequests
 
         firstRefresh.complete(AuthSessionRefreshResult.Active(principal))
-        runCurrent()
-
-        val requestsAfterPredecessorCompletion = authProvider.refreshRequests
-        val newerRefreshStillOwnsFlag = fixture.isRefreshInFlight
-        val timestampBeforeNewerRefreshCompletion = fixture.lastRefreshAtMillis
-
-        secondRefresh.complete(AuthSessionRefreshResult.NoSession)
         advanceUntilIdle()
 
-        assertEquals(1, requestsBeforePredecessorCompletion)
-        assertEquals(2, requestsAfterPredecessorCompletion)
-        assertTrue(newerRefreshStillOwnsFlag)
-        assertEquals(null, timestampBeforeNewerRefreshCompletion)
+        assertEquals(1, authProvider.refreshRequests)
         assertFalse(fixture.isRefreshInFlight)
-        assertEquals(1_000L, fixture.lastRefreshAtMillis)
+        assertEquals(null, fixture.lastRefreshAtMillis)
         assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
     }
 

--- a/docs-es/decisions/0008-acotar-operaciones-moviles-de-sesion.md
+++ b/docs-es/decisions/0008-acotar-operaciones-moviles-de-sesion.md
@@ -1,0 +1,170 @@
+# ADR-0008: Acotar operaciones móviles de sesión sin liberar trabajo inseguro de Firebase Auth
+
+## Estado
+
+Aceptada
+
+## Fecha
+
+2026-07-28
+
+## Contexto
+
+Android e iOS serializan login, alta y refresco de sesión para que una operación
+antigua de Firebase Authentication no termine después de otra nueva y sustituya
+al usuario autenticado global del proceso. El issue #216 introdujo fences de
+generación y propietario, además del orden cleanup-antes-del-sucesor.
+
+Esos fences no acotan el progreso visible. Una operación Android vigente aún
+puede lanzar fuera de su resultado esperado y dejar incompleto el estado de
+presentación. En ambas plataformas, una llamada del SDK Firebase o de un
+repositorio puede ignorar la cancelación cooperativa y no retornar nunca,
+dejando bloqueado un spinner o el carril serializado de sesión.
+
+Cancelar no equivale a terminar físicamente. Los timeouts de coroutines Kotlin
+cancelan de forma cooperativa y las tareas Swift necesitan que la operación en
+ejecución observe la cancelación. Un race simple contra un temporizador puede
+recuperar al caller mientras una petición Firebase antigua continúa y después
+muta el singleton Auth compartido. Liberar entonces un sucesor reabriría #216.
+
+## Criterios de decisión
+
+- Recuperar la UI en un intervalo finito y comprobable.
+- Preservar el orden cleanup-antes-del-sucesor de #216.
+- No retener ni encolar otra contraseña detrás de trabajo no acotado.
+- Impedir que mutaciones tardías de Firebase Auth autoricen o expongan datos privados.
+- Aplicar la misma política observable en Android e iOS.
+- Evitar cambios en backend, Rules, Functions o datos live de Firebase.
+
+## Decisión
+
+Los clientes móviles usan un único carril serializado para `signIn`, `signUp`,
+`refreshCurrentSession` y la hidratación de sesión autorizada propiedad de esas
+operaciones.
+
+Cada operación recibe un deadline de aplicación de 30 segundos. El presupuesto
+empieza solo después de que el predecesor y su cleanup hayan drenado. Acota la
+propiedad de presentación, pero no garantiza que el SDK Firebase o un
+repositorio hayan terminado físicamente. La duración está centralizada y es
+inyectable para pruebas deterministas.
+
+Treinta segundos es el valor por defecto porque una operación de sesión puede
+componer Auth, recarga de usuario, refresco de token, autorización y lecturas de
+repositorio. Usa el techo de red de 30 segundos ya presente en la app y deja
+margen sobre los 15 segundos de una petición aislada a una Function autenticada.
+El valor puede cambiar sin debilitar el contrato de estados siguiente.
+
+En el instante del deadline solo un evento conserva la propiedad: el resultado
+o la transición de timeout. El ganador se selecciona mediante el fence de
+generación y propietario dentro de la frontera serializada de cada plataforma.
+
+Si gana el deadline, o una operación vigente falla inesperadamente después de
+invocar Auth, el cliente debe:
+
+1. Invalidar la propiedad de presentación antes de publicar estado.
+2. Limpiar spinners, tracking de refresh, loaders de features, datos privados y
+   routing de entorno en runtime.
+3. Publicar un estado signed-out o no autorizado recuperable. Un timeout no se
+   presenta como expiración demostrada de credenciales.
+4. Intentar `signOut` inmediato en Firebase y cancelar cooperativamente la operación.
+5. Conservar la operación física como barrera `DRAINING`.
+
+Mientras cualquier operación posee el carril (`ACTIVE`, cleanup o `DRAINING`),
+se rechazan login y alta adicionales en vez de encolarlos, y se ignora refresh.
+Así una tarea que espera detrás de trabajo que puede resultar no acotado no
+captura una segunda credencial. Cuando la llamada antigua finalmente retorna,
+su fence impide publicar. El cliente reconfirma el sign-out de Firebase Auth y
+espera y valida el cleanup compuesto de routing, dispositivo autorizado y
+metadatos locales ya iniciado antes de liberar el carril. Otro login solo puede
+empezar después de esa confirmación definitiva.
+El cleanup de seguridad asíncrono iniciado por un cierre manual también posee
+el carril de cleanup hasta que se haya confirmado.
+
+Si el SDK no retorna nunca, la UI queda recuperada y sin datos privados, pero el
+carril sigue fail-closed durante la vida del proceso. Reiniciar el proceso es la
+única recuperación segura porque el cliente no puede demostrar que trabajo Auth
+abandonado no mutará el singleton más tarde.
+
+Los proveedores Firebase Auth añaden checkpoints de cancelación inmediatamente
+después de awaits que pueden crear o restaurar un usuario autenticado y antes de
+otra suspensión. Si observan cancelación, ejecutan sign-out síncrono antes de
+retornar o propagarla. El cleanup definitivo exterior sigue siendo una segunda defensa.
+
+El cleanup definitivo solo se confirma cuando tienen éxito el sign-out de
+Firebase Auth, el reset del entorno en runtime, la eliminación del contexto de
+dispositivo autorizado y la eliminación de los metadatos locales de sesión que
+apliquen. Si falla cualquier paso crítico de seguridad, el cliente conserva un
+estado local no autorizado/fail-closed, no restaura datos privados y no libera
+el carril. La credencial ya entregada al SDK sigue retenida por ese trabajo en
+vuelo hasta que retorna; el diseño evita retener una segunda credencial al
+rechazar envíos durante `DRAINING`.
+
+Password reset queda fuera de esta decisión. No comparte el carril de #216 ni
+cambia el usuario autenticado. Podrá recibir otra política acotada sin heredar
+el contrato de cuarentena Auth.
+
+## Opciones consideradas
+
+### Envolver la operación en `withTimeout` o competir contra `Task.sleep`
+
+Descartada como garantía de seguridad. Ambos mecanismos solicitan cancelación
+cooperativa; no demuestran que haya terminado trabajo bloqueante o no cooperativo.
+
+### Separar el trabajo antiguo y permitir inmediatamente un sucesor
+
+Descartada porque un resultado Firebase tardío aún puede sustituir al usuario
+autenticado global después de que el sucesor tenga éxito.
+
+### Encolar el sucesor detrás de un carril ocupado
+
+Descartada para autenticación interactiva porque puede retener otra contraseña
+durante un tiempo ilimitado y no ofrece al usuario un contrato de progreso honesto.
+
+### Recuperar la UI y mantener el carril en cuarentena hasta el cleanup definitivo
+
+Seleccionada. Preserva el invariante de #216 y aporta recuperación visual
+acotada y comportamiento determinista.
+
+## Consecuencias
+
+### Positivas
+
+- La UI de sesión no mantiene un spinner indefinido tras el deadline.
+- Los resultados tardíos no publican autorización ni adelantan el cleanup.
+- Android e iOS comparten una política explícita de máquina de estados.
+- Las pruebas controlan el tiempo sin sleeps reales.
+- No interviene ningún despliegue backend ni migración Firebase legacy.
+
+### Negativas
+
+- Un proveedor que nunca retorna exige reiniciar la app antes de otro login.
+- Una llamada SDK en vuelo puede retener la credencial ya suministrada.
+- Timeout y checkpoints del proveedor añaden estado de ciclo de vida y pruebas.
+- El valor de 30 segundos puede requerir ajuste futuro con telemetría de producción.
+
+## Implementación y verificación
+
+- Android usa un watchdog basado en delay inyectado y tiempo virtual de coroutines.
+- iOS usa un sleeper `Duration` inyectado y controlado por las pruebas.
+- Ambas plataformas comprueban el vencimiento del deadline, excepciones vigentes
+  inesperadas, proveedores no cooperativos, sucesores rechazados mientras el
+  carril está ocupado, resultados tardíos, orden y fallo del cleanup definitivo,
+  cleanup del cierre manual, recuperación de refresh y login posterior.
+- Android prueba además la carrera atómica resultado/deadline y cada checkpoint
+  concreto de recarga, refresco de token y verificación. iOS prueba el wrapper
+  postmutación compartido por esos callsites, incluida la cancelación y la
+  propagación de un sign-out fallido. Los fallos ordinarios posteriores a una
+  mutación Auth también deben confirmar el sign-out antes de devolver un
+  resultado recuperable; de lo contrario propagan la transición a `DRAINING`.
+
+## Decisiones y trabajo relacionados
+
+- ADR-0003: Firebase como servicios backend.
+- ADR-0004: inyección raíz iOS y propiedad de Session/Auth.
+- GitHub issue #216: propiedad de operación y fences de resultados tardíos.
+- GitHub issue #218: implementación de operaciones de sesión acotadas.
+
+## Referencias
+
+- [Cancelación de Task en Apple](https://developer.apple.com/documentation/swift/task#Task-Cancellation)
+- [Cancelación de timeout en coroutines Kotlin](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/with-timeout.html)

--- a/docs/decisions/0008-bound-mobile-session-operations.md
+++ b/docs/decisions/0008-bound-mobile-session-operations.md
@@ -1,0 +1,172 @@
+# ADR-0008: Bound Mobile Session Operations Without Releasing Unsafe Firebase Auth Work
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-28
+
+## Context
+
+Android and iOS serialize sign-in, sign-up, and session refresh so an older
+Firebase Authentication operation cannot finish after a newer one and replace
+the process-wide authenticated user. Issue #216 introduced generation and
+ownership fences plus cleanup-before-successor ordering.
+
+Those fences do not bound user-visible progress. A current Android operation
+can still throw outside its expected result mapping and leave presentation
+state incomplete. On both platforms, a Firebase SDK call or repository can
+ignore cooperative cancellation and never return, leaving a spinner or the
+serialized session lane blocked.
+
+Cancellation is not physical termination. Kotlin coroutine timeouts cancel
+cooperatively, and Swift tasks require the running operation to observe
+cancellation. A simple race against a timer can therefore recover the caller
+while an older Firebase request continues and later mutates the shared Auth
+singleton. Releasing a successor at that point would reopen #216.
+
+## Decision Drivers
+
+- Recover the UI within a finite, testable interval.
+- Preserve cleanup-before-successor ordering from #216.
+- Never retain or enqueue another password behind unbounded work.
+- Keep late Firebase Auth mutations from authorizing or exposing private data.
+- Use the same observable policy on Android and iOS.
+- Avoid any Firebase backend, Rules, Functions, or live-data change.
+
+## Decision
+
+The mobile clients use one serialized session-operation lane for `signIn`,
+`signUp`, `refreshCurrentSession`, and the authorized-session hydration owned
+by those operations.
+
+An operation receives an application deadline of 30 seconds. The budget starts
+only after its predecessor and predecessor cleanup have drained. It is a bound
+on presentation ownership, not a guarantee that the Firebase SDK or a
+repository has physically stopped. The duration is centralized and injectable
+for deterministic tests.
+
+Thirty seconds is the default because a session operation can compose Auth,
+user reload, token refresh, authorization, and repository reads. It uses the
+existing 30-second network ceiling in the app and leaves headroom over the
+15-second timeout used by one isolated authenticated Function request. The
+value can change without weakening the state-machine contract below.
+
+Exactly one event wins ownership at the deadline: the operation result or the
+deadline transition. The winner is selected by the existing generation and
+owner fence under the platform's serialized state boundary.
+
+If the deadline wins, or a current operation fails unexpectedly after invoking
+Auth, the client must:
+
+1. Invalidate presentation ownership before publishing state.
+2. Clear session spinners, refresh tracking, feature loaders, private data, and
+   runtime environment routing.
+3. Publish a recoverable signed-out or unauthorized state. A timeout is not
+   presented as proven credential expiry.
+4. Attempt immediate Firebase `signOut` and cancel the operation cooperatively.
+5. Keep the physical operation as a `DRAINING` barrier.
+
+While any operation owns the lane (`ACTIVE`, cleanup, or `DRAINING`), additional
+sign-in and sign-up submissions are rejected rather than queued, and refresh is
+ignored. This prevents a second credential from being captured by a task waiting
+behind work that may later prove unbounded. When the old call finally returns,
+its fence prevents publication. The client reconfirms Firebase Auth sign-out and
+waits for and validates the composite routing, authorized-device, and local
+metadata cleanup already started before releasing the lane. A later login can
+start only after that definitive confirmation completes.
+Asynchronous security cleanup started by a manual sign-out also owns the cleanup
+lane until it has been confirmed.
+
+If the SDK never returns, the UI remains recovered and contains no private
+session data, but the lane remains fail-closed for the lifetime of the process.
+Restarting the process is the only safe recovery because the client cannot
+prove that abandoned Auth work will not mutate the singleton later.
+
+Firebase Auth providers add cancellation checkpoints immediately after awaits
+that can create or restore an authenticated user and before another suspension.
+If cancellation is observed, they synchronously sign out before returning or
+propagating cancellation. The outer definitive cleanup remains a second line
+of defense.
+
+Definitive cleanup is confirmed only after Firebase Auth sign-out, runtime
+environment reset, authorized-device context removal, and applicable local
+session metadata removal succeed. If any security-critical step fails, the
+client keeps a local unauthorized/fail-closed state, does not restore private
+data, and does not release the lane. The credential already passed to the SDK
+remains retained by that in-flight SDK work until it returns; the design
+prevents retaining a second credential by rejecting submissions during
+`DRAINING`.
+
+Password reset is outside this decision. It does not share the #216 lane or
+change the authenticated user. It can receive a separate bounded policy later
+without inheriting the Auth quarantine contract.
+
+## Considered Options
+
+### Wrap the operation in `withTimeout` or race it against `Task.sleep`
+
+Rejected as a safety guarantee. Both mechanisms request cooperative
+cancellation; they do not prove termination of blocking or non-cooperative SDK
+work.
+
+### Detach old work and immediately allow a successor
+
+Rejected because a late Firebase result can still replace the process-wide
+authenticated user after the successor succeeds.
+
+### Queue the successor behind an owned lane
+
+Rejected for interactive authentication because it can retain a new password
+for an unbounded interval and gives the user no honest progress contract.
+
+### Recover the UI and quarantine the lane until definitive cleanup
+
+Selected. It preserves the #216 invariant while giving the user bounded visual
+recovery and deterministic behavior.
+
+## Consequences
+
+### Positive
+
+- Session UI cannot spin indefinitely after the application deadline.
+- Late results cannot publish authorization or overtake cleanup.
+- Android and iOS share one explicit state-machine policy.
+- Tests can control time without real sleeps.
+- No backend rollout or legacy Firebase migration is involved.
+
+### Negative
+
+- A provider that never returns requires an app restart before another login.
+- An in-flight SDK call may retain the credential already supplied to it.
+- Timeout handling and provider checkpoints add lifecycle state and tests.
+- The 30-second default may need future tuning from production telemetry.
+
+## Implementation and Verification
+
+- Android uses an injected delay-driven watchdog and virtual coroutine time.
+- iOS uses an injected `Duration` sleeper controlled by tests.
+- Both platforms test deadline expiry, unexpected current exceptions,
+  non-cooperative providers, rejected successors while the lane is occupied,
+  late results, definitive cleanup ordering and failure, manual sign-out
+  cleanup, refresh recovery, and a later login.
+- Android additionally exercises the atomic result/deadline race and each
+  concrete reload, token-refresh, and verification checkpoint. iOS exercises
+  the shared post-mutation wrapper used by those call sites, including
+  cancellation and failed sign-out propagation. Ordinary failures after an
+  Auth mutation must also confirm sign-out before returning a recoverable
+  result; otherwise they propagate into `DRAINING`.
+
+## Related Decisions and Work
+
+- ADR-0003: Firebase as backend services.
+- ADR-0004: iOS root dependency injection and Session/Auth ownership.
+- GitHub issue #216: session operation ownership and late-result fences.
+- GitHub issue #218: bounded session operation implementation.
+
+## References
+
+- [Apple Task cancellation](https://developer.apple.com/documentation/swift/task#Task-Cancellation)
+- [Kotlin coroutine timeout cancellation](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/with-timeout.html)

--- a/ios/Reguerta/Reguerta/App/MyOrderFreshnessFeatureDependencies.swift
+++ b/ios/Reguerta/Reguerta/App/MyOrderFreshnessFeatureDependencies.swift
@@ -7,11 +7,12 @@ struct MyOrderFreshnessFeatureDependencies {
 
     static func live(
         db: Firestore = Firestore.firestore(),
+        localRepository: any CriticalDataFreshnessLocalRepository =
+            UserDefaultsCriticalDataFreshnessLocalRepository(),
         nowProvider: @escaping @Sendable () -> Int64 = {
             Int64(Date().timeIntervalSince1970 * 1_000)
         }
     ) -> MyOrderFreshnessFeatureDependencies {
-        let localRepository = UserDefaultsCriticalDataFreshnessLocalRepository()
         let remoteRepository = makeLiveRemoteRepository(db: db)
 
         return MyOrderFreshnessFeatureDependencies(
@@ -26,11 +27,12 @@ struct MyOrderFreshnessFeatureDependencies {
 
     static func preview(
         remoteConfig: CriticalDataFreshnessConfig? = nil,
+        localRepository: (any CriticalDataFreshnessLocalRepository)? = nil,
         nowProvider: @escaping @Sendable () -> Int64 = {
             Int64(Date().timeIntervalSince1970 * 1_000)
         }
     ) -> MyOrderFreshnessFeatureDependencies {
-        let localRepository = PreviewCriticalDataFreshnessLocalRepository()
+        let localRepository = localRepository ?? PreviewCriticalDataFreshnessLocalRepository()
 
         return MyOrderFreshnessFeatureDependencies(
             resolveCriticalDataFreshness: ResolveCriticalDataFreshnessUseCase(
@@ -72,16 +74,22 @@ private struct PreviewCriticalDataFreshnessRemoteRepository: CriticalDataFreshne
 @MainActor
 private final class PreviewCriticalDataFreshnessLocalRepository: CriticalDataFreshnessLocalRepository {
     private var metadata: CriticalDataFreshnessMetadata?
+    private(set) var writeGeneration: UInt64 = 0
 
     func getMetadata() -> CriticalDataFreshnessMetadata? {
         metadata
     }
 
-    func saveMetadata(_ metadata: CriticalDataFreshnessMetadata) {
+    func saveMetadata(
+        _ metadata: CriticalDataFreshnessMetadata,
+        ifWriteGeneration expectedWriteGeneration: UInt64
+    ) {
+        guard writeGeneration == expectedWriteGeneration else { return }
         self.metadata = metadata
     }
 
-    func clear() {
+    func clear() throws {
+        writeGeneration &+= 1
         metadata = nil
     }
 }

--- a/ios/Reguerta/Reguerta/App/ReguertaAppEnvironment.swift
+++ b/ios/Reguerta/Reguerta/App/ReguertaAppEnvironment.swift
@@ -39,11 +39,14 @@ struct ReguertaAppEnvironment {
         let notificationRepository = InMemoryNotificationRepository()
         let feedbackCenter = GlobalFeedbackCenter()
         let authorizedDeviceRegistrar = NoOpAuthorizedDeviceRegistrar()
+        let freshnessDependencies = MyOrderFreshnessFeatureDependencies.preview()
         let sessionViewModel = SessionViewModel(
             dependencies: .preview(
                 repository: memberRepository,
                 feedbackCenter: feedbackCenter,
-                authorizedDeviceRegistrar: authorizedDeviceRegistrar
+                authorizedDeviceRegistrar: authorizedDeviceRegistrar,
+                criticalDataFreshnessLocalRepository:
+                    freshnessDependencies.criticalDataFreshnessLocalRepository
             )
         )
         let accessRootViewModel = AccessRootViewModel(
@@ -55,7 +58,7 @@ struct ReguertaAppEnvironment {
             newsNotificationsFeatureDependencies: .preview(notificationRepository: notificationRepository),
             sharedProfileFeatureDependencies: .preview(),
             usersFeatureDependencies: .preview(memberRepository: memberRepository),
-            myOrderFreshnessFeatureDependencies: .preview(),
+            myOrderFreshnessFeatureDependencies: freshnessDependencies,
             bylawsFeatureDependencies: .preview(),
             startupVersionGateUseCase: ResolveStartupVersionGateUseCase(
                 repository: PreviewStartupVersionPolicyRepository()
@@ -80,19 +83,25 @@ struct ReguertaAppEnvironment {
         let nowMillisProvider: @MainActor () -> Int64 = {
             DevelopmentTimeMachine.shared.nowMillis()
         }
-        let sessionViewModel = SessionViewModel(
-            dependencies: .preview(
-                repository: memberRepository,
-                feedbackCenter: feedbackCenter,
-                authorizedDeviceRegistrar: authorizedDeviceRegistrar
-            )
-        )
         let freshnessConfig = CriticalDataFreshnessConfig(
             cacheExpirationMinutes: 15,
             remoteTimestampsMillis: Dictionary(
                 uniqueKeysWithValues: CriticalCollection.allCases.map {
                     ($0, 1_000)
                 }
+            )
+        )
+        let freshnessDependencies = MyOrderFreshnessFeatureDependencies.preview(
+            remoteConfig: freshnessConfig,
+            nowProvider: { DevelopmentTimeMachine.shared.nowMillis() }
+        )
+        let sessionViewModel = SessionViewModel(
+            dependencies: .preview(
+                repository: memberRepository,
+                feedbackCenter: feedbackCenter,
+                authorizedDeviceRegistrar: authorizedDeviceRegistrar,
+                criticalDataFreshnessLocalRepository:
+                    freshnessDependencies.criticalDataFreshnessLocalRepository
             )
         )
         let accessRootViewModel = AccessRootViewModel(
@@ -120,10 +129,7 @@ struct ReguertaAppEnvironment {
             usersFeatureDependencies: .preview(
                 memberRepository: memberRepository
             ),
-            myOrderFreshnessFeatureDependencies: .preview(
-                remoteConfig: freshnessConfig,
-                nowProvider: { DevelopmentTimeMachine.shared.nowMillis() }
-            ),
+            myOrderFreshnessFeatureDependencies: freshnessDependencies,
             bylawsFeatureDependencies: .preview(),
             startupVersionGateUseCase: ResolveStartupVersionGateUseCase(
                 repository: PreviewStartupVersionPolicyRepository()
@@ -150,6 +156,7 @@ private struct LiveRootDependencies {
     let imagePipelineManager: FirebaseImagePipelineManager
     let notificationRepository: FirestoreNotificationRepository
     let authorizedDeviceRegistrar: FirebaseAuthorizedDeviceCoordinator
+    let criticalDataFreshnessLocalRepository: UserDefaultsCriticalDataFreshnessLocalRepository
 
     init(db: Firestore = Firestore.firestore()) {
         self.db = db
@@ -170,6 +177,8 @@ private struct LiveRootDependencies {
         )
         self.imagePipelineManager = FirebaseImagePipelineManager()
         self.notificationRepository = FirestoreNotificationRepository(db: db)
+        self.criticalDataFreshnessLocalRepository =
+            UserDefaultsCriticalDataFreshnessLocalRepository()
         self.authorizedDeviceRegistrar = FirebaseAuthorizedDeviceCoordinator(
             repository: FirestoreDeviceRegistrationRepository(db: db),
             keychainStore: KeychainStore()
@@ -194,6 +203,8 @@ private func makeLiveSessionViewModel(
             dependencies: .live(
                 db: dependencies.db,
                 feedbackCenter: feedbackCenter,
+                criticalDataFreshnessLocalRepository:
+                    dependencies.criticalDataFreshnessLocalRepository,
                 developImpersonationEnabled: dependencies.developImpersonationEnabled,
                 nowMillisProvider: { DevelopmentTimeMachine.shared.nowMillis() }
             )
@@ -210,6 +221,8 @@ private func makeLiveSessionViewModel(
                 client: dependencies.functionsClient
             ),
             authorizedDeviceRegistrar: dependencies.authorizedDeviceRegistrar,
+            criticalDataFreshnessLocalRepository:
+                dependencies.criticalDataFreshnessLocalRepository,
             environmentRouter: RuntimeSessionEnvironmentRouter(),
             developImpersonationEnabled: dependencies.developImpersonationEnabled,
             nowMillisProvider: { DevelopmentTimeMachine.shared.nowMillis() }
@@ -256,7 +269,8 @@ private func makeLiveAccessRootViewModel(
             memberAdministrationRepository: dependencies.memberAdministrationRepository
         ),
         myOrderFreshnessFeatureDependencies: MyOrderFreshnessFeatureDependencies.live(
-            db: dependencies.db
+            db: dependencies.db,
+            localRepository: dependencies.criticalDataFreshnessLocalRepository
         ),
         bylawsFeatureDependencies: .live(),
         startupVersionGateUseCase: ResolveStartupVersionGateUseCase(

--- a/ios/Reguerta/Reguerta/Data/Access/FirebaseAuthSessionProvider.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/FirebaseAuthSessionProvider.swift
@@ -14,17 +14,35 @@ struct FirebaseAuthSessionProvider: AuthSessionProvider {
         let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
 
         do {
-            let result = try await auth.signIn(withEmail: trimmedEmail, password: password)
-            try await result.user.reload()
-            guard let refreshedUser = auth.currentUser else {
-                return .failure(.unknown)
+            let principal = try await awaitFirebaseAuthenticationFlow {
+                try await auth.signIn(withEmail: trimmedEmail, password: password)
+            } continuation: { result in
+                try await awaitFirebaseAuthenticationMutation {
+                    try await result.user.reload()
+                } signOut: {
+                    signOut()
+                }
+                guard let refreshedUser = auth.currentUser else {
+                    throw FirebaseIDTokenError.noAuthenticatedUser
+                }
+                _ = try await awaitFirebaseAuthenticationMutation {
+                    try await refreshedUser.getIDTokenResult(forcingRefresh: true)
+                } signOut: {
+                    signOut()
+                }
+                return AuthPrincipal(
+                    uid: refreshedUser.uid,
+                    email: normalizedEmail(refreshedUser.email ?? trimmedEmail)
+                )
+            } signOut: {
+                signOut()
             }
-            _ = try await refreshedUser.getIDTokenResult(forcingRefresh: true)
-            let principal = AuthPrincipal(
-                uid: refreshedUser.uid,
-                email: normalizedEmail(refreshedUser.email ?? trimmedEmail)
-            )
             return .success(principal)
+        } catch let failure as FirebaseAuthenticationContinuationError {
+            return .failureAfterAuthenticationMutation(
+                reason: mapFirebaseAuthError(failure.underlyingError),
+                signedOut: failure.signedOut
+            )
         } catch {
             return .failure(mapFirebaseAuthError(error))
         }
@@ -34,13 +52,27 @@ struct FirebaseAuthSessionProvider: AuthSessionProvider {
         let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
 
         do {
-            let result = try await auth.createUser(withEmail: trimmedEmail, password: password)
-            let verificationSent = await sendVerificationEmail(to: result.user)
-            let signedOut = signOut()
-            return .verificationRequired(
-                email: normalizedEmail(result.user.email ?? trimmedEmail),
-                verificationSent: verificationSent,
-                signedOut: signedOut
+            return try await awaitFirebaseAuthenticationFlow {
+                try await auth.createUser(withEmail: trimmedEmail, password: password)
+            } continuation: { result in
+                let verificationSent = try await awaitFirebaseAuthenticationMutation {
+                    await sendVerificationEmail(to: result.user)
+                } signOut: {
+                    signOut()
+                }
+                let signedOut = signOut()
+                return .verificationRequired(
+                    email: normalizedEmail(result.user.email ?? trimmedEmail),
+                    verificationSent: verificationSent,
+                    signedOut: signedOut
+                )
+            } signOut: {
+                signOut()
+            }
+        } catch let failure as FirebaseAuthenticationContinuationError {
+            return .failureAfterAuthenticationMutation(
+                reason: mapFirebaseAuthError(failure.underlyingError),
+                signedOut: failure.signedOut
             )
         } catch {
             return .failure(mapFirebaseAuthError(error))
@@ -69,17 +101,34 @@ struct FirebaseAuthSessionProvider: AuthSessionProvider {
         }
 
         do {
-            try await user.reload()
-            guard let refreshedUser = auth.currentUser else {
+            return try await awaitFirebaseAuthenticationFlow {
+                try await user.reload()
+            } continuation: {
+                guard let refreshedUser = auth.currentUser else {
+                    return .expired
+                }
+                _ = try await awaitFirebaseAuthenticationMutation {
+                    try await refreshedUser.getIDTokenResult(forcingRefresh: true)
+                } signOut: {
+                    signOut()
+                }
+
+                let principal = AuthPrincipal(
+                    uid: refreshedUser.uid,
+                    email: normalizedEmail(refreshedUser.email ?? "")
+                )
+                return .active(principal)
+            } signOut: {
+                signOut()
+            }
+        } catch let failure as FirebaseAuthenticationContinuationError {
+            if isExpiredSessionError(failure.underlyingError) {
                 return .expired
             }
-            _ = try await refreshedUser.getIDTokenResult(forcingRefresh: true)
-
-            let principal = AuthPrincipal(
-                uid: refreshedUser.uid,
-                email: normalizedEmail(refreshedUser.email ?? "")
+            return .failureAfterAuthenticationMutation(
+                reason: mapFirebaseAuthError(failure.underlyingError),
+                signedOut: failure.signedOut
             )
-            return .active(principal)
         } catch {
             if isExpiredSessionError(error) {
                 return .expired
@@ -107,6 +156,55 @@ struct FirebaseAuthSessionProvider: AuthSessionProvider {
         } catch {
             return false
         }
+    }
+}
+
+@MainActor
+func awaitFirebaseAuthenticationMutation<Value>(
+    _ mutation: () async throws -> Value,
+    signOut: () -> Bool
+) async throws -> Value {
+    do {
+        let value = try await mutation()
+        try Task.checkCancellation()
+        return value
+    } catch let error as CancellationError {
+        throw FirebaseAuthenticationContinuationError(
+            underlyingError: error,
+            signedOut: signOut()
+        )
+    }
+}
+
+struct FirebaseAuthenticationContinuationError: Error {
+    let underlyingError: any Error
+    let signedOut: Bool
+}
+
+@MainActor
+func awaitFirebaseAuthenticationFlow<MutationValue, ResultValue>(
+    _ mutation: () async throws -> MutationValue,
+    continuation: (MutationValue) async throws -> ResultValue,
+    signOut: () -> Bool
+) async throws -> ResultValue {
+    let mutationValue = try await awaitFirebaseAuthenticationMutation(
+        mutation,
+        signOut: signOut
+    )
+    do {
+        return try await continuation(mutationValue)
+    } catch let failure as FirebaseAuthenticationContinuationError {
+        throw failure
+    } catch let error as CancellationError {
+        throw FirebaseAuthenticationContinuationError(
+            underlyingError: error,
+            signedOut: signOut()
+        )
+    } catch {
+        throw FirebaseAuthenticationContinuationError(
+            underlyingError: error,
+            signedOut: signOut()
+        )
     }
 }
 

--- a/ios/Reguerta/Reguerta/Data/Freshness/UserDefaultsCriticalDataFreshnessLocalRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Freshness/UserDefaultsCriticalDataFreshnessLocalRepository.swift
@@ -8,6 +8,10 @@ struct UserDefaultsCriticalDataFreshnessLocalRepository: CriticalDataFreshnessLo
         self.userDefaults = userDefaults
     }
 
+    var writeGeneration: UInt64 {
+        (userDefaults.object(forKey: Keys.writeGeneration) as? NSNumber)?.uint64Value ?? 0
+    }
+
     func getMetadata() -> CriticalDataFreshnessMetadata? {
         let validatedAtMillis = (userDefaults.object(forKey: Keys.validatedAt) as? NSNumber)?.int64Value
             ?? Int64(userDefaults.integer(forKey: Keys.validatedAt))
@@ -37,7 +41,11 @@ struct UserDefaultsCriticalDataFreshnessLocalRepository: CriticalDataFreshnessLo
         )
     }
 
-    func saveMetadata(_ metadata: CriticalDataFreshnessMetadata) {
+    func saveMetadata(
+        _ metadata: CriticalDataFreshnessMetadata,
+        ifWriteGeneration expectedWriteGeneration: UInt64
+    ) {
+        guard writeGeneration == expectedWriteGeneration else { return }
         userDefaults.set(metadata.validatedAtMillis, forKey: Keys.validatedAt)
         userDefaults.set(metadata.environment.rawValue, forKey: Keys.environment)
         for (collection, timestamp) in metadata.acknowledgedTimestampsMillis {
@@ -45,7 +53,11 @@ struct UserDefaultsCriticalDataFreshnessLocalRepository: CriticalDataFreshnessLo
         }
     }
 
-    func clear() {
+    func clear() throws {
+        userDefaults.set(
+            NSNumber(value: writeGeneration &+ 1),
+            forKey: Keys.writeGeneration
+        )
         userDefaults.removeObject(forKey: Keys.validatedAt)
         userDefaults.removeObject(forKey: Keys.environment)
         for collection in CriticalCollection.allCases {
@@ -55,6 +67,7 @@ struct UserDefaultsCriticalDataFreshnessLocalRepository: CriticalDataFreshnessLo
 }
 
 private enum Keys {
+    static let writeGeneration = "critical_data_freshness.write_generation"
     static let validatedAt = "critical_data_freshness.validated_at"
     static let environment = "critical_data_freshness.environment"
 }

--- a/ios/Reguerta/Reguerta/Domain/Access/AuthSessionProvider.swift
+++ b/ios/Reguerta/Reguerta/Domain/Access/AuthSessionProvider.swift
@@ -16,11 +16,13 @@ enum AuthSignInResult: Equatable, Sendable {
     case success(AuthPrincipal)
     case emailVerificationRequired(email: String, verificationResent: Bool, signedOut: Bool)
     case failure(AuthSignInFailureReason)
+    case failureAfterAuthenticationMutation(reason: AuthSignInFailureReason, signedOut: Bool)
 }
 
 enum AuthSignUpResult: Equatable, Sendable {
     case verificationRequired(email: String, verificationSent: Bool, signedOut: Bool)
     case failure(AuthSignInFailureReason)
+    case failureAfterAuthenticationMutation(reason: AuthSignInFailureReason, signedOut: Bool)
 }
 
 enum AuthPasswordResetResult: Equatable, Sendable {
@@ -33,6 +35,7 @@ enum AuthSessionRefreshResult: Equatable, Sendable {
     case active(AuthPrincipal)
     case emailVerificationRequired(email: String)
     case failure(AuthSignInFailureReason)
+    case failureAfterAuthenticationMutation(reason: AuthSignInFailureReason, signedOut: Bool)
     case expired
 }
 

--- a/ios/Reguerta/Reguerta/Domain/Freshness/CriticalDataFreshnessModels.swift
+++ b/ios/Reguerta/Reguerta/Domain/Freshness/CriticalDataFreshnessModels.swift
@@ -31,7 +31,17 @@ protocol CriticalDataFreshnessRemoteRepository: Sendable {
 
 @MainActor
 protocol CriticalDataFreshnessLocalRepository: Sendable {
+    var writeGeneration: UInt64 { get }
     func getMetadata() -> CriticalDataFreshnessMetadata?
-    func saveMetadata(_ metadata: CriticalDataFreshnessMetadata)
-    func clear()
+    func saveMetadata(
+        _ metadata: CriticalDataFreshnessMetadata,
+        ifWriteGeneration writeGeneration: UInt64
+    )
+    func clear() throws
+}
+
+extension CriticalDataFreshnessLocalRepository {
+    func saveMetadata(_ metadata: CriticalDataFreshnessMetadata) {
+        saveMetadata(metadata, ifWriteGeneration: writeGeneration)
+    }
 }

--- a/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+AuthActions.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+AuthActions.swift
@@ -2,6 +2,7 @@ import Foundation
 
 extension SessionViewModel {
     func signIn() {
+        guard sessionOperationState == .idle else { return }
         let email = normalizeAccessEmail(emailInput)
         let password = passwordInput
         feedbackCenter.clear()
@@ -12,42 +13,38 @@ extension SessionViewModel {
             return
         }
 
-        let operation = beginSessionOperation()
+        guard let operation = beginSessionOperation(principalEmail: email) else { return }
         let provider = authSessionProvider
         isAuthenticating = true
         sessionOperationTask = Task { @MainActor [weak self, provider] in
+            defer {
+                self?.finishSessionOperationAfterProviderReturn(operation.generation)
+            }
             await operation.predecessor?.value
             guard self?.isCurrentSessionOperation(operation.generation) == true else { return }
+            self?.startSessionOperationTimeout(operation.generation)
 
             let authResult = await provider.signIn(email: email, password: password)
             guard let self else {
                 _ = provider.signOut()
                 return
             }
-            defer { self.finishSessionOperation(operation.generation) }
             guard isCurrentSessionOperation(operation.generation) else {
-                _ = provider.signOut()
+                if !isDrainingSessionOperation(operation.generation) {
+                    _ = provider.signOut()
+                }
                 return
             }
 
-            switch authResult {
-            case .success(let principal):
-                await applyAuthorizedSession(principal: principal, generation: operation.generation)
-            case .emailVerificationRequired(let email, let verificationResent, let signedOut):
-                applyEmailVerificationRequiredSession(
-                    email: email,
-                    firebaseSignOutSucceeded: signedOut,
-                    feedbackMessageKey: verificationResent
-                        ? AccessL10nKey.authInfoVerificationResent
-                        : AccessL10nKey.authInfoVerificationPending
-                )
-            case .failure(let reason):
-                applySignInFailure(reason)
-            }
+            await applySignInResult(
+                authResult,
+                generation: operation.generation
+            )
         }
     }
 
     func signUp() {
+        guard sessionOperationState == .idle else { return }
         let email = normalizeAccessEmail(registerEmailInput)
         let password = registerPasswordInput
         let repeatedPassword = registerRepeatPasswordInput
@@ -60,36 +57,77 @@ extension SessionViewModel {
             return
         }
 
-        let operation = beginSessionOperation()
+        guard let operation = beginSessionOperation(principalEmail: email) else { return }
         let provider = authSessionProvider
         isRegistering = true
         sessionOperationTask = Task { @MainActor [weak self, provider] in
+            defer {
+                self?.finishSessionOperationAfterProviderReturn(operation.generation)
+            }
             await operation.predecessor?.value
             guard self?.isCurrentSessionOperation(operation.generation) == true else { return }
+            self?.startSessionOperationTimeout(operation.generation)
 
             let authResult = await provider.signUp(email: email, password: password)
             guard let self else {
                 _ = provider.signOut()
                 return
             }
-            defer { self.finishSessionOperation(operation.generation) }
             guard isCurrentSessionOperation(operation.generation) else {
-                _ = provider.signOut()
+                if !isDrainingSessionOperation(operation.generation) {
+                    _ = provider.signOut()
+                }
                 return
             }
 
-            switch authResult {
-            case .verificationRequired(let email, let verificationSent, let signedOut):
-                applyEmailVerificationRequiredSession(
-                    email: email,
-                    firebaseSignOutSucceeded: signedOut,
-                    feedbackMessageKey: verificationSent
-                        ? AccessL10nKey.authInfoVerificationSent
-                        : AccessL10nKey.authInfoVerificationPending
-                )
-            case .failure(let reason):
-                applySignUpFailure(reason)
-            }
+            applySignUpResult(authResult)
+        }
+    }
+
+    private func applySignInResult(
+        _ result: AuthSignInResult,
+        generation: UInt64
+    ) async {
+        switch result {
+        case .success(let principal):
+            await applyAuthorizedSession(principal: principal, generation: generation)
+        case .emailVerificationRequired(let email, let verificationResent, let signedOut):
+            applyEmailVerificationRequiredSession(
+                email: email,
+                firebaseSignOutSucceeded: signedOut,
+                feedbackMessageKey: verificationResent
+                    ? AccessL10nKey.authInfoVerificationResent
+                    : AccessL10nKey.authInfoVerificationPending
+            )
+        case .failure(let reason):
+            applySignInFailure(reason)
+        case .failureAfterAuthenticationMutation(let reason, let signedOut):
+            applyLocalSessionTermination(
+                firebaseSignOutSucceeded: signedOut,
+                showsExpiredDialog: false
+            )
+            applySignInFailure(reason)
+        }
+    }
+
+    private func applySignUpResult(_ result: AuthSignUpResult) {
+        switch result {
+        case .verificationRequired(let email, let verificationSent, let signedOut):
+            applyEmailVerificationRequiredSession(
+                email: email,
+                firebaseSignOutSucceeded: signedOut,
+                feedbackMessageKey: verificationSent
+                    ? AccessL10nKey.authInfoVerificationSent
+                    : AccessL10nKey.authInfoVerificationPending
+            )
+        case .failure(let reason):
+            applySignUpFailure(reason)
+        case .failureAfterAuthenticationMutation(let reason, let signedOut):
+            applyLocalSessionTermination(
+                firebaseSignOutSucceeded: signedOut,
+                showsExpiredDialog: false
+            )
+            applySignUpFailure(reason)
         }
     }
 
@@ -143,24 +181,29 @@ extension SessionViewModel {
     func refreshSession(trigger: SessionRefreshTrigger) {
         guard canStartSessionRefresh(trigger: trigger) else { return }
 
-        let operation = beginSessionOperation()
+        guard let operation = beginSessionOperation(
+            principalEmail: currentPrincipalEmail
+        ) else { return }
         let provider = authSessionProvider
         isSessionRefreshInFlight = true
         let hadAuthenticatedSession = mode.isAuthenticatedSession
         sessionOperationTask = Task { @MainActor [weak self, provider] in
+            defer {
+                self?.finishSessionOperationAfterProviderReturn(operation.generation)
+            }
             await operation.predecessor?.value
             guard self?.isCurrentSessionOperation(operation.generation) == true else { return }
+            self?.startSessionOperationTimeout(operation.generation)
 
             let result = await provider.refreshCurrentSession()
             guard let self else {
                 _ = provider.signOut()
                 return
             }
-            defer {
-                self.finishSessionOperation(operation.generation)
-            }
             guard isCurrentSessionOperation(operation.generation) else {
-                _ = provider.signOut()
+                if !isDrainingSessionOperation(operation.generation) {
+                    _ = provider.signOut()
+                }
                 return
             }
             await applySessionRefreshResult(

--- a/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+AuthSessionSupport.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+AuthSessionSupport.swift
@@ -119,11 +119,11 @@ extension SessionViewModel {
             await handleExpiredSession()
         } catch {
             guard isCurrentSessionOperation(generation) else { return }
-            feedbackCenter.show(AccessL10nKey.authErrorNetwork)
-            applyUnauthorizedSession(
-                principalEmail: principal.email,
-                reason: .userAccessRestricted
+            applyLocalSessionTermination(
+                firebaseSignOutSucceeded: authSessionProvider.signOut(),
+                showsExpiredDialog: false
             )
+            feedbackCenter.show(AccessL10nKey.authErrorNetwork)
         }
     }
 
@@ -134,66 +134,7 @@ extension SessionViewModel {
         )
     }
 
-    func applyLocalSessionTermination(
-        firebaseSignOutSucceeded: Bool,
-        showsExpiredDialog: Bool
-    ) {
-        let principalEmail = currentPrincipalEmail
-        prepareForLocalSessionTermination()
-        if firebaseSignOutSucceeded {
-            mode = .signedOut
-        } else {
-            mode = .unauthorized(
-                email: principalEmail,
-                reason: .userAccessRestricted
-            )
-            feedbackCenter.show(AccessL10nKey.authErrorUnknown)
-        }
-        showSessionExpiredDialog = showsExpiredDialog
-        showUnauthorizedDialog = !firebaseSignOutSucceeded && !showsExpiredDialog
-    }
-
-    func applyEmailVerificationRequiredSession(
-        email: String,
-        firebaseSignOutSucceeded: Bool,
-        feedbackMessageKey: String
-    ) {
-        prepareForLocalSessionTermination()
-        mode = firebaseSignOutSucceeded
-            ? .signedOut
-            : .unauthorized(email: email, reason: .emailVerificationRequired)
-        feedbackCenter.show(feedbackMessageKey)
-    }
-
-    private func prepareForLocalSessionTermination() {
-        let deviceSessionLease = authorizedDeviceSessionLease
-        authorizedDeviceSessionLease = nil
-        invalidateSessionOperation()
-        clearSessionRefreshTracking()
-        environmentRouter.resetToBaseEnvironment()
-        if let deviceSessionLease {
-            Task {
-                do {
-                    try await authorizedDeviceRegistrar.clearAuthorization(
-                        ifOwnedBy: deviceSessionLease
-                    )
-                } catch is CancellationError {
-                    return
-                } catch {
-                    // The live coordinator records private diagnostics; local logout must complete.
-                }
-            }
-        }
-        resetAccessCredentialsAndErrors()
-        isAuthenticating = false
-        isRegistering = false
-        isRecoveringPassword = false
-        feedbackCenter.clear()
-        showSessionExpiredDialog = false
-        showUnauthorizedDialog = false
-    }
-
-    private var currentPrincipalEmail: String {
+    var currentPrincipalEmail: String {
         switch mode {
         case .authorized(let session):
             return session.principal.email
@@ -225,7 +166,7 @@ extension SessionViewModel {
     }
 
     func canStartSessionRefresh(trigger: SessionRefreshTrigger) -> Bool {
-        guard !isAuthenticating, !isRegistering else { return false }
+        guard sessionOperationState == .idle, !isAuthenticating, !isRegistering else { return false }
         return sessionRefreshPolicy.shouldRefresh(
             trigger: trigger,
             lastRefreshAtMillis: lastSessionRefreshAtMillis,
@@ -255,40 +196,16 @@ extension SessionViewModel {
         case .failure(let reason):
             let mapped = mapAuthFailure(reason, flow: .signIn)
             feedbackCenter.show(mapped.globalMessageKey)
+        case .failureAfterAuthenticationMutation(let reason, let signedOut):
+            let mapped = mapAuthFailure(reason, flow: .signIn)
+            applyLocalSessionTermination(
+                firebaseSignOutSucceeded: signedOut,
+                showsExpiredDialog: false
+            )
+            feedbackCenter.show(mapped.globalMessageKey)
         case .expired:
             await handleExpiredSession()
         }
-    }
-
-    func beginSessionOperation() -> SessionOperationContext {
-        let predecessor = invalidateSessionOperation()
-        return SessionOperationContext(
-            generation: sessionOperationGeneration,
-            predecessor: predecessor
-        )
-    }
-
-    @discardableResult
-    func invalidateSessionOperation() -> Task<Void, Never>? {
-        let invalidatedTask = sessionOperationTask
-        invalidatedTask?.cancel()
-        sessionOperationGeneration += 1
-        isAuthenticating = false
-        isRegistering = false
-        isSessionRefreshInFlight = false
-        return invalidatedTask
-    }
-
-    func isCurrentSessionOperation(_ generation: UInt64) -> Bool {
-        !Task.isCancelled && generation == sessionOperationGeneration
-    }
-
-    func finishSessionOperation(_ generation: UInt64) {
-        guard generation == sessionOperationGeneration else { return }
-        sessionOperationTask = nil
-        isAuthenticating = false
-        isRegistering = false
-        isSessionRefreshInFlight = false
     }
 
     private func applyAuthorizedSession(
@@ -302,11 +219,11 @@ extension SessionViewModel {
             members = try await repository.members(visibleTo: member)
         } catch {
             guard isCurrentSessionOperation(generation) else { return }
-            feedbackCenter.show(AccessL10nKey.authErrorNetwork)
-            applyUnauthorizedSession(
-                principalEmail: principal.email,
-                reason: .userAccessRestricted
+            applyLocalSessionTermination(
+                firebaseSignOutSucceeded: authSessionProvider.signOut(),
+                showsExpiredDialog: false
             )
+            feedbackCenter.show(AccessL10nKey.authErrorNetwork)
             return
         }
         guard isCurrentSessionOperation(generation) else { return }

--- a/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+SessionOperationLifecycle.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+SessionOperationLifecycle.swift
@@ -1,0 +1,310 @@
+import Foundation
+
+extension SessionViewModel {
+    func applyLocalSessionTermination(
+        firebaseSignOutSucceeded: Bool,
+        showsExpiredDialog: Bool
+    ) {
+        let principalEmail = sessionOperationState == .idle
+            ? currentPrincipalEmail
+            : sessionOperationPrincipalEmail
+        let hadOwnedSessionOperation = prepareForLocalSessionTermination()
+        if firebaseSignOutSucceeded {
+            mode = .signedOut
+        } else {
+            mode = .unauthorized(
+                email: principalEmail,
+                reason: .userAccessRestricted
+            )
+            feedbackCenter.show(AccessL10nKey.authErrorUnknown)
+        }
+        showSessionExpiredDialog = showsExpiredDialog
+        showUnauthorizedDialog = !firebaseSignOutSucceeded && !showsExpiredDialog
+        if !hadOwnedSessionOperation {
+            startStandaloneSessionTerminationBarrier(
+                firebaseSignOutSucceeded: firebaseSignOutSucceeded,
+                principalEmail: principalEmail
+            )
+        }
+    }
+
+    func applyEmailVerificationRequiredSession(
+        email: String,
+        firebaseSignOutSucceeded: Bool,
+        feedbackMessageKey: String
+    ) {
+        let hadOwnedSessionOperation = prepareForLocalSessionTermination()
+        mode = firebaseSignOutSucceeded
+            ? .signedOut
+            : .unauthorized(email: email, reason: .emailVerificationRequired)
+        feedbackCenter.show(feedbackMessageKey)
+        if !hadOwnedSessionOperation {
+            startStandaloneSessionTerminationBarrier(
+                firebaseSignOutSucceeded: firebaseSignOutSucceeded,
+                principalEmail: email
+            )
+        }
+    }
+
+    func beginSessionOperation(principalEmail: String) -> SessionOperationContext? {
+        guard sessionOperationState == .idle else { return nil }
+        let predecessor = invalidateSessionOperation()
+        sessionOperationPrincipalEmail = principalEmail
+        sessionOperationState = .active(generation: sessionOperationGeneration)
+        return SessionOperationContext(
+            generation: sessionOperationGeneration,
+            predecessor: predecessor,
+            principalEmail: principalEmail
+        )
+    }
+
+    @discardableResult
+    func invalidateSessionOperation() -> Task<Void, Never>? {
+        let invalidatedTask = sessionOperationTask
+        invalidatedTask?.cancel()
+        switch sessionOperationState {
+        case .draining:
+            isAuthenticating = false
+            isRegistering = false
+            isSessionRefreshInFlight = false
+            return invalidatedTask
+        case .active(let generation):
+            sessionOperationTimeoutTask?.cancel()
+            sessionOperationTimeoutTask = nil
+            sessionOperationState = .draining(generation: generation)
+            isAuthenticating = false
+            isRegistering = false
+            isSessionRefreshInFlight = false
+            return invalidatedTask
+        case .idle:
+            break
+        }
+        sessionOperationTimeoutTask?.cancel()
+        sessionOperationTimeoutTask = nil
+        sessionOperationGeneration &+= 1
+        sessionOperationState = .idle
+        isAuthenticating = false
+        isRegistering = false
+        isSessionRefreshInFlight = false
+        return invalidatedTask
+    }
+
+    func isCurrentSessionOperation(_ generation: UInt64) -> Bool {
+        guard !Task.isCancelled, generation == sessionOperationGeneration else {
+            return false
+        }
+        return sessionOperationState != .draining(generation: generation)
+    }
+
+    func finishSessionOperation(_ generation: UInt64) {
+        guard generation == sessionOperationGeneration else { return }
+        guard sessionOperationState == .active(generation: generation) ||
+            sessionOperationState == .draining(generation: generation) else { return }
+        guard sessionTerminationCleanupTask == nil else { return }
+        sessionOperationTimeoutTask?.cancel()
+        sessionOperationTimeoutTask = nil
+        sessionOperationTask = nil
+        sessionOperationState = .idle
+        sessionOperationPrincipalEmail = ""
+        isAuthenticating = false
+        isRegistering = false
+        isSessionRefreshInFlight = false
+    }
+
+    func startSessionOperationTimeout(_ generation: UInt64) {
+        guard sessionOperationState == .active(generation: generation) else { return }
+        let timeout = sessionOperationTimeout
+        let sleeper = sessionOperationSleeper
+
+        sessionOperationTimeoutTask = Task { @MainActor [weak self, sleeper] in
+            do {
+                try await sleeper(timeout)
+                try Task.checkCancellation()
+            } catch {
+                self?.finishSessionOperationTimeout(generation)
+                return
+            }
+            self?.handleSessionOperationTimeout(generation)
+        }
+    }
+
+    func finishSessionOperationAfterProviderReturn(_ generation: UInt64) {
+        if sessionOperationState == .draining(generation: generation) {
+            guard authSessionProvider.signOut() else {
+                applyDefinitiveSessionCleanupFailure()
+                return
+            }
+            if let cleanupTask = sessionTerminationCleanupTask {
+                startSessionTerminationCleanupBarrier(
+                    cleanupTask,
+                    generation: generation,
+                    cleanupGeneration: sessionTerminationCleanupGeneration
+                )
+                return
+            }
+        }
+        finishSessionOperation(generation)
+    }
+
+    func isDrainingSessionOperation(_ generation: UInt64) -> Bool {
+        sessionOperationState == .draining(generation: generation)
+    }
+
+    @discardableResult
+    private func prepareForLocalSessionTermination() -> Bool {
+        let deviceSessionLease = authorizedDeviceSessionLease
+        let hadOwnedSessionOperation = sessionOperationState != .idle
+        authorizedDeviceSessionLease = nil
+        invalidateSessionOperation()
+        clearSessionRefreshTracking()
+        environmentRouter.resetToBaseEnvironment()
+        let freshnessCleanupSucceeded: Bool
+        do {
+            try criticalDataFreshnessLocalRepository.clear()
+            freshnessCleanupSucceeded = true
+        } catch {
+            freshnessCleanupSucceeded = false
+        }
+        let cleanupTask: Task<Bool, Never>?
+        if let deviceSessionLease {
+            cleanupTask = Task { [authorizedDeviceRegistrar] in
+                let deviceCleanupSucceeded: Bool
+                do {
+                    try await authorizedDeviceRegistrar.clearAuthorization(
+                        ifOwnedBy: deviceSessionLease
+                    )
+                    deviceCleanupSucceeded = true
+                } catch is CancellationError {
+                    deviceCleanupSucceeded = false
+                } catch {
+                    deviceCleanupSucceeded = false
+                }
+                return freshnessCleanupSucceeded && deviceCleanupSucceeded
+            }
+        } else if !freshnessCleanupSucceeded {
+            cleanupTask = Task { false }
+        } else {
+            cleanupTask = nil
+        }
+        appendSessionTerminationCleanup(cleanupTask)
+        resetAccessCredentialsAndErrors()
+        isAuthenticating = false
+        isRegistering = false
+        isRecoveringPassword = false
+        feedbackCenter.clear()
+        showSessionExpiredDialog = false
+        showUnauthorizedDialog = false
+        return hadOwnedSessionOperation
+    }
+
+    private func handleSessionOperationTimeout(_ generation: UInt64) {
+        guard sessionOperationState == .active(generation: generation) else { return }
+
+        sessionOperationState = .draining(generation: generation)
+        sessionOperationTask?.cancel()
+        sessionOperationTimeoutTask = nil
+        let principalEmail = sessionOperationPrincipalEmail
+        let firebaseSignOutSucceeded = authSessionProvider.signOut()
+        prepareForLocalSessionTermination()
+        mode = firebaseSignOutSucceeded
+            ? .signedOut
+            : .unauthorized(email: principalEmail, reason: .userAccessRestricted)
+        feedbackCenter.show(AccessL10nKey.authErrorNetwork)
+        showSessionExpiredDialog = false
+        showUnauthorizedDialog = false
+    }
+
+    private func finishSessionOperationTimeout(_ generation: UInt64) {
+        guard sessionOperationState == .active(generation: generation) else { return }
+        sessionOperationTimeoutTask = nil
+    }
+
+    private func applyDefinitiveSessionCleanupFailure() {
+        if case .unauthorized(_, .emailVerificationRequired) = mode {
+            showSessionExpiredDialog = false
+            showUnauthorizedDialog = false
+            return
+        }
+        mode = .unauthorized(
+            email: sessionOperationPrincipalEmail,
+            reason: .userAccessRestricted
+        )
+        feedbackCenter.show(AccessL10nKey.authErrorUnknown)
+        showSessionExpiredDialog = false
+        showUnauthorizedDialog = false
+    }
+
+    private func startStandaloneSessionTerminationBarrier(
+        firebaseSignOutSucceeded: Bool,
+        principalEmail: String
+    ) {
+        guard !firebaseSignOutSucceeded || sessionTerminationCleanupTask != nil else {
+            return
+        }
+        let generation = sessionOperationGeneration
+        sessionOperationPrincipalEmail = principalEmail
+        sessionOperationState = .draining(generation: generation)
+
+        guard firebaseSignOutSucceeded,
+              let cleanupTask = sessionTerminationCleanupTask else {
+            let cleanupTask = sessionTerminationCleanupTask
+            sessionOperationTask = Task {
+                if let cleanupTask {
+                    _ = await cleanupTask.value
+                }
+            }
+            return
+        }
+        startSessionTerminationCleanupBarrier(
+            cleanupTask,
+            generation: generation,
+            cleanupGeneration: sessionTerminationCleanupGeneration
+        )
+    }
+
+    private func startSessionTerminationCleanupBarrier(
+        _ cleanupTask: Task<Bool, Never>,
+        generation: UInt64,
+        cleanupGeneration: UInt64
+    ) {
+        sessionOperationTask = Task { @MainActor [weak self] in
+            let cleanupSucceeded = await cleanupTask.value
+            guard let self,
+                  self.sessionOperationState == .draining(generation: generation) else {
+                return
+            }
+            guard self.sessionTerminationCleanupGeneration == cleanupGeneration else {
+                if let currentCleanupTask = self.sessionTerminationCleanupTask {
+                    self.startSessionTerminationCleanupBarrier(
+                        currentCleanupTask,
+                        generation: generation,
+                        cleanupGeneration: self.sessionTerminationCleanupGeneration
+                    )
+                }
+                return
+            }
+            guard cleanupSucceeded else {
+                self.applyDefinitiveSessionCleanupFailure()
+                return
+            }
+            self.sessionTerminationCleanupTask = nil
+            self.finishSessionOperation(generation)
+        }
+    }
+
+    private func appendSessionTerminationCleanup(
+        _ cleanupTask: Task<Bool, Never>?
+    ) {
+        guard let cleanupTask else { return }
+        sessionTerminationCleanupGeneration &+= 1
+        guard let previousCleanupTask = sessionTerminationCleanupTask else {
+            sessionTerminationCleanupTask = cleanupTask
+            return
+        }
+        sessionTerminationCleanupTask = Task {
+            let previousSucceeded = await previousCleanupTask.value
+            let currentSucceeded = await cleanupTask.value
+            return previousSucceeded && currentSucceeded
+        }
+    }
+}

--- a/ios/Reguerta/Reguerta/Presentation/Freshness/MyOrderFreshnessViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Freshness/MyOrderFreshnessViewModel.swift
@@ -63,9 +63,10 @@ final class MyOrderFreshnessViewModel {
             }
         case .signedOut:
             reset()
-            criticalDataFreshnessLocalRepository.clear()
+            try? criticalDataFreshnessLocalRepository.clear()
         case .unauthorized:
             reset()
+            try? criticalDataFreshnessLocalRepository.clear()
         }
     }
 
@@ -82,6 +83,7 @@ final class MyOrderFreshnessViewModel {
     private func refresh(for identity: FreshnessSessionIdentity) {
         invalidateFreshnessOperation()
         let generation = freshnessGeneration
+        let metadataWriteGeneration = criticalDataFreshnessLocalRepository.writeGeneration
         let resolver = resolveCriticalDataFreshness
         let timeout = timeout
         let sleeper = sleeper
@@ -99,14 +101,22 @@ final class MyOrderFreshnessViewModel {
                 guard let self, isCurrentFreshnessOperation(generation, identity: identity) else {
                     return
                 }
-                publish(resolution, generation: generation)
+                publish(
+                    resolution,
+                    generation: generation,
+                    metadataWriteGeneration: metadataWriteGeneration
+                )
             } catch is CancellationError {
                 return
             } catch {
                 guard let self, isCurrentFreshnessOperation(generation, identity: identity) else {
                     return
                 }
-                publish(.invalidConfig, generation: generation)
+                publish(
+                    .invalidConfig,
+                    generation: generation,
+                    metadataWriteGeneration: metadataWriteGeneration
+                )
             }
         }
 
@@ -170,7 +180,8 @@ final class MyOrderFreshnessViewModel {
 
     private func publish(
         _ resolution: CriticalDataFreshnessResolution,
-        generation: UInt64
+        generation: UInt64,
+        metadataWriteGeneration: UInt64
     ) {
         guard generation == freshnessGeneration else { return }
         freshnessTimeoutTask?.cancel()
@@ -179,7 +190,10 @@ final class MyOrderFreshnessViewModel {
         switch resolution {
         case .fresh(let metadataToPersist):
             if let metadataToPersist {
-                criticalDataFreshnessLocalRepository.saveMetadata(metadataToPersist)
+                criticalDataFreshnessLocalRepository.saveMetadata(
+                    metadataToPersist,
+                    ifWriteGeneration: metadataWriteGeneration
+                )
             }
             state = .ready
         case .invalidConfig:

--- a/ios/Reguerta/Reguerta/Presentation/Root/SessionViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Root/SessionViewModel.swift
@@ -12,6 +12,13 @@ struct AuthorizedSession: Equatable, Sendable {
 struct SessionOperationContext {
     let generation: UInt64
     let predecessor: Task<Void, Never>?
+    let principalEmail: String
+}
+
+enum SessionOperationState: Equatable, Sendable {
+    case idle
+    case active(generation: UInt64)
+    case draining(generation: UInt64)
 }
 
 enum SessionMode: Equatable, Sendable {
@@ -82,23 +89,39 @@ final class SessionViewModel {
     let authSessionProvider: any AuthSessionProvider
     let resolveAuthorizedSession: ResolveAuthorizedSessionUseCase
     let authorizedDeviceRegistrar: any AuthorizedDeviceRegistrar
+    let criticalDataFreshnessLocalRepository: any CriticalDataFreshnessLocalRepository
     let environmentRouter: any SessionEnvironmentRouting
     let sessionRefreshPolicy: SessionRefreshPolicy
     let nowMillisProvider: @MainActor @Sendable () -> Int64
+    let sessionOperationTimeout: Duration
+    let sessionOperationSleeper: @Sendable (Duration) async throws -> Void
     let developImpersonationEnabled: Bool
     var lastSessionRefreshAtMillis: Int64?
     var isSessionRefreshInFlight = false
+    var sessionOperationState: SessionOperationState = .idle
     @ObservationIgnored var sessionOperationTask: Task<Void, Never>?
+    @ObservationIgnored var sessionOperationTimeoutTask: Task<Void, Never>?
+    @ObservationIgnored var sessionTerminationCleanupTask: Task<Bool, Never>?
+    @ObservationIgnored var sessionTerminationCleanupGeneration: UInt64 = 0
     @ObservationIgnored var sessionOperationGeneration: UInt64 = 0
+    @ObservationIgnored var sessionOperationPrincipalEmail = ""
     @ObservationIgnored var authorizedDeviceSessionLease: AuthorizedDeviceSessionLease?
 
     var isDevelopImpersonationEnabled: Bool {
         developImpersonationEnabled
     }
 
+    var isSessionOperationDraining: Bool {
+        if case .draining = sessionOperationState {
+            return true
+        }
+        return false
+    }
+
     var canSubmitSignIn: Bool {
         let normalizedEmail = normalizeAccessEmail(emailInput)
-        return !isAuthenticating &&
+        return sessionOperationState == .idle &&
+            !isAuthenticating &&
             !normalizedEmail.isEmpty &&
             isValidAccessEmail(normalizedEmail) &&
             isValidAccessPassword(passwordInput) &&
@@ -108,7 +131,8 @@ final class SessionViewModel {
 
     var canSubmitSignUp: Bool {
         let normalizedEmail = normalizeAccessEmail(registerEmailInput)
-        return !isRegistering &&
+        return sessionOperationState == .idle &&
+            !isRegistering &&
             !normalizedEmail.isEmpty &&
             isValidAccessEmail(normalizedEmail) &&
             isValidAccessPassword(registerPasswordInput) &&
@@ -133,9 +157,12 @@ final class SessionViewModel {
         self.authSessionProvider = dependencies.authSessionProvider
         self.resolveAuthorizedSession = dependencies.resolveAuthorizedSession
         self.authorizedDeviceRegistrar = dependencies.authorizedDeviceRegistrar
+        self.criticalDataFreshnessLocalRepository = dependencies.criticalDataFreshnessLocalRepository
         self.environmentRouter = dependencies.environmentRouter
         self.sessionRefreshPolicy = dependencies.sessionRefreshPolicy
         self.nowMillisProvider = dependencies.nowMillisProvider
+        self.sessionOperationTimeout = dependencies.sessionOperationTimeout
+        self.sessionOperationSleeper = dependencies.sessionOperationSleeper
         self.developImpersonationEnabled = dependencies.developImpersonationEnabled
     }
 
@@ -146,10 +173,16 @@ final class SessionViewModel {
         resolveAuthorizedSession: ResolveAuthorizedSessionUseCase? = nil,
         authorizedMemberResolver: (any AuthorizedMemberResolving)? = nil,
         authorizedDeviceRegistrar: (any AuthorizedDeviceRegistrar)? = nil,
+        criticalDataFreshnessLocalRepository: any CriticalDataFreshnessLocalRepository =
+            NoOpCriticalDataFreshnessLocalRepository(),
         environmentRouter: (any SessionEnvironmentRouting)? = nil,
         developImpersonationEnabled: Bool = false,
         sessionRefreshPolicy: SessionRefreshPolicy = SessionRefreshPolicy(),
-        nowMillisProvider: @escaping @MainActor @Sendable () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1_000) }
+        nowMillisProvider: @escaping @MainActor @Sendable () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1_000) },
+        sessionOperationTimeout: Duration = SessionOperationConfiguration.defaultTimeout,
+        sessionOperationSleeper: @escaping @Sendable (Duration) async throws -> Void = {
+            try await ContinuousClock().sleep(for: $0)
+        }
     ) {
         self.init(
             dependencies: .live(
@@ -159,10 +192,13 @@ final class SessionViewModel {
                 resolveAuthorizedSession: resolveAuthorizedSession,
                 authorizedMemberResolver: authorizedMemberResolver,
                 authorizedDeviceRegistrar: authorizedDeviceRegistrar,
+                criticalDataFreshnessLocalRepository: criticalDataFreshnessLocalRepository,
                 environmentRouter: environmentRouter,
                 developImpersonationEnabled: developImpersonationEnabled,
                 sessionRefreshPolicy: sessionRefreshPolicy,
-                nowMillisProvider: nowMillisProvider
+                nowMillisProvider: nowMillisProvider,
+                sessionOperationTimeout: sessionOperationTimeout,
+                sessionOperationSleeper: sessionOperationSleeper
             )
         )
     }

--- a/ios/Reguerta/Reguerta/Presentation/Root/SessionViewModelDependencies.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Root/SessionViewModelDependencies.swift
@@ -2,15 +2,22 @@ import FirebaseCore
 import FirebaseFirestore
 import Foundation
 
+enum SessionOperationConfiguration {
+    static let defaultTimeout: Duration = .seconds(30)
+}
+
 struct SessionViewModelDependencies {
     let feedbackCenter: GlobalFeedbackCenter
     let repository: any MemberRepository
     let authSessionProvider: any AuthSessionProvider
     let resolveAuthorizedSession: ResolveAuthorizedSessionUseCase
     let authorizedDeviceRegistrar: any AuthorizedDeviceRegistrar
+    let criticalDataFreshnessLocalRepository: any CriticalDataFreshnessLocalRepository
     let environmentRouter: any SessionEnvironmentRouting
     let sessionRefreshPolicy: SessionRefreshPolicy
     let nowMillisProvider: @MainActor @Sendable () -> Int64
+    let sessionOperationTimeout: Duration
+    let sessionOperationSleeper: @Sendable (Duration) async throws -> Void
     let developImpersonationEnabled: Bool
 
     static func live(
@@ -21,10 +28,15 @@ struct SessionViewModelDependencies {
         resolveAuthorizedSession: ResolveAuthorizedSessionUseCase? = nil,
         authorizedMemberResolver: (any AuthorizedMemberResolving)? = nil,
         authorizedDeviceRegistrar: (any AuthorizedDeviceRegistrar)? = nil,
+        criticalDataFreshnessLocalRepository: (any CriticalDataFreshnessLocalRepository)? = nil,
         environmentRouter: (any SessionEnvironmentRouting)? = nil,
         developImpersonationEnabled: Bool = false,
         sessionRefreshPolicy: SessionRefreshPolicy = SessionRefreshPolicy(),
-        nowMillisProvider: @escaping @MainActor @Sendable () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1_000) }
+        nowMillisProvider: @escaping @MainActor @Sendable () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1_000) },
+        sessionOperationTimeout: Duration = SessionOperationConfiguration.defaultTimeout,
+        sessionOperationSleeper: @escaping @Sendable (Duration) async throws -> Void = {
+            try await ContinuousClock().sleep(for: $0)
+        }
     ) -> SessionViewModelDependencies {
         let useMockAuth = ProcessInfo.processInfo.arguments.contains("-useMockAuth")
         let selectedRepository: any MemberRepository = repository ?? (useMockAuth
@@ -64,9 +76,13 @@ struct SessionViewModelDependencies {
                 environmentRouter: selectedEnvironmentRouter
             ),
             authorizedDeviceRegistrar: authorizedDeviceRegistrar ?? NoOpAuthorizedDeviceRegistrar(),
+            criticalDataFreshnessLocalRepository: criticalDataFreshnessLocalRepository
+                ?? UserDefaultsCriticalDataFreshnessLocalRepository(),
             environmentRouter: selectedEnvironmentRouter,
             sessionRefreshPolicy: sessionRefreshPolicy,
             nowMillisProvider: nowMillisProvider,
+            sessionOperationTimeout: sessionOperationTimeout,
+            sessionOperationSleeper: sessionOperationSleeper,
             developImpersonationEnabled: developImpersonationEnabled
         )
     }
@@ -74,7 +90,9 @@ struct SessionViewModelDependencies {
     static func preview(
         repository: any LocalMemberRepository = InMemoryMemberRepository(),
         feedbackCenter: GlobalFeedbackCenter = GlobalFeedbackCenter(),
-        authorizedDeviceRegistrar: any AuthorizedDeviceRegistrar = NoOpAuthorizedDeviceRegistrar()
+        authorizedDeviceRegistrar: any AuthorizedDeviceRegistrar = NoOpAuthorizedDeviceRegistrar(),
+        criticalDataFreshnessLocalRepository: any CriticalDataFreshnessLocalRepository =
+            NoOpCriticalDataFreshnessLocalRepository()
     ) -> SessionViewModelDependencies {
         let environmentRouter = FixedSessionEnvironmentRouter()
         return SessionViewModelDependencies(
@@ -87,9 +105,12 @@ struct SessionViewModelDependencies {
                 environmentRouter: environmentRouter
             ),
             authorizedDeviceRegistrar: authorizedDeviceRegistrar,
+            criticalDataFreshnessLocalRepository: criticalDataFreshnessLocalRepository,
             environmentRouter: environmentRouter,
             sessionRefreshPolicy: SessionRefreshPolicy(),
             nowMillisProvider: { Int64(Date().timeIntervalSince1970 * 1_000) },
+            sessionOperationTimeout: SessionOperationConfiguration.defaultTimeout,
+            sessionOperationSleeper: { try await ContinuousClock().sleep(for: $0) },
             developImpersonationEnabled: false
         )
     }
@@ -107,4 +128,20 @@ nonisolated struct NoOpAuthorizedDeviceRegistrar: AuthorizedDeviceRegistrar {
     func updateRegistrationToken(_ token: String?) async throws {}
 
     func clearAuthorization(ifOwnedBy lease: AuthorizedDeviceSessionLease) async throws {}
+}
+
+@MainActor
+final class NoOpCriticalDataFreshnessLocalRepository: CriticalDataFreshnessLocalRepository {
+    private(set) var writeGeneration: UInt64 = 0
+
+    func getMetadata() -> CriticalDataFreshnessMetadata? { nil }
+
+    func saveMetadata(
+        _: CriticalDataFreshnessMetadata,
+        ifWriteGeneration _: UInt64
+    ) {}
+
+    func clear() throws {
+        writeGeneration &+= 1
+    }
 }

--- a/ios/Reguerta/ReguertaTests/ControlledSessionAuthProvider.swift
+++ b/ios/Reguerta/ReguertaTests/ControlledSessionAuthProvider.swift
@@ -11,10 +11,14 @@ final class ControlledSessionAuthProvider: AuthSessionProvider {
     }
 
     private let immediateSignInResult: AuthSignInResult?
+    private let immediateSignUpResult: AuthSignUpResult?
     private let immediateRefreshResult: AuthSessionRefreshResult?
+    private var signOutResults: [Bool]
     private var signInContinuations: [CheckedContinuation<AuthSignInResult, Never>?] = []
+    private var signUpContinuations: [CheckedContinuation<AuthSignUpResult, Never>?] = []
     private var refreshContinuations: [CheckedContinuation<AuthSessionRefreshResult, Never>?] = []
     private(set) var signInRequestCount = 0
+    private(set) var signUpRequestCount = 0
     private(set) var refreshRequestCount = 0
     private(set) var signOutCallCount = 0
     private(set) var isAuthenticated: Bool
@@ -22,12 +26,16 @@ final class ControlledSessionAuthProvider: AuthSessionProvider {
 
     init(
         signInResult: AuthSignInResult? = nil,
+        signUpResult: AuthSignUpResult? = nil,
         refreshResult: AuthSessionRefreshResult? = nil,
-        isAuthenticated: Bool = false
+        isAuthenticated: Bool = false,
+        signOutResults: [Bool] = []
     ) {
         immediateSignInResult = signInResult
+        immediateSignUpResult = signUpResult
         immediateRefreshResult = refreshResult
         self.isAuthenticated = isAuthenticated
+        self.signOutResults = signOutResults
     }
 
     func signIn(email _: String, password _: String) async -> AuthSignInResult {
@@ -48,7 +56,16 @@ final class ControlledSessionAuthProvider: AuthSessionProvider {
     }
 
     func signUp(email _: String, password _: String) async -> AuthSignUpResult {
-        .failure(.unknown)
+        signUpRequestCount += 1
+        if let immediateSignUpResult {
+            applyAuthenticationState(for: immediateSignUpResult)
+            return immediateSignUpResult
+        }
+        let result = await withCheckedContinuation { continuation in
+            signUpContinuations.append(continuation)
+        }
+        applyAuthenticationState(for: result)
+        return result
     }
 
     func sendPasswordReset(email _: String) async -> AuthPasswordResetResult {
@@ -79,9 +96,12 @@ final class ControlledSessionAuthProvider: AuthSessionProvider {
     @discardableResult
     func signOut() -> Bool {
         signOutCallCount += 1
-        isAuthenticated = false
+        let succeeded = signOutResults.isEmpty ? true : signOutResults.removeFirst()
+        if succeeded {
+            isAuthenticated = false
+        }
         events.append(.signOut)
-        return true
+        return succeeded
     }
 
     func waitForSignInRequestCount(_ expectedCount: Int) async -> Bool {
@@ -106,6 +126,17 @@ final class ControlledSessionAuthProvider: AuthSessionProvider {
         return false
     }
 
+    func waitForSignUpRequestCount(_ expectedCount: Int) async -> Bool {
+        for _ in 0 ..< 1_000 {
+            if signUpRequestCount >= expectedCount {
+                return true
+            }
+            await Task.yield()
+        }
+        Issue.record("No se iniciaron \(expectedCount) peticiones de alta")
+        return false
+    }
+
     func completeSignIn(at index: Int = 0, with result: AuthSignInResult) {
         guard signInContinuations.indices.contains(index),
               let continuation = signInContinuations[index] else {
@@ -126,11 +157,23 @@ final class ControlledSessionAuthProvider: AuthSessionProvider {
         continuation.resume(returning: result)
     }
 
+    func completeSignUp(at index: Int = 0, with result: AuthSignUpResult) {
+        guard signUpContinuations.indices.contains(index),
+              let continuation = signUpContinuations[index] else {
+            Issue.record("No existe la petición de alta \(index)")
+            return
+        }
+        signUpContinuations[index] = nil
+        continuation.resume(returning: result)
+    }
+
     private func applyAuthenticationState(for result: AuthSignInResult) {
         switch result {
         case .success:
             isAuthenticated = true
         case .emailVerificationRequired(_, _, let signedOut):
+            isAuthenticated = !signedOut
+        case .failureAfterAuthenticationMutation(_, let signedOut):
             isAuthenticated = !signedOut
         case .failure:
             break
@@ -138,8 +181,23 @@ final class ControlledSessionAuthProvider: AuthSessionProvider {
     }
 
     private func applyAuthenticationState(for result: AuthSessionRefreshResult) {
-        if case .active = result {
+        switch result {
+        case .active:
             isAuthenticated = true
+        case .failureAfterAuthenticationMutation(_, let signedOut):
+            isAuthenticated = !signedOut
+        case .noSession, .emailVerificationRequired, .failure, .expired:
+            break
+        }
+    }
+
+    private func applyAuthenticationState(for result: AuthSignUpResult) {
+        switch result {
+        case .verificationRequired(_, _, let signedOut),
+             .failureAfterAuthenticationMutation(_, let signedOut):
+            isAuthenticated = !signedOut
+        case .failure:
+            break
         }
     }
 }

--- a/ios/Reguerta/ReguertaTests/CriticalDataFreshnessEnvironmentTests.swift
+++ b/ios/Reguerta/ReguertaTests/CriticalDataFreshnessEnvironmentTests.swift
@@ -33,13 +33,13 @@ struct CriticalDataFreshnessEnvironmentTests {
     }
 
     @Test
-    func userDefaultsClearRemovesAllFreshnessMetadata() {
+    func userDefaultsClearRemovesAllFreshnessMetadata() throws {
         let (suiteName, userDefaults) = isolatedUserDefaults(suffix: "clear")
         defer { userDefaults.removePersistentDomain(forName: suiteName) }
         let repository = UserDefaultsCriticalDataFreshnessLocalRepository(userDefaults: userDefaults)
         repository.saveMetadata(freshnessMetadata(environment: .develop))
 
-        repository.clear()
+        try repository.clear()
 
         #expect(repository.getMetadata() == nil)
         #expect(userDefaults.object(forKey: freshnessValidatedAtKey) == nil)
@@ -136,6 +136,43 @@ struct CriticalDataFreshnessEnvironmentTests {
 
         #expect(viewModel.state == .ready)
         #expect(await remoteRepository.requestedEnvironments() == [.develop])
+    }
+
+    @Test("Un clear compartido cerca una escritura remota tardia")
+    func sharedClearFencesLateRemoteMetadataWrite() async throws {
+        let remoteRepository = ControlledEnvironmentFreshnessRemoteRepository()
+        let localRepository = InMemoryCriticalDataFreshnessLocalRepository()
+        localRepository.saveMetadata(
+            freshnessMetadata(environment: .develop, timestamp: 500)
+        )
+        let viewModel = MyOrderFreshnessViewModel(
+            resolveCriticalDataFreshness: ResolveCriticalDataFreshnessUseCase(
+                remoteRepository: remoteRepository,
+                localRepository: localRepository,
+                nowProvider: { 3_000 }
+            ),
+            criticalDataFreshnessLocalRepository: localRepository,
+            timeout: .seconds(60)
+        )
+
+        viewModel.retry(currentMode: freshnessAuthorizedMode(environment: .develop))
+        let refreshTasks = try #require(ownedFreshnessTasks(in: viewModel))
+        await remoteRepository.waitForRequestCount(1)
+        let initialWriteGeneration = localRepository.writeGeneration
+
+        try localRepository.clear()
+        #expect(localRepository.writeGeneration == initialWriteGeneration &+ 1)
+        #expect(localRepository.getMetadata() == nil)
+
+        await remoteRepository.completeRequest(
+            at: 0,
+            with: freshnessConfig(timestamp: 2_000)
+        )
+        await refreshTasks.operation.value
+        await refreshTasks.timeout.value
+
+        #expect(viewModel.state == .ready)
+        #expect(localRepository.getMetadata() == nil)
     }
 }
 

--- a/ios/Reguerta/ReguertaTests/FirebaseAuthenticationMutationFlowTests.swift
+++ b/ios/Reguerta/ReguertaTests/FirebaseAuthenticationMutationFlowTests.swift
@@ -1,0 +1,189 @@
+import Testing
+
+@testable import Reguerta
+
+@MainActor
+struct FirebaseAuthenticationMutationFlowTests {
+    @Test("Un checkpoint Firebase limpia una mutación que termina después de cancelar")
+    func checkpointSignsOutBeforeReturning() async {
+        let phase = ControlledFirebaseMutationPhase()
+        var events: [FirebaseMutationCheckpointEvent] = []
+        let task = Task { @MainActor in
+            do {
+                _ = try await awaitFirebaseAuthenticationMutation {
+                    await phase.run()
+                    return "authenticated"
+                } signOut: {
+                    events.append(.signedOut)
+                    return true
+                }
+                events.append(.continued)
+            } catch let failure as FirebaseAuthenticationContinuationError {
+                #expect(failure.underlyingError is CancellationError)
+                #expect(failure.signedOut)
+                events.append(.cancelled)
+            } catch {
+                Issue.record("El checkpoint propagó un error inesperado: \(error)")
+            }
+        }
+
+        guard await phase.waitUntilStarted() else { return }
+        task.cancel()
+        await phase.complete()
+        await task.value
+        #expect(events == [.signedOut, .cancelled])
+    }
+
+    @Test("El checkpoint limpia también si Firebase lanza cancelación")
+    func checkpointSignsOutForMutationCancellationError() async {
+        var signOutCallCount = 0
+        let mutation: () async throws -> String = { throw CancellationError() }
+        do {
+            _ = try await awaitFirebaseAuthenticationMutation(mutation) {
+                signOutCallCount += 1
+                return false
+            }
+            Issue.record("La cancelación de Firebase no se propagó")
+        } catch let failure as FirebaseAuthenticationContinuationError {
+            #expect(failure.underlyingError is CancellationError)
+            #expect(failure.signedOut == false)
+            #expect(signOutCallCount == 1)
+        } catch {
+            Issue.record("La mutación propagó un error inesperado: \(error)")
+        }
+    }
+
+    @Test("El flujo no vuelve a envolver una cancelación ya limpiada")
+    func flowPreservesNestedMutationCleanupResult() async {
+        var signOutCallCount = 0
+        do {
+            let _: String = try await awaitFirebaseAuthenticationFlow {
+                "authenticated"
+            } continuation: { _ in
+                try await awaitFirebaseAuthenticationMutation {
+                    throw CancellationError()
+                } signOut: {
+                    signOutCallCount += 1
+                    return false
+                }
+            } signOut: {
+                signOutCallCount += 1
+                return true
+            }
+            Issue.record("La cancelación posterior a Auth no se propagó")
+        } catch let failure as FirebaseAuthenticationContinuationError {
+            #expect(failure.underlyingError is CancellationError)
+            #expect(failure.signedOut == false)
+            #expect(signOutCallCount == 1)
+        } catch {
+            Issue.record("El flujo propagó un error inesperado: \(error)")
+        }
+    }
+
+    @Test("Una cancelación directa de la continuación conserva el cleanup")
+    func directContinuationCancellationPreservesCleanupResult() async {
+        var signOutCallCount = 0
+        do {
+            let _: String = try await awaitFirebaseAuthenticationFlow {
+                "authenticated"
+            } continuation: { _ in
+                throw CancellationError()
+            } signOut: {
+                signOutCallCount += 1
+                return true
+            }
+            Issue.record("La cancelación de continuación no se propagó")
+        } catch let failure as FirebaseAuthenticationContinuationError {
+            #expect(failure.underlyingError is CancellationError)
+            #expect(failure.signedOut)
+            #expect(signOutCallCount == 1)
+        } catch {
+            Issue.record("El flujo propagó un error inesperado: \(error)")
+        }
+    }
+
+    @Test("Un fallo tras mutar Auth fuerza sign-out y conserva su resultado")
+    func continuationFailureForcesSignOut() async {
+        var signOutCallCount = 0
+        do {
+            let _: String = try await awaitFirebaseAuthenticationFlow {
+                "authenticated"
+            } continuation: { _ in
+                throw FirebaseAuthenticationMutationTestError.continuation
+            } signOut: {
+                signOutCallCount += 1
+                return false
+            }
+            Issue.record("El fallo posterior a la mutación no se propagó")
+        } catch let failure as FirebaseAuthenticationContinuationError {
+            #expect(failure.underlyingError is FirebaseAuthenticationMutationTestError)
+            #expect(failure.signedOut == false)
+            #expect(signOutCallCount == 1)
+        } catch {
+            Issue.record("El flujo propagó un error inesperado: \(error)")
+        }
+    }
+
+    @Test("Un fallo previo a mutar Auth no cierra una sesión ajena")
+    func initialMutationFailureDoesNotSignOut() async {
+        var signOutCallCount = 0
+        let mutation: () async throws -> String = {
+            throw FirebaseAuthenticationMutationTestError.initial
+        }
+        do {
+            let _: String = try await awaitFirebaseAuthenticationFlow(
+                mutation,
+                continuation: { $0 },
+                signOut: {
+                    signOutCallCount += 1
+                    return true
+                }
+            )
+            Issue.record("El fallo inicial de Firebase no se propagó")
+        } catch FirebaseAuthenticationMutationTestError.initial {
+            #expect(signOutCallCount == 0)
+        } catch {
+            Issue.record("El flujo propagó un error inesperado: \(error)")
+        }
+    }
+}
+
+private enum FirebaseAuthenticationMutationTestError: Error {
+    case initial
+    case continuation
+}
+
+private enum FirebaseMutationCheckpointEvent: Equatable {
+    case signedOut
+    case continued
+    case cancelled
+}
+
+private actor ControlledFirebaseMutationPhase {
+    private var started = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func run() async {
+        started = true
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func waitUntilStarted() async -> Bool {
+        for _ in 0 ..< 1_000 {
+            if started {
+                return true
+            }
+            await Task.yield()
+        }
+        Issue.record("La mutación Firebase controlada no se inició")
+        return false
+    }
+
+    func complete() {
+        let continuation = continuation
+        self.continuation = nil
+        continuation?.resume()
+    }
+}

--- a/ios/Reguerta/ReguertaTests/ReguertaTestSupport.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaTestSupport.swift
@@ -326,16 +326,22 @@ struct FixedCriticalDataFreshnessRemoteRepository: CriticalDataFreshnessRemoteRe
 @MainActor
 final class InMemoryCriticalDataFreshnessLocalRepository: CriticalDataFreshnessLocalRepository {
     private var metadata: CriticalDataFreshnessMetadata?
+    private(set) var writeGeneration: UInt64 = 0
 
     func getMetadata() -> CriticalDataFreshnessMetadata? {
         metadata
     }
 
-    func saveMetadata(_ metadata: CriticalDataFreshnessMetadata) {
+    func saveMetadata(
+        _ metadata: CriticalDataFreshnessMetadata,
+        ifWriteGeneration expectedWriteGeneration: UInt64
+    ) {
+        guard writeGeneration == expectedWriteGeneration else { return }
         self.metadata = metadata
     }
 
-    func clear() {
+    func clear() throws {
+        writeGeneration &+= 1
         metadata = nil
     }
 }

--- a/ios/Reguerta/ReguertaTests/SessionOperationCleanupBarrierTests.swift
+++ b/ios/Reguerta/ReguertaTests/SessionOperationCleanupBarrierTests.swift
@@ -1,0 +1,383 @@
+import Testing
+
+@testable import Reguerta
+
+extension SessionOperationInvalidationTests {
+    @Test("El cierre manual rechaza logins hasta limpiar su lease")
+    func manualSignOutOwnsLaneUntilAuthorizedDeviceCleanup() async {
+        let registrar = ControlledSessionCleanupRegistrar()
+        let freshnessRepository = ControlledSessionFreshnessRepository()
+        freshnessRepository.saveMetadata(sessionCleanupFreshnessMetadata())
+        let scenario = makeSessionTimeoutScenario(
+            isAuthenticated: true,
+            authorizedDeviceRegistrar: registrar,
+            criticalDataFreshnessLocalRepository: freshnessRepository
+        )
+        scenario.viewModel.mode = timeoutAuthorizedMode(
+            member: scenario.member,
+            principal: scenario.principal
+        )
+        scenario.viewModel.authorizedDeviceSessionLease = AuthorizedDeviceSessionLease()
+
+        scenario.viewModel.signOut()
+        guard await registrar.waitForClearRequest() else { return }
+        guard let cleanupBarrier = scenario.viewModel.sessionOperationTask else {
+            Issue.record("El cierre manual no conserva la barrera de limpieza")
+            return
+        }
+        populateValidSignIn(in: scenario)
+        scenario.viewModel.signIn()
+        #expect(scenario.viewModel.mode == .signedOut)
+        #expect(scenario.viewModel.isSessionOperationDraining)
+        #expect(scenario.provider.signInRequestCount == 0)
+        #expect(freshnessRepository.getMetadata() == nil)
+        #expect(freshnessRepository.clearCallCount == 1)
+
+        await registrar.completeClear()
+        await cleanupBarrier.value
+        #expect(scenario.viewModel.sessionOperationState == .idle)
+        #expect(scenario.viewModel.sessionOperationTask == nil)
+        #expect(scenario.viewModel.sessionTerminationCleanupTask == nil)
+        #expect(scenario.viewModel.canSubmitSignIn)
+    }
+
+    @Test("Un fallo al limpiar freshness mantiene la sesión fail-closed")
+    func failedFreshnessCleanupKeepsSessionDraining() async {
+        let freshnessRepository = ControlledSessionFreshnessRepository(clearSucceeds: false)
+        let metadata = sessionCleanupFreshnessMetadata()
+        freshnessRepository.saveMetadata(metadata)
+        let scenario = makeSessionTimeoutScenario(
+            isAuthenticated: true,
+            criticalDataFreshnessLocalRepository: freshnessRepository
+        )
+        scenario.viewModel.mode = timeoutAuthorizedMode(
+            member: scenario.member,
+            principal: scenario.principal
+        )
+
+        scenario.viewModel.signOut()
+        guard let cleanupBarrier = scenario.viewModel.sessionOperationTask else {
+            Issue.record("El fallo de freshness no conserva la barrera")
+            return
+        }
+        await cleanupBarrier.value
+        populateValidSignIn(in: scenario)
+        scenario.viewModel.signIn()
+
+        #expect(
+            scenario.viewModel.mode == .unauthorized(
+                email: scenario.member.normalizedEmail,
+                reason: .userAccessRestricted
+            )
+        )
+        #expect(scenario.viewModel.isSessionOperationDraining)
+        #expect(scenario.viewModel.sessionOperationTask != nil)
+        #expect(freshnessRepository.getMetadata() == metadata)
+        #expect(freshnessRepository.clearCallCount == 1)
+        #expect(scenario.provider.signInRequestCount == 0)
+    }
+
+    @Test("El drenaje espera a limpiar el lease antes de liberar un nuevo login")
+    func drainingWaitsForAuthorizedDeviceCleanup() async throws {
+        let registrar = ControlledSessionCleanupRegistrar()
+        let scenario = makeSessionTimeoutScenario(
+            isAuthenticated: true,
+            authorizedDeviceRegistrar: registrar
+        )
+        scenario.viewModel.mode = timeoutAuthorizedMode(
+            member: scenario.member,
+            principal: scenario.principal
+        )
+        scenario.viewModel.authorizedDeviceSessionLease = AuthorizedDeviceSessionLease()
+
+        guard let providerOperation = try await expireRefresh(in: scenario) else { return }
+        guard await registrar.waitForClearRequest() else { return }
+        scenario.provider.completeRefresh(with: .active(scenario.principal))
+        await providerOperation.value
+        guard let cleanupBarrier = scenario.viewModel.sessionOperationTask else {
+            Issue.record("El drenaje liberó el propietario antes de limpiar el lease")
+            return
+        }
+
+        populateValidSignIn(in: scenario)
+        scenario.viewModel.signIn()
+        #expect(scenario.viewModel.isSessionOperationDraining)
+        #expect(scenario.provider.signInRequestCount == 0)
+
+        await registrar.completeClear()
+        await cleanupBarrier.value
+        #expect(scenario.viewModel.sessionOperationState == .idle)
+        #expect(scenario.viewModel.sessionOperationTask == nil)
+        #expect(scenario.viewModel.sessionTerminationCleanupTask == nil)
+    }
+
+    @Test("Un fallo al limpiar el lease mantiene la sesión fail-closed")
+    func failedAuthorizedDeviceCleanupKeepsSessionDraining() async throws {
+        let registrar = ControlledSessionCleanupRegistrar()
+        let scenario = makeSessionTimeoutScenario(
+            isAuthenticated: true,
+            authorizedDeviceRegistrar: registrar
+        )
+        scenario.viewModel.mode = timeoutAuthorizedMode(
+            member: scenario.member,
+            principal: scenario.principal
+        )
+        scenario.viewModel.authorizedDeviceSessionLease = AuthorizedDeviceSessionLease()
+
+        guard let providerOperation = try await expireRefresh(in: scenario) else { return }
+        guard await registrar.waitForClearRequest() else { return }
+        scenario.provider.completeRefresh(with: .active(scenario.principal))
+        await providerOperation.value
+        guard let cleanupBarrier = scenario.viewModel.sessionOperationTask else {
+            Issue.record("El drenaje no conservó la barrera de limpieza")
+            return
+        }
+
+        await registrar.failClear()
+        await cleanupBarrier.value
+        #expect(
+            scenario.viewModel.mode == .unauthorized(
+                email: scenario.member.normalizedEmail,
+                reason: .userAccessRestricted
+            )
+        )
+        #expect(scenario.viewModel.isSessionOperationDraining)
+        #expect(scenario.viewModel.sessionOperationTask != nil)
+        #expect(scenario.viewModel.sessionTerminationCleanupTask != nil)
+        #expect(scenario.viewModel.feedbackCenter.messageKey == AccessL10nKey.authErrorUnknown)
+
+        populateValidSignIn(in: scenario)
+        scenario.viewModel.signIn()
+        #expect(scenario.provider.signInRequestCount == 0)
+    }
+
+    @Test("Un cierre repetido no pierde un cleanup que sigue en vuelo")
+    func repeatedSignOutPreservesInFlightCleanup() async {
+        let registrar = ControlledSessionCleanupRegistrar()
+        let scenario = makeSessionTimeoutScenario(
+            isAuthenticated: true,
+            authorizedDeviceRegistrar: registrar
+        )
+        scenario.viewModel.mode = timeoutAuthorizedMode(
+            member: scenario.member,
+            principal: scenario.principal
+        )
+        scenario.viewModel.authorizedDeviceSessionLease = AuthorizedDeviceSessionLease()
+
+        scenario.viewModel.refreshSession(trigger: .startup)
+        guard await scenario.provider.waitForRefreshRequestCount(1),
+              let providerOperation = scenario.viewModel.sessionOperationTask else {
+            Issue.record("El refresh no conserva su operación propietaria")
+            return
+        }
+        scenario.viewModel.signOut()
+        guard await registrar.waitForClearRequest() else { return }
+
+        scenario.viewModel.signOut()
+        scenario.provider.completeRefresh(with: .active(scenario.principal))
+        await providerOperation.value
+
+        guard let cleanupBarrier = scenario.viewModel.sessionOperationTask else {
+            Issue.record("El segundo cierre perdió la barrera de limpieza")
+            return
+        }
+        #expect(scenario.viewModel.isSessionOperationDraining)
+        #expect(scenario.viewModel.sessionTerminationCleanupTask != nil)
+
+        await registrar.completeClear()
+        await cleanupBarrier.value
+        #expect(scenario.viewModel.sessionOperationState == .idle)
+        #expect(scenario.viewModel.sessionOperationTask == nil)
+        #expect(scenario.viewModel.sessionTerminationCleanupTask == nil)
+    }
+
+    @Test("Una barrera antigua encadena el cleanup nuevo antes de liberar el carril")
+    func staleCleanupBarrierWaitsForNewFailedCleanup() async {
+        let registrar = ControlledSessionCleanupRegistrar()
+        let freshnessRepository = ControlledSessionFreshnessRepository(
+            clearResults: [true, false]
+        )
+        let scenario = makeSessionTimeoutScenario(
+            isAuthenticated: true,
+            authorizedDeviceRegistrar: registrar,
+            criticalDataFreshnessLocalRepository: freshnessRepository
+        )
+        scenario.viewModel.mode = timeoutAuthorizedMode(
+            member: scenario.member,
+            principal: scenario.principal
+        )
+        scenario.viewModel.authorizedDeviceSessionLease = AuthorizedDeviceSessionLease()
+
+        scenario.viewModel.signOut()
+        guard await registrar.waitForClearRequest(),
+              let firstCleanupBarrier = scenario.viewModel.sessionOperationTask else {
+            Issue.record("El primer cierre no conserva su barrera")
+            return
+        }
+
+        scenario.viewModel.signOut()
+        #expect(freshnessRepository.clearCallCount == 2)
+        await registrar.completeClear()
+        await firstCleanupBarrier.value
+        guard let failedCleanupBarrier = scenario.viewModel.sessionOperationTask else {
+            Issue.record("La barrera antigua no encadenó el cleanup nuevo")
+            return
+        }
+        await failedCleanupBarrier.value
+
+        populateValidSignIn(in: scenario)
+        scenario.viewModel.signIn()
+        #expect(scenario.viewModel.isSessionOperationDraining)
+        #expect(scenario.viewModel.sessionTerminationCleanupTask != nil)
+        #expect(scenario.viewModel.feedbackCenter.messageKey == AccessL10nKey.authErrorUnknown)
+        #expect(scenario.provider.signInRequestCount == 0)
+    }
+
+    @Test("Un cierre repetido no oculta un cleanup que ya falló")
+    func repeatedSignOutPreservesFailedCleanup() async {
+        let freshnessRepository = ControlledSessionFreshnessRepository(
+            clearResults: [false, true]
+        )
+        freshnessRepository.saveMetadata(sessionCleanupFreshnessMetadata())
+        let scenario = makeSessionTimeoutScenario(
+            isAuthenticated: true,
+            criticalDataFreshnessLocalRepository: freshnessRepository
+        )
+        scenario.viewModel.mode = timeoutAuthorizedMode(
+            member: scenario.member,
+            principal: scenario.principal
+        )
+
+        scenario.viewModel.signOut()
+        guard let failedCleanupBarrier = scenario.viewModel.sessionOperationTask else {
+            Issue.record("El primer cierre no conserva el cleanup fallido")
+            return
+        }
+        await failedCleanupBarrier.value
+        scenario.viewModel.signOut()
+
+        populateValidSignIn(in: scenario)
+        scenario.viewModel.signIn()
+        #expect(scenario.viewModel.isSessionOperationDraining)
+        #expect(scenario.viewModel.sessionTerminationCleanupTask != nil)
+        #expect(freshnessRepository.clearCallCount == 2)
+        #expect(scenario.provider.signInRequestCount == 0)
+    }
+}
+
+@MainActor
+private func expireRefresh(
+    in scenario: SessionTimeoutScenario
+) async throws -> Task<Void, Never>? {
+    scenario.viewModel.refreshSession(trigger: .startup)
+    guard await scenario.provider.waitForRefreshRequestCount(1) else { return nil }
+    try await scenario.sleeper.waitForRequestCount(1)
+    guard let operation = scenario.viewModel.sessionOperationTask,
+          let timeout = scenario.viewModel.sessionOperationTimeoutTask else {
+        Issue.record("El refresh no conserva las tareas de operación y timeout")
+        return nil
+    }
+    await scenario.sleeper.completeRequest(at: 0)
+    await timeout.value
+    return operation
+}
+
+@MainActor
+private func populateValidSignIn(in scenario: SessionTimeoutScenario) {
+    scenario.viewModel.emailInput = scenario.member.normalizedEmail
+    scenario.viewModel.passwordInput = "secret12"
+}
+
+private enum SessionCleanupTestError: Error {
+    case failed
+}
+
+@MainActor
+private final class ControlledSessionFreshnessRepository: CriticalDataFreshnessLocalRepository {
+    private var metadata: CriticalDataFreshnessMetadata?
+    private var clearResults: [Bool]
+    private(set) var writeGeneration: UInt64 = 0
+    private(set) var clearCallCount = 0
+
+    init(clearSucceeds: Bool = true) {
+        clearResults = [clearSucceeds]
+    }
+
+    init(clearResults: [Bool]) {
+        self.clearResults = clearResults
+    }
+
+    func getMetadata() -> CriticalDataFreshnessMetadata? {
+        metadata
+    }
+
+    func saveMetadata(
+        _ metadata: CriticalDataFreshnessMetadata,
+        ifWriteGeneration expectedWriteGeneration: UInt64
+    ) {
+        guard writeGeneration == expectedWriteGeneration else { return }
+        self.metadata = metadata
+    }
+
+    func clear() throws {
+        writeGeneration &+= 1
+        clearCallCount += 1
+        let succeeds = clearResults.isEmpty ? true : clearResults.removeFirst()
+        guard succeeds else {
+            throw SessionCleanupTestError.failed
+        }
+        metadata = nil
+    }
+}
+
+private func sessionCleanupFreshnessMetadata() -> CriticalDataFreshnessMetadata {
+    CriticalDataFreshnessMetadata(
+        validatedAtMillis: 1_000,
+        acknowledgedTimestampsMillis: Dictionary(
+            uniqueKeysWithValues: CriticalCollection.allCases.map { ($0, 1_000) }
+        ),
+        environment: .develop
+    )
+}
+
+private actor ControlledSessionCleanupRegistrar: AuthorizedDeviceRegistrar {
+    private var clearContinuation: CheckedContinuation<Void, any Error>?
+
+    func register(
+        command _: AuthorizedDeviceRegistrationCommand,
+        isSessionCurrent _: @escaping @MainActor @Sendable () -> Bool
+    ) async throws -> AuthorizedDeviceRegistrationResult {
+        .skipped
+    }
+
+    func updateRegistrationToken(_: String?) async throws {}
+
+    func clearAuthorization(ifOwnedBy _: AuthorizedDeviceSessionLease) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            clearContinuation = continuation
+        }
+    }
+
+    func waitForClearRequest() async -> Bool {
+        for _ in 0 ..< 1_000 {
+            if clearContinuation != nil {
+                return true
+            }
+            await Task.yield()
+        }
+        Issue.record("No se inició la limpieza controlada del lease")
+        return false
+    }
+
+    func completeClear() {
+        let continuation = clearContinuation
+        clearContinuation = nil
+        continuation?.resume()
+    }
+
+    func failClear() {
+        let continuation = clearContinuation
+        clearContinuation = nil
+        continuation?.resume(throwing: SessionCleanupTestError.failed)
+    }
+}

--- a/ios/Reguerta/ReguertaTests/SessionOperationInvalidationTests.swift
+++ b/ios/Reguerta/ReguertaTests/SessionOperationInvalidationTests.swift
@@ -93,8 +93,8 @@ struct SessionOperationInvalidationTests {
         #expect(routingRecorder.appliedEnvironments.isEmpty)
     }
 
-    @Test("Un nuevo login espera la limpieza del resultado antiguo")
-    func newerSignInWaitsForStaleProviderCleanup() async {
+    @Test("Un nuevo login se rechaza hasta limpiar el resultado antiguo")
+    func newerSignInIsRejectedUntilStaleProviderCleanup() async {
         let fixture = authenticatedMember()
         let principal = authenticatedPrincipal(for: fixture)
         let provider = ControlledSessionAuthProvider()
@@ -117,14 +117,20 @@ struct SessionOperationInvalidationTests {
         viewModel.emailInput = fixture.normalizedEmail
         viewModel.passwordInput = "secret12"
         viewModel.signIn()
-        guard let newerOperation = viewModel.sessionOperationTask else {
-            Issue.record("El segundo login no tiene propietario")
-            return
-        }
+        #expect(viewModel.canSubmitSignIn == false)
+        #expect(provider.signInRequestCount == 1)
 
         provider.completeSignIn(at: 0, with: .success(principal))
         await staleOperation.value
         #expect(provider.isAuthenticated == false)
+
+        viewModel.emailInput = fixture.normalizedEmail
+        viewModel.passwordInput = "secret12"
+        viewModel.signIn()
+        guard let newerOperation = viewModel.sessionOperationTask else {
+            Issue.record("El segundo login no tiene propietario tras el drenaje")
+            return
+        }
 
         guard await provider.waitForSignInRequestCount(2) else { return }
         #expect(provider.events == [
@@ -278,6 +284,7 @@ struct SessionOperationInvalidationTests {
         }
         #expect(session.environment == .production)
     }
+
 }
 
 @MainActor

--- a/ios/Reguerta/ReguertaTests/SessionOperationPreProviderCancellationTests.swift
+++ b/ios/Reguerta/ReguertaTests/SessionOperationPreProviderCancellationTests.swift
@@ -1,0 +1,76 @@
+import Testing
+
+@testable import Reguerta
+
+extension SessionOperationInvalidationTests {
+    @Test("Un cierre inmediato termina el login antes de invocar al proveedor")
+    func immediateSignOutFinishesPreProviderSignIn() async {
+        let scenario = makeSessionTimeoutScenario()
+        populateValidPreProviderSignIn(in: scenario)
+
+        scenario.viewModel.signIn()
+        guard let operation = scenario.viewModel.sessionOperationTask else {
+            Issue.record("El login no conserva su operación propietaria")
+            return
+        }
+        scenario.viewModel.signOut()
+        await operation.value
+
+        assertPreProviderTermination(in: scenario)
+        #expect(scenario.provider.signInRequestCount == 0)
+    }
+
+    @Test("Un cierre inmediato termina el alta antes de invocar al proveedor")
+    func immediateSignOutFinishesPreProviderSignUp() async {
+        let scenario = makeSessionTimeoutScenario()
+        scenario.viewModel.registerEmailInput = "new-member@example.com"
+        scenario.viewModel.registerPasswordInput = "secret12"
+        scenario.viewModel.registerRepeatPasswordInput = "secret12"
+
+        scenario.viewModel.signUp()
+        guard let operation = scenario.viewModel.sessionOperationTask else {
+            Issue.record("El alta no conserva su operación propietaria")
+            return
+        }
+        scenario.viewModel.signOut()
+        await operation.value
+
+        assertPreProviderTermination(in: scenario)
+        #expect(scenario.provider.signUpRequestCount == 0)
+    }
+
+    @Test("Un cierre inmediato termina el refresh antes de invocar al proveedor")
+    func immediateSignOutFinishesPreProviderRefresh() async {
+        let scenario = makeSessionTimeoutScenario(isAuthenticated: true)
+        scenario.viewModel.mode = timeoutAuthorizedMode(
+            member: scenario.member,
+            principal: scenario.principal
+        )
+
+        scenario.viewModel.refreshSession(trigger: .startup)
+        guard let operation = scenario.viewModel.sessionOperationTask else {
+            Issue.record("El refresh no conserva su operación propietaria")
+            return
+        }
+        scenario.viewModel.signOut()
+        await operation.value
+
+        assertPreProviderTermination(in: scenario)
+        #expect(scenario.provider.refreshRequestCount == 0)
+    }
+}
+
+@MainActor
+private func populateValidPreProviderSignIn(in scenario: SessionTimeoutScenario) {
+    scenario.viewModel.emailInput = scenario.member.normalizedEmail
+    scenario.viewModel.passwordInput = "secret12"
+}
+
+@MainActor
+private func assertPreProviderTermination(in scenario: SessionTimeoutScenario) {
+    #expect(scenario.viewModel.mode == .signedOut)
+    #expect(scenario.viewModel.sessionOperationState == .idle)
+    #expect(scenario.viewModel.sessionOperationTask == nil)
+    #expect(scenario.viewModel.sessionOperationTimeoutTask == nil)
+    #expect(scenario.provider.isAuthenticated == false)
+}

--- a/ios/Reguerta/ReguertaTests/SessionOperationTimeoutTests.swift
+++ b/ios/Reguerta/ReguertaTests/SessionOperationTimeoutTests.swift
@@ -1,0 +1,421 @@
+import Testing
+
+@testable import Reguerta
+
+extension SessionOperationInvalidationTests {
+    @Test("Una operación activa rechaza sucesores sin perder su deadline")
+    func activeOperationRejectsSuccessorsWithoutCancellingDeadline() async throws {
+        let scenario = makeSessionTimeoutScenario()
+        scenario.viewModel.emailInput = scenario.member.normalizedEmail
+        scenario.viewModel.passwordInput = "secret12"
+        scenario.viewModel.signIn()
+        guard await scenario.provider.waitForSignInRequestCount(1) else { return }
+        try await scenario.sleeper.waitForRequestCount(1)
+        guard scenario.viewModel.sessionOperationTimeoutTask != nil,
+              let operation = scenario.viewModel.sessionOperationTask else {
+            Issue.record("La operación activa perdió su propietario o deadline")
+            return
+        }
+
+        populateValidAccessDrafts(in: scenario.viewModel, member: scenario.member)
+        scenario.viewModel.signIn()
+        scenario.viewModel.signUp()
+        #expect(scenario.provider.signInRequestCount == 1)
+        #expect(scenario.provider.signUpRequestCount == 0)
+        #expect(scenario.viewModel.sessionOperationTimeoutTask != nil)
+
+        scenario.provider.completeSignIn(with: .failure(.unknown))
+        await operation.value
+        #expect(scenario.viewModel.sessionOperationState == .idle)
+    }
+
+    @Test("El timeout recupera la UI y bloquea nuevas sesiones hasta limpiar el proveedor tardío")
+    func signInTimeoutFailsClosedUntilProviderDrains() async throws {
+        let scenario = makeSessionTimeoutScenario()
+        guard let operation = try await expireSignIn(in: scenario) else { return }
+        let viewModel = scenario.viewModel
+        let provider = scenario.provider
+
+        #expect(viewModel.mode == .signedOut)
+        #expect(viewModel.isAuthenticating == false)
+        #expect(viewModel.isSessionOperationDraining)
+        #expect(viewModel.sessionOperationTask != nil)
+        #expect(viewModel.showSessionExpiredDialog == false)
+        #expect(viewModel.showUnauthorizedDialog == false)
+        #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.authErrorNetwork)
+        #expect(provider.isAuthenticated == false)
+
+        populateValidAccessDrafts(in: viewModel, member: scenario.member)
+        #expect(viewModel.canSubmitSignIn == false)
+        #expect(viewModel.canSubmitSignUp == false)
+        viewModel.signIn()
+        viewModel.signUp()
+        viewModel.refreshSession(trigger: .startup)
+        #expect(provider.signInRequestCount == 1)
+        #expect(provider.signUpRequestCount == 0)
+        #expect(provider.refreshRequestCount == 0)
+
+        provider.completeSignIn(with: .success(scenario.principal))
+        await operation.value
+        #expect(viewModel.mode == .signedOut)
+        #expect(viewModel.isSessionOperationDraining == false)
+        #expect(viewModel.sessionOperationTask == nil)
+        #expect(provider.isAuthenticated == false)
+        #expect(provider.signOutCallCount == 2)
+
+        viewModel.emailInput = scenario.member.normalizedEmail
+        viewModel.passwordInput = "secret12"
+        viewModel.signIn()
+        guard await provider.waitForSignInRequestCount(2) else { return }
+        try await scenario.sleeper.waitForRequestCount(2)
+        guard let retry = viewModel.sessionOperationTask else {
+            Issue.record("El reintento posterior al drenaje no tiene propietario")
+            return
+        }
+        provider.completeSignIn(at: 1, with: .success(scenario.principal))
+        await retry.value
+        #expect(viewModel.mode.isAuthenticatedSession)
+        #expect(provider.isAuthenticated)
+    }
+
+    @Test("El timeout de refresh expulsa la sesión sin diálogo y descarta el resultado tardío")
+    func refreshTimeoutFailsClosedWithoutExpiredDialog() async throws {
+        let scenario = makeSessionTimeoutScenario(isAuthenticated: true)
+        scenario.viewModel.mode = timeoutAuthorizedMode(
+            member: scenario.member,
+            principal: scenario.principal
+        )
+
+        scenario.viewModel.refreshSession(trigger: .startup)
+        guard await scenario.provider.waitForRefreshRequestCount(1) else { return }
+        try await scenario.sleeper.waitForRequestCount(1)
+        guard let operation = scenario.viewModel.sessionOperationTask,
+              let timeout = scenario.viewModel.sessionOperationTimeoutTask else {
+            Issue.record("El refresh no conserva las tareas de operación y timeout")
+            return
+        }
+        await scenario.sleeper.completeRequest(at: 0)
+        await timeout.value
+
+        #expect(scenario.viewModel.mode == .signedOut)
+        #expect(scenario.viewModel.isSessionRefreshInFlight == false)
+        #expect(scenario.viewModel.isSessionOperationDraining)
+        #expect(scenario.viewModel.showSessionExpiredDialog == false)
+        #expect(scenario.viewModel.feedbackCenter.messageKey == AccessL10nKey.authErrorNetwork)
+
+        scenario.provider.completeRefresh(with: .active(scenario.principal))
+        await operation.value
+        #expect(scenario.viewModel.mode == .signedOut)
+        #expect(scenario.viewModel.isSessionOperationDraining == false)
+        #expect(scenario.provider.isAuthenticated == false)
+        #expect(scenario.provider.signOutCallCount == 2)
+    }
+
+    @Test("El alta comparte deadline y cuarentena con el resto del carril de sesión")
+    func signUpTimeoutFailsClosedUntilProviderDrains() async throws {
+        let scenario = makeSessionTimeoutScenario()
+        let viewModel = scenario.viewModel
+        viewModel.registerEmailInput = "new-member@example.com"
+        viewModel.registerPasswordInput = "secret12"
+        viewModel.registerRepeatPasswordInput = "secret12"
+
+        viewModel.signUp()
+        guard await scenario.provider.waitForSignUpRequestCount(1) else { return }
+        try await scenario.sleeper.waitForRequestCount(1)
+        #expect(await scenario.sleeper.requestedDuration(at: 0) == Duration.seconds(30))
+        guard let operation = viewModel.sessionOperationTask,
+              let timeout = viewModel.sessionOperationTimeoutTask else {
+            Issue.record("El alta no conserva las tareas de operación y timeout")
+            return
+        }
+        await scenario.sleeper.completeRequest(at: 0)
+        await timeout.value
+        #expect(viewModel.mode == .signedOut)
+        #expect(viewModel.isRegistering == false)
+        #expect(viewModel.isSessionOperationDraining)
+        #expect(viewModel.canSubmitSignUp == false)
+
+        scenario.provider.completeSignUp(
+            with: .verificationRequired(
+                email: "new-member@example.com",
+                verificationSent: true,
+                signedOut: false
+            )
+        )
+        await operation.value
+        #expect(viewModel.mode == .signedOut)
+        #expect(viewModel.isSessionOperationDraining == false)
+        #expect(scenario.provider.isAuthenticated == false)
+        #expect(scenario.provider.signOutCallCount == 2)
+    }
+
+    @Test("Un cleanup definitivo fallido mantiene la sesión en cuarentena")
+    func failedDefinitiveCleanupKeepsSessionDraining() async throws {
+        let scenario = makeSessionTimeoutScenario(signOutResults: [true, false])
+        guard let operation = try await expireSignIn(in: scenario) else { return }
+
+        scenario.provider.completeSignIn(with: .success(scenario.principal))
+        await operation.value
+
+        #expect(
+            scenario.viewModel.mode == .unauthorized(
+                email: scenario.member.normalizedEmail,
+                reason: .userAccessRestricted
+            )
+        )
+        #expect(scenario.viewModel.isSessionOperationDraining)
+        #expect(scenario.viewModel.sessionOperationTask != nil)
+        #expect(scenario.viewModel.feedbackCenter.messageKey == AccessL10nKey.authErrorUnknown)
+        #expect(scenario.provider.isAuthenticated)
+        #expect(scenario.provider.signOutCallCount == 2)
+
+        populateValidAccessDrafts(in: scenario.viewModel, member: scenario.member)
+        scenario.viewModel.signIn()
+        #expect(scenario.viewModel.canSubmitSignIn == false)
+        #expect(scenario.provider.signInRequestCount == 1)
+    }
+
+    @Test("El timeout de alta conserva el email registrado si falla el cleanup")
+    func signUpCleanupFailureUsesRegistrationEmail() async throws {
+        let scenario = makeSessionTimeoutScenario(signOutResults: [true, false])
+        let registrationEmail = "new-member@example.com"
+        scenario.viewModel.registerEmailInput = registrationEmail
+        scenario.viewModel.registerPasswordInput = "secret12"
+        scenario.viewModel.registerRepeatPasswordInput = "secret12"
+
+        scenario.viewModel.signUp()
+        guard await scenario.provider.waitForSignUpRequestCount(1) else { return }
+        try await scenario.sleeper.waitForRequestCount(1)
+        guard let operation = scenario.viewModel.sessionOperationTask,
+              let timeout = scenario.viewModel.sessionOperationTimeoutTask else {
+            Issue.record("El alta no conserva sus tareas de timeout")
+            return
+        }
+        await scenario.sleeper.completeRequest(at: 0)
+        await timeout.value
+        scenario.provider.completeSignUp(
+            with: .verificationRequired(
+                email: registrationEmail,
+                verificationSent: true,
+                signedOut: false
+            )
+        )
+        await operation.value
+
+        #expect(
+            scenario.viewModel.mode == .unauthorized(
+                email: registrationEmail,
+                reason: .userAccessRestricted
+            )
+        )
+        #expect(scenario.viewModel.isSessionOperationDraining)
+        #expect(scenario.viewModel.feedbackCenter.messageKey == AccessL10nKey.authErrorUnknown)
+        #expect(scenario.provider.signOutCallCount == 2)
+    }
+
+}
+
+struct SessionTimeoutScenario {
+    let member: Member
+    let principal: AuthPrincipal
+    let provider: ControlledSessionAuthProvider
+    let sleeper: ControlledSessionOperationSleeper
+    let viewModel: SessionViewModel
+}
+
+@MainActor
+func makeSessionTimeoutScenario(
+    isAuthenticated: Bool = false,
+    signOutResults: [Bool] = [],
+    authorizedDeviceRegistrar: any AuthorizedDeviceRegistrar = NoOpAuthorizedDeviceRegistrar(),
+    criticalDataFreshnessLocalRepository: any CriticalDataFreshnessLocalRepository =
+        NoOpCriticalDataFreshnessLocalRepository()
+) -> SessionTimeoutScenario {
+    let member = timeoutMember()
+    let principal = AuthPrincipal(
+        uid: member.authUid ?? "",
+        email: member.normalizedEmail
+    )
+    let provider = ControlledSessionAuthProvider(
+        isAuthenticated: isAuthenticated,
+        signOutResults: signOutResults
+    )
+    let sleeper = ControlledSessionOperationSleeper()
+    let repository = TimeoutSessionMemberRepository(member: member)
+    let environmentRouter = FixedSessionEnvironmentRouter()
+    let viewModel = SessionViewModel(
+        repository: repository,
+        authSessionProvider: provider,
+        resolveAuthorizedSession: ResolveAuthorizedSessionUseCase(
+            repository: repository,
+            resolver: TimeoutAuthorizedMemberResolver(member: member),
+            environmentRouter: environmentRouter
+        ),
+        authorizedDeviceRegistrar: authorizedDeviceRegistrar,
+        criticalDataFreshnessLocalRepository: criticalDataFreshnessLocalRepository,
+        environmentRouter: environmentRouter,
+        sessionRefreshPolicy: SessionRefreshPolicy(minimumForegroundIntervalMillis: 0),
+        nowMillisProvider: { 1_000 },
+        sessionOperationTimeout: .seconds(30),
+        sessionOperationSleeper: { try await sleeper.sleep(for: $0) }
+    )
+    return SessionTimeoutScenario(
+        member: member,
+        principal: principal,
+        provider: provider,
+        sleeper: sleeper,
+        viewModel: viewModel
+    )
+}
+
+@MainActor
+private func expireSignIn(
+    in scenario: SessionTimeoutScenario
+) async throws -> Task<Void, Never>? {
+    scenario.viewModel.emailInput = scenario.member.normalizedEmail
+    scenario.viewModel.passwordInput = "secret12"
+    scenario.viewModel.signIn()
+    guard await scenario.provider.waitForSignInRequestCount(1) else { return nil }
+    try await scenario.sleeper.waitForRequestCount(1)
+    #expect(await scenario.sleeper.requestedDuration(at: 0) == Duration.seconds(30))
+    guard let operation = scenario.viewModel.sessionOperationTask,
+          let timeout = scenario.viewModel.sessionOperationTimeoutTask else {
+        Issue.record("El login no conserva las tareas de operación y timeout")
+        return nil
+    }
+    await scenario.sleeper.completeRequest(at: 0)
+    await timeout.value
+    return operation
+}
+
+@MainActor
+private func populateValidAccessDrafts(
+    in viewModel: SessionViewModel,
+    member: Member
+) {
+    viewModel.emailInput = member.normalizedEmail
+    viewModel.passwordInput = "new-secret12"
+    viewModel.registerEmailInput = "new-member@example.com"
+    viewModel.registerPasswordInput = "new-secret12"
+    viewModel.registerRepeatPasswordInput = "new-secret12"
+}
+
+@MainActor
+private func timeoutMember() -> Member {
+    Member(
+        id: "timeout_member",
+        displayName: "Timeout Member",
+        normalizedEmail: "timeout@example.com",
+        authUid: "timeout_auth",
+        roles: [.member],
+        isActive: true,
+        producerCatalogEnabled: true
+    )
+}
+
+func timeoutAuthorizedMode(
+    member: Member,
+    principal: AuthPrincipal
+) -> SessionMode {
+    .authorized(
+        AuthorizedSession(
+            principal: principal,
+            authenticatedMember: member,
+            member: member,
+            members: [member],
+            environment: .develop
+        )
+    )
+}
+
+nonisolated private struct TimeoutAuthorizedMemberResolver: AuthorizedMemberResolving {
+    let member: Member
+
+    func resolve(
+        authPrincipal _: AuthPrincipal,
+        requestedEnvironment: SessionEnvironment
+    ) async throws -> AuthorizedMemberResolution {
+        AuthorizedMemberResolution(
+            memberId: member.id,
+            roles: member.roles,
+            isActive: member.isActive,
+            environment: requestedEnvironment,
+            firstLoginLinked: false
+        )
+    }
+}
+
+nonisolated private struct TimeoutSessionMemberRepository: MemberRepository {
+    let member: Member
+
+    func member(id: String) async throws -> Member? {
+        id == member.id ? member : nil
+    }
+
+    func members(visibleTo _: Member) async throws -> [Member] {
+        [member]
+    }
+
+    func updateOwnProducerCatalogEnabled(member _: Member, enabled _: Bool) async throws -> Member {
+        member
+    }
+}
+
+actor ControlledSessionOperationSleeper {
+    private var nextRequestIndex = 0
+    private var registeredRequestCount = 0
+    private var requestedDurations: [Duration] = []
+    private var requestContinuations: [Int: CheckedContinuation<Void, any Error>] = [:]
+    private var cancelledRequests: Set<Int> = []
+
+    func sleep(for duration: Duration) async throws {
+        let requestIndex = nextRequestIndex
+        nextRequestIndex += 1
+        requestedDurations.append(duration)
+        try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                if cancelledRequests.remove(requestIndex) != nil {
+                    continuation.resume(throwing: CancellationError())
+                } else {
+                    requestContinuations[requestIndex] = continuation
+                    registeredRequestCount += 1
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelRequest(at: requestIndex) }
+        }
+    }
+
+    func waitForRequestCount(_ expectedCount: Int) async throws {
+        for _ in 0 ..< 1_000 {
+            try Task.checkCancellation()
+            if registeredRequestCount >= expectedCount {
+                return
+            }
+            await Task.yield()
+        }
+        Issue.record("No se registraron \(expectedCount) deadlines de sesión")
+    }
+
+    func completeRequest(at index: Int) {
+        guard let continuation = requestContinuations.removeValue(forKey: index) else {
+            Issue.record("No existe el timeout de sesión número \(index)")
+            return
+        }
+        continuation.resume()
+    }
+
+    func requestedDuration(at index: Int) -> Duration? {
+        requestedDurations.indices.contains(index) ? requestedDurations[index] : nil
+    }
+
+    private func cancelRequest(at index: Int) {
+        guard let continuation = requestContinuations.removeValue(forKey: index) else {
+            cancelledRequests.insert(index)
+            return
+        }
+        continuation.resume(throwing: CancellationError())
+    }
+
+}

--- a/ios/Reguerta/ReguertaTests/SessionPostAuthenticationFailureTests.swift
+++ b/ios/Reguerta/ReguertaTests/SessionPostAuthenticationFailureTests.swift
@@ -1,0 +1,287 @@
+import Testing
+
+@testable import Reguerta
+
+@MainActor
+struct SessionPostAuthenticationFailureTests {
+    @Test("Un fallo del resolver después de Auth termina la sesión")
+    func resolverFailureTerminatesAuthenticatedSession() async {
+        let member = postAuthenticationMember()
+        let provider = ControlledSessionAuthProvider(
+            signInResult: .success(postAuthenticationPrincipal(for: member))
+        )
+        let viewModel = makePostAuthenticationViewModel(
+            member: member,
+            provider: provider,
+            resolver: FailingPostAuthenticationResolver()
+        )
+
+        guard let operation = startPostAuthenticationSignIn(
+            in: viewModel,
+            member: member
+        ) else { return }
+        await operation.value
+
+        assertPostAuthenticationFailure(viewModel: viewModel, provider: provider)
+    }
+
+    @Test("Un fallo del directorio privado después de Auth termina la sesión")
+    func memberListFailureTerminatesAuthenticatedSession() async {
+        let member = postAuthenticationMember()
+        let provider = ControlledSessionAuthProvider(
+            signInResult: .success(postAuthenticationPrincipal(for: member))
+        )
+        let viewModel = makePostAuthenticationViewModel(
+            member: member,
+            provider: provider,
+            resolver: SuccessfulPostAuthenticationResolver(member: member),
+            failsMemberList: true
+        )
+
+        guard let operation = startPostAuthenticationSignIn(
+            in: viewModel,
+            member: member
+        ) else { return }
+        await operation.value
+
+        assertPostAuthenticationFailure(viewModel: viewModel, provider: provider)
+    }
+
+    @Test("Un fallo post-mutación sin sign-out conserva el carril en drenaje")
+    func failedPostMutationSignOutRejectsSuccessor() async {
+        let member = postAuthenticationMember()
+        let provider = ControlledSessionAuthProvider(
+            signInResult: .failureAfterAuthenticationMutation(
+                reason: .unknown,
+                signedOut: false
+            ),
+            signOutResults: [false]
+        )
+        let viewModel = makePostAuthenticationViewModel(
+            member: member,
+            provider: provider,
+            resolver: SuccessfulPostAuthenticationResolver(member: member)
+        )
+
+        guard let operation = startPostAuthenticationSignIn(
+            in: viewModel,
+            member: member
+        ) else { return }
+        await operation.value
+
+        #expect(
+            viewModel.mode == .unauthorized(
+                email: member.normalizedEmail,
+                reason: .userAccessRestricted
+            )
+        )
+        #expect(viewModel.isSessionOperationDraining)
+        #expect(viewModel.sessionOperationTask != nil)
+        #expect(provider.isAuthenticated)
+        #expect(provider.signOutCallCount == 1)
+
+        viewModel.emailInput = member.normalizedEmail
+        viewModel.passwordInput = "secret12"
+        viewModel.signIn()
+        #expect(provider.signInRequestCount == 1)
+    }
+
+    @Test("Un cleanup post-mutación confirmado expulsa también el refresh")
+    func successfulPostMutationSignOutEndsAuthorizedRefresh() async {
+        let member = postAuthenticationMember()
+        let principal = postAuthenticationPrincipal(for: member)
+        let provider = ControlledSessionAuthProvider(
+            refreshResult: .failureAfterAuthenticationMutation(
+                reason: .unknown,
+                signedOut: true
+            ),
+            isAuthenticated: true
+        )
+        let viewModel = makePostAuthenticationViewModel(
+            member: member,
+            provider: provider,
+            resolver: SuccessfulPostAuthenticationResolver(member: member)
+        )
+        viewModel.mode = .authorized(
+            AuthorizedSession(
+                principal: principal,
+                authenticatedMember: member,
+                member: member,
+                members: [member],
+                environment: .develop
+            )
+        )
+
+        viewModel.refreshSession(trigger: .startup)
+        guard let operation = viewModel.sessionOperationTask else {
+            Issue.record("El refresh no conserva su tarea propietaria")
+            return
+        }
+        await operation.value
+
+        #expect(viewModel.mode == .signedOut)
+        #expect(viewModel.sessionOperationState == .idle)
+        #expect(viewModel.sessionOperationTask == nil)
+        #expect(provider.isAuthenticated == false)
+    }
+
+    @Test("El fallo post-mutación de alta conserva el email registrado")
+    func signUpPostMutationFailurePreservesRegistrationEmail() async {
+        let member = postAuthenticationMember()
+        let registrationEmail = "new-member@example.com"
+        let provider = ControlledSessionAuthProvider(
+            signUpResult: .failureAfterAuthenticationMutation(
+                reason: .unknown,
+                signedOut: false
+            ),
+            signOutResults: [true]
+        )
+        let viewModel = makePostAuthenticationViewModel(
+            member: member,
+            provider: provider,
+            resolver: SuccessfulPostAuthenticationResolver(member: member)
+        )
+        viewModel.emailInput = "stale-sign-in@example.com"
+        viewModel.registerEmailInput = "  NEW-MEMBER@example.com  "
+        viewModel.registerPasswordInput = "secret12"
+        viewModel.registerRepeatPasswordInput = "secret12"
+
+        viewModel.signUp()
+        guard let operation = viewModel.sessionOperationTask else {
+            Issue.record("El alta no conserva su tarea propietaria")
+            return
+        }
+        await operation.value
+
+        #expect(
+            viewModel.mode == .unauthorized(
+                email: registrationEmail,
+                reason: .userAccessRestricted
+            )
+        )
+        #expect(viewModel.sessionOperationState == .idle)
+        #expect(viewModel.sessionOperationTask == nil)
+        #expect(provider.isAuthenticated == false)
+        #expect(provider.signOutCallCount == 1)
+    }
+}
+
+@MainActor
+private func makePostAuthenticationViewModel(
+    member: Member,
+    provider: ControlledSessionAuthProvider,
+    resolver: some AuthorizedMemberResolving,
+    failsMemberList: Bool = false
+) -> SessionViewModel {
+    let repository = PostAuthenticationMemberRepository(
+        member: member,
+        failsMemberList: failsMemberList
+    )
+    let environmentRouter = FixedSessionEnvironmentRouter()
+    return SessionViewModel(
+        repository: repository,
+        authSessionProvider: provider,
+        resolveAuthorizedSession: ResolveAuthorizedSessionUseCase(
+            repository: repository,
+            resolver: resolver,
+            environmentRouter: environmentRouter
+        ),
+        environmentRouter: environmentRouter
+    )
+}
+
+@MainActor
+private func startPostAuthenticationSignIn(
+    in viewModel: SessionViewModel,
+    member: Member
+) -> Task<Void, Never>? {
+    viewModel.emailInput = member.normalizedEmail
+    viewModel.passwordInput = "secret12"
+    viewModel.signIn()
+    guard let operation = viewModel.sessionOperationTask else {
+        Issue.record("El login no conserva su tarea propietaria")
+        return nil
+    }
+    return operation
+}
+
+@MainActor
+private func assertPostAuthenticationFailure(
+    viewModel: SessionViewModel,
+    provider: ControlledSessionAuthProvider
+) {
+    #expect(viewModel.mode == .signedOut)
+    #expect(viewModel.sessionOperationState == .idle)
+    #expect(viewModel.sessionOperationTask == nil)
+    #expect(viewModel.isAuthenticating == false)
+    #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.authErrorNetwork)
+    #expect(provider.isAuthenticated == false)
+    #expect(provider.signOutCallCount == 2)
+}
+
+@MainActor
+private func postAuthenticationMember() -> Member {
+    Member(
+        id: "post_auth_member",
+        displayName: "Post Auth Member",
+        normalizedEmail: "post-auth@example.com",
+        authUid: "post_auth_uid",
+        roles: [.member],
+        isActive: true,
+        producerCatalogEnabled: true
+    )
+}
+
+private func postAuthenticationPrincipal(for member: Member) -> AuthPrincipal {
+    AuthPrincipal(uid: member.authUid ?? "", email: member.normalizedEmail)
+}
+
+private enum PostAuthenticationTestError: Error {
+    case failed
+}
+
+nonisolated private struct FailingPostAuthenticationResolver: AuthorizedMemberResolving {
+    func resolve(
+        authPrincipal _: AuthPrincipal,
+        requestedEnvironment _: SessionEnvironment
+    ) async throws -> AuthorizedMemberResolution {
+        throw PostAuthenticationTestError.failed
+    }
+}
+
+nonisolated private struct SuccessfulPostAuthenticationResolver: AuthorizedMemberResolving {
+    let member: Member
+
+    func resolve(
+        authPrincipal _: AuthPrincipal,
+        requestedEnvironment: SessionEnvironment
+    ) async throws -> AuthorizedMemberResolution {
+        AuthorizedMemberResolution(
+            memberId: member.id,
+            roles: member.roles,
+            isActive: member.isActive,
+            environment: requestedEnvironment,
+            firstLoginLinked: false
+        )
+    }
+}
+
+nonisolated private struct PostAuthenticationMemberRepository: MemberRepository {
+    let member: Member
+    let failsMemberList: Bool
+
+    func member(id: String) async throws -> Member? {
+        id == member.id ? member : nil
+    }
+
+    func members(visibleTo _: Member) async throws -> [Member] {
+        if failsMemberList {
+            throw PostAuthenticationTestError.failed
+        }
+        return [member]
+    }
+
+    func updateOwnProducerCatalogEnabled(member _: Member, enabled _: Bool) async throws -> Member {
+        member
+    }
+}


### PR DESCRIPTION
## Summary

- bound sign-in, sign-up, and session refresh with an injectable 30-second UI/ownership deadline
- keep late Firebase Auth work fail-closed in `DRAINING` until sign-out and composite cleanup complete
- reject Android refresh while any session operation or cleanup owns the lane
- add post-mutation cancellation checkpoints and deterministic race/cleanup coverage on Android and iOS
- fence iOS freshness metadata against late writes after session termination
- document the cross-platform policy in ADR-0008 in English and Spanish
- leave Firebase backend, Rules, Functions, and live data unchanged

## Review follow-up

- review found that an Android refresh with no prior UID could replace a sign-out `CLEANUP` barrier
- commit `08e6b51` blocks every refresh while the lane is owned and adds deterministic normal/failing-cleanup regressions
- RED reproduced one provider refresh after failed cleanup where zero was required; GREEN keeps the provider at zero and the lane in `DRAINING`
- two independent follow-up audits found no remaining issues

## Validation

- Android: `./gradlew app:testDebugUnitTest app:lintDebug --no-daemon` — 331 tests, 0 failures, BUILD SUCCESSFUL
- Android instrumentation: Pixel 8 Pro API 35 — 14/14, BUILD SUCCESSFUL
- iOS `ReguertaTests`, iPhone 17 / iOS 26.5 — 392 logical tests / 511 parameterized executions, 0 failures
- iOS UI — all 8 functional tests passed across the main run and one isolated retry; the launch screenshot test remains intentionally skipped
- SwiftLint — 16 existing warnings, 0 serious; no new warnings from this cut
- `git diff --check` — clean
- independent Android and final iOS audits — no findings

## Known validation limitation

The main UI run passed 7 tests, then Xcode repeatedly failed to launch the last runner with `DebuggerLLDB.DebuggerVersionStore.StoreError`. That invocation was stopped after 171 seconds; the affected test passed when rerun in isolation, so there is no outstanding product assertion failure.

Refs #218