### PR TITLE
🐛 fix(push): fence registration to live sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- 2026-07-28 | 🐛 fix(push): fence registration to live sessions
 - 2026-07-28 | 🐛 fix(android-auth): preserve cleanup quarantine
 - 2026-07-28 | 🐛 fix(auth): bound session operations
 - 2026-07-28 | 🐛 fix(android-auth): shorten credential lifetime

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/data/devices/AuthorizedDeviceProcessSession.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/data/devices/AuthorizedDeviceProcessSession.kt
@@ -1,0 +1,81 @@
+package com.reguerta.user.data.devices
+
+import java.util.concurrent.atomic.AtomicReference
+
+internal enum class AuthorizedDeviceProcessSessionMatch {
+    NOT_ESTABLISHED,
+    CURRENT,
+    SUPERSEDED,
+}
+
+internal interface AuthorizedDeviceProcessSession {
+    fun activationGeneration(): Long
+
+    fun activate(
+        context: AuthorizedDeviceSessionContext,
+        expectedGeneration: Long,
+    ): Boolean
+
+    fun invalidate()
+
+    fun invalidateIfOwned(context: AuthorizedDeviceSessionContext)
+
+    fun match(context: AuthorizedDeviceSessionContext): AuthorizedDeviceProcessSessionMatch
+}
+
+internal object ReguertaAuthorizedDeviceProcessSession : AuthorizedDeviceProcessSession {
+    private data class State(
+        val generation: Long,
+        val activeContext: AuthorizedDeviceSessionContext?,
+    )
+
+    private val state = AtomicReference(
+        State(generation = 0L, activeContext = null),
+    )
+
+    override fun activationGeneration(): Long = state.get().generation
+
+    override fun activate(
+        context: AuthorizedDeviceSessionContext,
+        expectedGeneration: Long,
+    ): Boolean {
+        while (true) {
+            val currentState = state.get()
+            if (currentState.generation != expectedGeneration) return false
+            if (state.compareAndSet(currentState, currentState.copy(activeContext = context))) {
+                return true
+            }
+        }
+    }
+
+    override fun invalidate() {
+        while (true) {
+            val currentState = state.get()
+            val invalidatedState = State(
+                generation = currentState.generation + 1L,
+                activeContext = null,
+            )
+            if (state.compareAndSet(currentState, invalidatedState)) return
+        }
+    }
+
+    override fun invalidateIfOwned(context: AuthorizedDeviceSessionContext) {
+        while (true) {
+            val currentState = state.get()
+            if (currentState.activeContext != context) return
+            if (state.compareAndSet(currentState, currentState.copy(activeContext = null))) return
+        }
+    }
+
+    override fun match(
+        context: AuthorizedDeviceSessionContext,
+    ): AuthorizedDeviceProcessSessionMatch {
+        val currentContext = state.get().activeContext
+            ?: return AuthorizedDeviceProcessSessionMatch.NOT_ESTABLISHED
+        return if (currentContext == context) {
+            AuthorizedDeviceProcessSessionMatch.CURRENT
+        } else {
+            AuthorizedDeviceProcessSessionMatch.SUPERSEDED
+        }
+    }
+}

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/data/devices/AuthorizedDeviceTokenRefreshCoordinator.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/data/devices/AuthorizedDeviceTokenRefreshCoordinator.kt
@@ -25,6 +25,8 @@ internal class AuthorizedDeviceTokenRefreshCoordinator(
     private val currentAuthUidProvider: () -> String?,
     private val nowMillisProvider: () -> Long,
     private val deviceProvider: (token: String, deviceId: String, nowMillis: Long) -> RegisteredDevice,
+    private val processSession: AuthorizedDeviceProcessSession =
+        ReguertaAuthorizedDeviceProcessSession,
 ) {
     private val refreshMutex = Mutex()
 
@@ -46,6 +48,13 @@ internal class AuthorizedDeviceTokenRefreshCoordinator(
 
         val authorizedContext = store.getAuthorizedSessionContext()
             ?: return AuthorizedDeviceTokenRefreshResult.STORED_ONLY
+        when (processSession.match(authorizedContext)) {
+            AuthorizedDeviceProcessSessionMatch.NOT_ESTABLISHED ->
+                return AuthorizedDeviceTokenRefreshResult.STORED_ONLY
+            AuthorizedDeviceProcessSessionMatch.SUPERSEDED ->
+                return AuthorizedDeviceTokenRefreshResult.STALE_SESSION
+            AuthorizedDeviceProcessSessionMatch.CURRENT -> Unit
+        }
         if (currentAuthUidProvider() != authorizedContext.authUid) {
             return AuthorizedDeviceTokenRefreshResult.STALE_SESSION
         }
@@ -63,7 +72,9 @@ internal class AuthorizedDeviceTokenRefreshCoordinator(
             isSessionCurrent = {
                 store.getAuthorizedSessionContext() == authorizedContext &&
                     store.getFcmToken() == normalizedToken &&
-                    currentAuthUidProvider() == authorizedContext.authUid
+                    currentAuthUidProvider() == authorizedContext.authUid &&
+                    processSession.match(authorizedContext) ==
+                    AuthorizedDeviceProcessSessionMatch.CURRENT
             },
         )
         return AuthorizedDeviceTokenRefreshResult.UPLOADED

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/data/devices/DeviceRegistrationPreferences.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/data/devices/DeviceRegistrationPreferences.kt
@@ -116,23 +116,34 @@ class DeviceRegistrationPreferences internal constructor(
         authUid: String,
         environment: String,
         isSessionCurrent: () -> Boolean = { true },
-    ): Boolean = withEncryptedPreferences { preferences ->
+    ): AuthorizedDeviceSessionContext? = withEncryptedPreferences { preferences ->
         if (!isSessionCurrent()) {
-            return@withEncryptedPreferences false
+            return@withEncryptedPreferences null
         }
+        val authorizedContext = AuthorizedDeviceSessionContext(
+            memberId = requireNotNull(memberId.normalizedOrNull()) {
+                "Authorized member ID must not be blank"
+            },
+            authUid = requireNotNull(authUid.normalizedOrNull()) {
+                "Authorized Auth UID must not be blank"
+            },
+            environment = requireNotNull(
+                environment.trim().lowercase(Locale.ROOT).ifBlank { null },
+            ) {
+                "Authorized environment must not be blank"
+            },
+            leaseId = leaseIdProvider(),
+        )
         writeValues(
             preferences = preferences,
             values = mapOf(
-                KEY_MEMBER_ID to memberId.normalizedOrNull(),
-                KEY_AUTH_UID to authUid.normalizedOrNull(),
-                KEY_ENVIRONMENT to environment
-                    .trim()
-                    .lowercase(Locale.ROOT)
-                    .ifBlank { null },
-                KEY_LEASE_ID to leaseIdProvider(),
+                KEY_MEMBER_ID to authorizedContext.memberId,
+                KEY_AUTH_UID to authorizedContext.authUid,
+                KEY_ENVIRONMENT to authorizedContext.environment,
+                KEY_LEASE_ID to authorizedContext.leaseId,
             ),
         )
-        true
+        authorizedContext
     }
 
     suspend fun clearAuthorizedSessionContext() {
@@ -146,15 +157,26 @@ class DeviceRegistrationPreferences internal constructor(
 
     override suspend fun getAuthorizedSessionContext(): AuthorizedDeviceSessionContext? =
         withEncryptedPreferences { preferences ->
+            val presentKeys = AUTHORIZED_SESSION_KEYS.filterTo(mutableSetOf()) { key ->
+                containsKey(preferences, key)
+            }
+            if (presentKeys.isEmpty()) {
+                return@withEncryptedPreferences null
+            }
             val values = AUTHORIZED_SESSION_KEYS.associateWith { key ->
                 readOptionalString(preferences, key)
             }
-            if (values.values.all { it == null }) {
+            val missingKeys = values.filterValues { it == null }.keys
+            if (
+                missingKeys == setOf(KEY_AUTH_UID) &&
+                presentKeys == LEGACY_AUTHORIZED_SESSION_KEYS
+            ) {
+                deleteKeys(preferences, AUTHORIZED_SESSION_KEYS)
                 return@withEncryptedPreferences null
             }
             if (values.values.any { it == null }) {
                 throw DeviceRegistrationPreferencesException.Corrupted(
-                    keys = values.filterValues { it == null }.keys,
+                    keys = missingKeys,
                 )
             }
 
@@ -199,6 +221,17 @@ class DeviceRegistrationPreferences internal constructor(
     private fun readOptionalString(preferences: SharedPreferences, key: String): String? =
         try {
             preferences.getString(key, null).normalizedOrNull()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: DeviceRegistrationPreferencesException) {
+            throw error
+        } catch (error: Exception) {
+            throw DeviceRegistrationPreferencesException.Read(key = key, cause = error)
+        }
+
+    private fun containsKey(preferences: SharedPreferences, key: String): Boolean =
+        try {
+            preferences.contains(key)
         } catch (error: CancellationException) {
             throw error
         } catch (error: DeviceRegistrationPreferencesException) {
@@ -263,6 +296,11 @@ class DeviceRegistrationPreferences internal constructor(
         val AUTHORIZED_SESSION_KEYS = setOf(
             KEY_MEMBER_ID,
             KEY_AUTH_UID,
+            KEY_ENVIRONMENT,
+            KEY_LEASE_ID,
+        )
+        val LEGACY_AUTHORIZED_SESSION_KEYS = setOf(
+            KEY_MEMBER_ID,
             KEY_ENVIRONMENT,
             KEY_LEASE_ID,
         )

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/data/devices/FirebaseAuthorizedDeviceRegistrar.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/data/devices/FirebaseAuthorizedDeviceRegistrar.kt
@@ -25,6 +25,8 @@ class FirebaseAuthorizedDeviceRegistrar(
     }
 
     private val registrationGeneration = AtomicLong(0L)
+    private val processSession: AuthorizedDeviceProcessSession =
+        ReguertaAuthorizedDeviceProcessSession
     private val registrationWriter = AuthorizedDeviceRegistrationWriter(
         store = preferences,
         repository = repository,
@@ -36,6 +38,7 @@ class FirebaseAuthorizedDeviceRegistrar(
         isSessionCurrent: () -> Boolean,
     ) {
         val generation = registrationGeneration.get()
+        val processActivationGeneration = processSession.activationGeneration()
         val registrationIsCurrent = {
             registrationGeneration.get() == generation && isSessionCurrent()
         }
@@ -49,13 +52,24 @@ class FirebaseAuthorizedDeviceRegistrar(
             val authUid = requireNotNull(member.authUid?.trim()?.ifBlank { null }) {
                 "Authorized member must have an Auth UID"
             }
-            val contextSaved = preferences.saveAuthorizedSessionContext(
+            val authorizedContext = preferences.saveAuthorizedSessionContext(
                 memberId = member.id,
                 authUid = authUid,
                 environment = environment,
                 isSessionCurrent = registrationIsCurrent,
             )
-            if (!contextSaved) return
+                ?: return
+            if (!registrationIsCurrent()) return
+            if (!processSession.activate(authorizedContext, processActivationGeneration)) return
+            if (!registrationIsCurrent()) {
+                processSession.invalidateIfOwned(authorizedContext)
+                return
+            }
+            val authorizedRegistrationIsCurrent = {
+                registrationIsCurrent() &&
+                    processSession.match(authorizedContext) ==
+                    AuthorizedDeviceProcessSessionMatch.CURRENT
+            }
             Log.d(TAG, "Registering authorized device")
 
             val device = RegisteredDevice(
@@ -75,7 +89,7 @@ class FirebaseAuthorizedDeviceRegistrar(
                 memberId = member.id,
                 environment = environment,
                 device = device,
-                isSessionCurrent = registrationIsCurrent,
+                isSessionCurrent = authorizedRegistrationIsCurrent,
                 refreshedDevice = { latestToken ->
                     val refreshedAtMillis = nowMillisProvider()
                     device.copy(
@@ -97,7 +111,7 @@ class FirebaseAuthorizedDeviceRegistrar(
     }
 
     override suspend fun clearAuthorizedSession() {
-        registrationGeneration.incrementAndGet()
+        invalidateAuthorizedSession()
         try {
             preferences.clearAuthorizedSessionContext()
         } catch (error: CancellationException) {
@@ -106,6 +120,11 @@ class FirebaseAuthorizedDeviceRegistrar(
             Log.e(TAG, "Unable to clear authorized device storage")
             throw error
         }
+    }
+
+    override fun invalidateAuthorizedSession() {
+        registrationGeneration.incrementAndGet()
+        processSession.invalidate()
     }
 
     private fun resolveAppVersion(): String {

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/domain/devices/AuthorizedDeviceRegistrar.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/domain/devices/AuthorizedDeviceRegistrar.kt
@@ -9,5 +9,7 @@ fun interface AuthorizedDeviceRegistrar {
         isSessionCurrent: () -> Boolean,
     )
 
+    fun invalidateAuthorizedSession() = Unit
+
     suspend fun clearAuthorizedSession() = Unit
 }

--- a/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/auth/SessionAuthActions.kt
+++ b/android/Reguerta/app/src/main/java/com/reguerta/user/presentation/auth/SessionAuthActions.kt
@@ -315,12 +315,14 @@ internal class SessionAuthActions(
     }
 
     fun signOut() {
+        invalidateAuthorizedDeviceSessionSafely()
         cancelMyOrderFreshness()
         val cleanupJob = ownSessionTerminationCleanup {
             val authenticationAndRoutingClosed = closeAuthenticationAndRoutingSafely()
             val privateContextClosed = clearPrivateSessionContext()
             authenticationAndRoutingClosed && privateContextClosed
         }
+        invalidateAuthorizedDeviceSessionSafely()
         closeAuthenticationAndRoutingSafely()
         clearSessionRefreshTracking()
         uiState.update { state -> state.toSignedOutSessionState(showSessionExpiredDialog = false) }
@@ -709,6 +711,7 @@ internal class SessionAuthActions(
     }
 
     private fun recoverSessionUi(kind: SessionAuthOperationKind) {
+        invalidateAuthorizedDeviceSessionSafely()
         cancelMyOrderFreshness()
         clearSessionRefreshTracking()
         uiState.update { state ->
@@ -839,6 +842,7 @@ internal class SessionAuthActions(
             ) {
                 throw CancellationException("Session operation was superseded before routing")
             }
+            invalidateAuthorizedDeviceSessionSafely()
             sessionEnvironmentRouter.applyResolvedEnvironment(environment)
         }
     }
@@ -945,6 +949,14 @@ internal class SessionAuthActions(
         return deviceContextClosed && localFreshnessClosed
     }
 
+    private fun invalidateAuthorizedDeviceSessionSafely(): Boolean =
+        try {
+            authorizedDeviceRegistrar.invalidateAuthorizedSession()
+            true
+        } catch (_: Exception) {
+            false
+        }
+
     private fun resetSessionRoutingSafely(): Boolean =
         try {
             sessionEnvironmentRouter.resetToBaseEnvironment()
@@ -962,6 +974,7 @@ internal class SessionAuthActions(
             return abandonStaleAuthorizedSession()
         }
 
+        invalidateAuthorizedDeviceSessionSafely()
         cancelMyOrderFreshness()
         clearSessionRefreshTracking()
         if (!updateUiStateIfCurrent(operation, transformUiState)) {

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/data/devices/AuthorizedDeviceTokenRefreshCoordinatorTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/data/devices/AuthorizedDeviceTokenRefreshCoordinatorTest.kt
@@ -57,6 +57,84 @@ class AuthorizedDeviceTokenRefreshCoordinatorTest {
     }
 
     @Test
+    fun `cold process stores token without adopting persisted authorization`() = runTest {
+        val context = authorizedContext()
+        val store = FakeAuthorizedDeviceTokenStore(context = context)
+        val repository = RecordingDeviceRegistrationRepository()
+        val processSession = FakeAuthorizedDeviceProcessSession()
+        val coordinator = coordinator(
+            store = store,
+            repository = repository,
+            processSession = processSession,
+        )
+
+        val result = coordinator.refresh("TOKEN-A")
+
+        assertEquals(AuthorizedDeviceTokenRefreshResult.STORED_ONLY, result)
+        assertEquals("TOKEN-A", store.fcmToken)
+        assertTrue(repository.registrations.isEmpty())
+    }
+
+    @Test
+    fun `different process lease rejects persisted authorization`() = runTest {
+        val context = authorizedContext(leaseId = "LEASE-A")
+        val store = FakeAuthorizedDeviceTokenStore(context = context)
+        val repository = RecordingDeviceRegistrationRepository()
+        val processSession = FakeAuthorizedDeviceProcessSession(
+            initialContext = context.copy(leaseId = "LEASE-B"),
+        )
+        val coordinator = coordinator(
+            store = store,
+            repository = repository,
+            processSession = processSession,
+        )
+
+        val result = coordinator.refresh("TOKEN-A")
+
+        assertEquals(AuthorizedDeviceTokenRefreshResult.STALE_SESSION, result)
+        assertTrue(repository.registrations.isEmpty())
+    }
+
+    @Test
+    fun `different process environment rejects persisted authorization`() = runTest {
+        val context = authorizedContext(environment = "develop")
+        val store = FakeAuthorizedDeviceTokenStore(context = context)
+        val repository = RecordingDeviceRegistrationRepository()
+        val processSession = FakeAuthorizedDeviceProcessSession(
+            initialContext = context.copy(environment = "production"),
+        )
+        val coordinator = coordinator(
+            store = store,
+            repository = repository,
+            processSession = processSession,
+        )
+
+        val result = coordinator.refresh("TOKEN-A")
+
+        assertEquals(AuthorizedDeviceTokenRefreshResult.STALE_SESSION, result)
+        assertTrue(repository.registrations.isEmpty())
+    }
+
+    @Test
+    fun `invalidation supersedes an activation permit`() {
+        ReguertaAuthorizedDeviceProcessSession.invalidate()
+        val activationGeneration =
+            ReguertaAuthorizedDeviceProcessSession.activationGeneration()
+
+        ReguertaAuthorizedDeviceProcessSession.invalidate()
+        val activated = ReguertaAuthorizedDeviceProcessSession.activate(
+            context = authorizedContext(),
+            expectedGeneration = activationGeneration,
+        )
+
+        assertFalse(activated)
+        assertEquals(
+            AuthorizedDeviceProcessSessionMatch.NOT_ESTABLISHED,
+            ReguertaAuthorizedDeviceProcessSession.match(authorizedContext()),
+        )
+    }
+
+    @Test
     fun `authorized refresh forwards persisted member environment and device`() = runTest {
         val context = authorizedContext(
             memberId = "MEMBER-A",
@@ -133,6 +211,33 @@ class AuthorizedDeviceTokenRefreshCoordinatorTest {
     }
 
     @Test
+    fun `process invalidation while repository is suspended prevents commit`() = runTest {
+        val registrationStarted = CompletableDeferred<Unit>()
+        val registrationRelease = CompletableDeferred<Unit>()
+        val context = authorizedContext()
+        val store = FakeAuthorizedDeviceTokenStore(context = context)
+        val processSession = FakeAuthorizedDeviceProcessSession(initialContext = context)
+        val repository = RecordingDeviceRegistrationRepository(
+            suspendedToken = "TOKEN-A",
+            started = registrationStarted,
+            release = registrationRelease,
+        )
+        val coordinator = coordinator(
+            store = store,
+            repository = repository,
+            processSession = processSession,
+        )
+
+        val refresh = async { runCatching { coordinator.refresh("TOKEN-A") } }
+        registrationStarted.await()
+        processSession.invalidate()
+        registrationRelease.complete(Unit)
+
+        assertTrue(refresh.await().isFailure)
+        assertTrue(repository.registrations.isEmpty())
+    }
+
+    @Test
     fun `login registration catches up token received before context was published`() = runTest {
         val store = FakeAuthorizedDeviceTokenStore(context = null)
         val repository = RecordingDeviceRegistrationRepository()
@@ -196,10 +301,13 @@ class AuthorizedDeviceTokenRefreshCoordinatorTest {
     private fun coordinator(
         store: FakeAuthorizedDeviceTokenStore,
         repository: RecordingDeviceRegistrationRepository,
+        processSession: AuthorizedDeviceProcessSession =
+            FakeAuthorizedDeviceProcessSession(initialContext = store.context),
         currentAuthUid: () -> String? = { "UID-A" },
     ) = AuthorizedDeviceTokenRefreshCoordinator(
         store = store,
         repository = repository,
+        processSession = processSession,
         currentAuthUidProvider = currentAuthUid,
         nowMillisProvider = { 1_000L },
         deviceProvider = { token, deviceId, nowMillis ->
@@ -223,11 +331,12 @@ class AuthorizedDeviceTokenRefreshCoordinatorTest {
         memberId: String = "MEMBER-A",
         authUid: String = "UID-A",
         environment: String = "develop",
+        leaseId: String = "LEASE-A",
     ) = AuthorizedDeviceSessionContext(
         memberId = memberId,
         authUid = authUid,
         environment = environment,
-        leaseId = "LEASE-A",
+        leaseId = leaseId,
     )
 
     private fun registeredDevice(token: String?) = RegisteredDevice(
@@ -248,6 +357,46 @@ class AuthorizedDeviceTokenRefreshCoordinatorTest {
         val projectRoot = generateSequence(Path.of(System.getProperty("user.dir"))) { it.parent }
             .first { Files.exists(it.resolve("app/src/main/java/com/reguerta/user")) }
         return Files.readString(projectRoot.resolve("app/src/main/java/com/reguerta/user/$relativePath"))
+    }
+}
+
+private class FakeAuthorizedDeviceProcessSession(
+    initialContext: AuthorizedDeviceSessionContext? = null,
+) : AuthorizedDeviceProcessSession {
+    private var generation = 0L
+    private var activeContext = initialContext
+
+    override fun activationGeneration(): Long = generation
+
+    override fun activate(
+        context: AuthorizedDeviceSessionContext,
+        expectedGeneration: Long,
+    ): Boolean {
+        if (generation != expectedGeneration) return false
+        activeContext = context
+        return true
+    }
+
+    override fun invalidate() {
+        generation += 1L
+        activeContext = null
+    }
+
+    override fun invalidateIfOwned(context: AuthorizedDeviceSessionContext) {
+        if (activeContext == context) {
+            activeContext = null
+        }
+    }
+
+    override fun match(
+        context: AuthorizedDeviceSessionContext,
+    ): AuthorizedDeviceProcessSessionMatch = when (val currentContext = activeContext) {
+        null -> AuthorizedDeviceProcessSessionMatch.NOT_ESTABLISHED
+        context -> AuthorizedDeviceProcessSessionMatch.CURRENT
+        else -> {
+            check(currentContext != context)
+            AuthorizedDeviceProcessSessionMatch.SUPERSEDED
+        }
     }
 }
 

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/data/devices/DeviceRegistrationPreferencesTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/data/devices/DeviceRegistrationPreferencesTest.kt
@@ -159,7 +159,6 @@ class DeviceRegistrationPreferencesTest {
             environment = " ProDuction ",
         )
 
-        assertTrue(saved)
         assertEquals(
             AuthorizedDeviceSessionContext(
                 memberId = "MEMBER-1",
@@ -167,8 +166,9 @@ class DeviceRegistrationPreferencesTest {
                 environment = "production",
                 leaseId = "LEASE-1",
             ),
-            preferences.getAuthorizedSessionContext(),
+            saved,
         )
+        assertEquals(saved, preferences.getAuthorizedSessionContext())
     }
 
     @Test
@@ -195,7 +195,7 @@ class DeviceRegistrationPreferencesTest {
             isSessionCurrent = { false },
         )
 
-        assertFalse(saved)
+        assertNull(saved)
         assertEquals(
             AuthorizedDeviceSessionContext(
                 memberId = "CURRENT-MEMBER",
@@ -240,14 +240,77 @@ class DeviceRegistrationPreferencesTest {
     }
 
     @Test
-    fun `partial authorized context is corruption rather than absence`() = runTest {
+    fun `legacy encrypted context without auth uid is invalidated without deleting device data`() = runTest {
+        val encryptedPreferences = FakeSharedPreferences(
+            initialValues = mapOf(
+                "device_id" to "DEVICE-1",
+                "fcm_token" to "TOKEN-1",
+                "member_id" to "MEMBER-1",
+                "environment" to "production",
+                "lease_id" to "LEASE-1",
+            ),
+        )
+        val preferences = testPreferences(
+            encrypted = encryptedPreferences,
+            raw = FakeSharedPreferences(),
+        )
+
+        assertNull(preferences.getAuthorizedSessionContext())
+        assertFalse(encryptedPreferences.contains("member_id"))
+        assertFalse(encryptedPreferences.contains("auth_uid"))
+        assertFalse(encryptedPreferences.contains("environment"))
+        assertFalse(encryptedPreferences.contains("lease_id"))
+        assertEquals("DEVICE-1", preferences.getOrCreateDeviceId())
+        assertEquals("TOKEN-1", preferences.getFcmToken())
+    }
+
+    @Test
+    fun `unknown partial authorized context is corruption rather than absence`() = runTest {
         val preferences = testPreferences(
             encrypted = FakeSharedPreferences(
                 initialValues = mapOf(
                     "member_id" to "MEMBER-1",
+                    "auth_uid" to "UID-1",
                     "environment" to "production",
-                    "lease_id" to "LEASE-1",
                 ),
+            ),
+            raw = FakeSharedPreferences(),
+        )
+
+        assertSuspendThrows<DeviceRegistrationPreferencesException.Corrupted> {
+            preferences.getAuthorizedSessionContext()
+        }
+    }
+
+    @Test
+    fun `blank stored auth uid remains corruption rather than legacy absence`() = runTest {
+        val encryptedPreferences = FakeSharedPreferences(
+            initialValues = mapOf(
+                "member_id" to "MEMBER-1",
+                "auth_uid" to "   ",
+                "environment" to "production",
+                "lease_id" to "LEASE-1",
+            ),
+        )
+        val preferences = testPreferences(
+            encrypted = encryptedPreferences,
+            raw = FakeSharedPreferences(),
+        )
+
+        assertSuspendThrows<DeviceRegistrationPreferencesException.Corrupted> {
+            preferences.getAuthorizedSessionContext()
+        }
+        assertTrue(encryptedPreferences.contains("member_id"))
+        assertTrue(encryptedPreferences.contains("auth_uid"))
+        assertTrue(encryptedPreferences.contains("environment"))
+        assertTrue(encryptedPreferences.contains("lease_id"))
+    }
+
+    @Test
+    fun `isolated blank authorized key remains corruption rather than absence`() = runTest {
+        val preferences = testPreferences(
+            encrypted = FakeSharedPreferences(
+                initialValues = mapOf("auth_uid" to "   "),
             ),
             raw = FakeSharedPreferences(),
         )

--- a/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/auth/SessionAuthActionsConcurrencyTest.kt
+++ b/android/Reguerta/app/src/test/java/com/reguerta/user/presentation/auth/SessionAuthActionsConcurrencyTest.kt
@@ -825,6 +825,9 @@ class SessionAuthActionsConcurrencyTest {
     fun `environment switch forces critical freshness check for the same principal`() = runTest {
         val principal = principal("environment")
         val member = member(principal)
+        val lifecycleEvents = mutableListOf<String>()
+        val environmentRouter = RecordingSessionEnvironmentRouter(lifecycleEvents)
+        val deviceRegistrar = TestAuthorizedDeviceRegistrar(lifecycleEvents = lifecycleEvents)
         val authProvider = ControlledAuthSessionProvider(
             refreshResult = CompletableDeferred(AuthSessionRefreshResult.Active(principal)),
         )
@@ -836,6 +839,8 @@ class SessionAuthActionsConcurrencyTest {
             ),
             authProvider = authProvider,
             authorizedMemberResolver = ProductionAuthorizedMemberResolver,
+            environmentRouter = environmentRouter,
+            deviceRegistrar = deviceRegistrar,
             freshnessRemoteRepository = freshnessRemoteRepository,
         )
 
@@ -846,6 +851,10 @@ class SessionAuthActionsConcurrencyTest {
         assertEquals(MyOrderFreshnessUiState.Ready, fixture.state.value.myOrderFreshnessState)
         assertEquals(1, fixture.localFreshnessRepository.saveRequests)
         assertEquals(listOf("production"), freshnessRemoteRepository.requestedEnvironments)
+        assertTrue(
+            lifecycleEvents.indexOf("invalidate") <
+                lifecycleEvents.indexOf("apply:production"),
+        )
     }
 
     @Test
@@ -1012,10 +1021,15 @@ class SessionAuthActionsConcurrencyTest {
         fixture.actions.signIn("secret123")
         resolverStarted.await()
         fixture.actions.signOut()
+        val invalidationRequestsAfterSignOut = fixture.deviceRegistrar.invalidationRequests
         resolverRelease.complete(Unit)
         advanceUntilIdle()
 
         assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
+        assertEquals(
+            invalidationRequestsAfterSignOut,
+            fixture.deviceRegistrar.invalidationRequests,
+        )
         assertTrue(environmentRouter.appliedEnvironments.isEmpty())
         assertEquals(null, environmentRouter.currentEnvironment)
         assertEquals(0, memberRepository.findByAuthUidRequests)
@@ -1069,10 +1083,21 @@ class SessionAuthActionsConcurrencyTest {
 
         fixture.actions.signIn("secret123")
         registrationStarted.await()
+        val invalidationRequestsBeforeLogout = deviceRegistrar.invalidationRequests
+        val invalidationFenceCountBeforeLogout =
+            deviceRegistrar.sessionFenceValuesAtInvalidation.size
         fixture.actions.signOut()
+        val invalidationRequestsAtLogout =
+            deviceRegistrar.invalidationRequests - invalidationRequestsBeforeLogout
+        val sessionFenceValuesAtLogout = deviceRegistrar.sessionFenceValuesAtInvalidation
+            .drop(invalidationFenceCountBeforeLogout)
+        val clearRequestsAtLogout = deviceRegistrar.clearRequests
         registrationRelease.complete(Unit)
         advanceUntilIdle()
 
+        assertEquals(2, invalidationRequestsAtLogout)
+        assertEquals(listOf(true, false), sessionFenceValuesAtLogout)
+        assertEquals(0, clearRequestsAtLogout)
         assertTrue(fixture.state.value.mode is SessionMode.SignedOut)
         assertEquals(listOf("develop"), deviceRegistrar.requestedEnvironments)
         assertEquals(0, deviceRegistrar.completedRegistrations)
@@ -1336,11 +1361,15 @@ private class TestAuthorizedDeviceRegistrar(
     private val started: CompletableDeferred<Unit>? = null,
     private val release: CompletableDeferred<Unit>? = null,
     private val clearErrors: List<Throwable?> = emptyList(),
+    private val lifecycleEvents: MutableList<String>? = null,
 ) : AuthorizedDeviceRegistrar {
     var registerRequests = 0
     var completedRegistrations = 0
     var clearRequests = 0
+    var invalidationRequests = 0
+    val sessionFenceValuesAtInvalidation = mutableListOf<Boolean?>()
     val requestedEnvironments = mutableListOf<String>()
+    private var currentSessionFence: (() -> Boolean)? = null
 
     override suspend fun register(
         member: Member,
@@ -1348,7 +1377,9 @@ private class TestAuthorizedDeviceRegistrar(
         isSessionCurrent: () -> Boolean,
     ) {
         registerRequests += 1
+        currentSessionFence = isSessionCurrent
         requestedEnvironments += environment
+        lifecycleEvents?.add("register:$environment")
         started?.complete(Unit)
         release?.let { gate ->
             withContext(NonCancellable) {
@@ -1364,6 +1395,12 @@ private class TestAuthorizedDeviceRegistrar(
         val error = clearErrors.getOrNull(clearRequests)
         clearRequests += 1
         error?.let { throw it }
+    }
+
+    override fun invalidateAuthorizedSession() {
+        invalidationRequests += 1
+        sessionFenceValuesAtInvalidation += currentSessionFence?.invoke()
+        lifecycleEvents?.add("invalidate")
     }
 }
 
@@ -1670,7 +1707,9 @@ private fun validFreshnessMetadata(
         .associateWith { 2_000L },
 )
 
-private class RecordingSessionEnvironmentRouter : SessionEnvironmentRouter {
+private class RecordingSessionEnvironmentRouter(
+    private val lifecycleEvents: MutableList<String>? = null,
+) : SessionEnvironmentRouter {
     var currentEnvironment: String? = null
     val appliedEnvironments = mutableListOf<String>()
     var resetRequests = 0
@@ -1678,6 +1717,7 @@ private class RecordingSessionEnvironmentRouter : SessionEnvironmentRouter {
     override fun applyResolvedEnvironment(environment: String) {
         currentEnvironment = environment
         appliedEnvironments += environment
+        lifecycleEvents?.add("apply:$environment")
     }
 
     override fun resetToBaseEnvironment() {

--- a/docs-es/decisions/0009-exigir-autorizacion-push-viva-de-proceso.md
+++ b/docs-es/decisions/0009-exigir-autorizacion-push-viva-de-proceso.md
@@ -1,0 +1,169 @@
+# ADR-0009: Exigir autorización viva de proceso para registrar push de cuenta
+
+## Estado
+
+Aceptada
+
+## Fecha
+
+2026-07-28
+
+## Contexto
+
+Reguerta guarda un identificador de dispositivo, el último token de registro
+FCM y un contexto de cuenta autorizada para asociar las renovaciones del token
+con el miembro correcto. El ADR-0007 mantiene a los clientes Firebase
+publicados en un despliegue de autorización por fases, así que un callback móvil
+todavía no puede confiar en que las Rules estrictas rechacen cada registro
+obsoleto.
+
+La issue #214 añadió almacenamiento cifrado, contextos exactos `memberId +
+authUid + environment + lease` y revalidación en el repositorio. Aún quedaba un
+hueco de ciclo de vida: un proceso nuevo podía combinar Firebase Auth restaurado
+con el estado de disco y subir un token antes de que la aplicación revalidara al
+miembro autorizado. Android también podía recibir un callback FCM mientras el
+cleanup de logout esperaba trabajo de sesión anterior. En iOS, el callback de
+mensajería podía adoptar un contexto de Keychain en un coordinador recién
+creado.
+
+Un contexto persistido solo demuestra lo autorizado por un proceso anterior.
+No demuestra que el proceso actual haya completado la resolución del miembro,
+la validación de estado activo y la propiedad de la sesión.
+
+## Impulsores de la decisión
+
+- Detener la asociación del token en cuanto la sesión local pierde autorización.
+- No reconstruir nunca la autoridad de subida solo desde Firebase Auth y disco.
+- Conservar el token para que un login válido posterior pueda recuperarlo sin
+  perder el callback de renovación.
+- Aplicar las mismas comprobaciones de miembro, UID, entorno, lease y ciclo de
+  vida en Android e iOS.
+- Mantener compatibilidad con los clientes publicados y el despliegue Firebase
+  por fases.
+- Evitar cambios de backend, Rules, Functions o datos live en este corte.
+
+## Decisión
+
+El registro push ligado a una cuenta exige una **autorización viva de proceso**
+además de Firebase Auth y del estado cifrado persistido.
+
+Esa autorización contiene el miembro, UID de Auth, entorno y lease exactos que
+ha establecido el flujo de sesión autorizada actual. También conserva un fence
+vivo de proceso/sesión: generaciones atómicas en Android y la closure de
+propiedad de sesión en iOS. Cada subida debe demostrar en los checkpoints del
+repositorio, inmediatamente antes de escribir, que:
+
+1. La autorización viva de proceso sigue siendo propietaria de la operación.
+2. El UID actual de Firebase coincide con el UID autorizado.
+3. El contexto persistido sigue coincidiendo en miembro, UID, entorno y lease.
+4. El último token guardado coincide con el token que se va a escribir.
+5. El fence de proceso/sesión sigue declarando vigente la sesión autorizada.
+
+El callback del token siempre normaliza y guarda el token más reciente. Sin
+autorización viva de proceso no realiza ninguna subida de cuenta. El siguiente
+login completamente autorizado puede usar ese token durante su registro
+acotado.
+
+Android comparte un registro de autorización local al proceso entre el
+registrar del dispositivo autorizado y `FirebaseMessagingService`. El logout y
+la recuperación terminal de sesión lo invalidan de forma síncrona, antes del
+cleanup persistente asíncrono. El registro usa una generación atómica: un
+permiso de activación obtenido antes del logout no puede reactivar la
+autorización después de que logout avance la generación.
+
+iOS guarda el contexto y su fence `@MainActor @Sendable` como un único valor de
+estado del actor. El callback de mensajería nunca adopta un contexto de Keychain
+en un coordinador nuevo. El fence se evalúa antes de la subida y dentro del
+callback de revalidación del repositorio, para que la reentrada del actor en un
+`await` no convierta una autorización obsoleta en una escritura.
+
+La forma legacy cifrada conocida de Android, con `member_id`, `environment` y
+`lease_id` pero sin `auth_uid`, se migra fail-closed eliminando únicamente las
+claves del contexto autorizado. El ID de dispositivo y el token guardado se
+conservan como datos de recuperación no autorizantes. Cualquier otra forma
+parcial sigue siendo un error tipado de corrupción.
+
+Los fallos de registro, almacenamiento y cleanup siguen una política
+best-effort para preservar la continuidad del producto: se informan o registran
+sin bloquear el cierre de sesión local. La invalidación en memoria es síncrona
+y no depende de red ni de la disponibilidad del almacenamiento cifrado.
+
+## Opciones consideradas
+
+### Confiar en el contexto persistido si Firebase Auth restaura el mismo UID
+
+Rechazada. Autorizaría un callback antes de que el proceso actual revalide la
+actividad del miembro, el routing y la propiedad de la sesión.
+
+### Desactivar por completo las subidas de renovaciones de token
+
+Rechazada. Evitaría escrituras obsoletas, pero también dejaría sesiones válidas
+con credenciales push desactualizadas.
+
+### Borrar remotamente el token y desvincularlo en backend durante logout ahora
+
+Aplazada. Exige retry durable, compatibilidad con las apps y el emisor
+publicados, y una decisión coordinada entre el modelo legacy de token y el nuevo
+modelo de registro mediante Firebase Installation ID.
+
+## Consecuencias
+
+### Positivas
+
+- Un arranque en frío no recupera silenciosamente desde disco la autoridad para
+  escribir asociaciones push de cuenta.
+- Logout cerca los callbacks antes de que termine el cleanup persistente o el
+  sign-out de Firebase.
+- Una lease o un entorno sustituidos no pueden confirmar una actualización
+  tardía del token.
+- Ambos clientes conservan el último token para recuperarlo tras una
+  autorización posterior.
+- No requiere despliegue Firebase ni mutación de datos live.
+
+### Negativas
+
+- Tras reiniciar el proceso, la aplicación debe completar de nuevo la
+  autorización antes de reanudar subidas de token.
+- El ciclo de vida móvil mantiene ahora una generación/fence adicional en
+  memoria.
+- Esta decisión no elimina del servidor los tokens remotos de una cuenta que
+  ha cerrado sesión.
+
+## Frontera de revocación y trabajo aplazado
+
+Esta decisión revoca la **autorización local para crear o actualizar
+asociaciones push de cuenta**. Aún no proporciona revocación remota absoluta. El
+emisor puede conservar un token registrado anteriormente y FCM puede haber
+aceptado ya mensajes para entregar. Por tanto, el producto no debe prometer
+cero notificaciones tardías después del logout.
+
+La desvinculación remota, el retry durable, la política TTL del emisor, la
+política de auto-init de Android y la migración desde las APIs de token
+deprecadas hacia `register`/`unregister` de Firebase Installation ID permanecen
+aplazadas hasta poder coordinar con seguridad todos los clientes Firebase
+compartidos.
+
+## Implementación y verificación
+
+- Android prueba de forma determinista el proceso en frío, diferencias de UID
+  y contexto, sustitución de lease y entorno, invalidación durante una escritura
+  suspendida, carreras de generación de activación, fence inmediato de logout y
+  migración legacy.
+- iOS prueba de forma determinista el estado Keychain en un proceso frío, un
+  callback válido después del registro vivo y la invalidación del fence durante
+  una escritura suspendida en el repositorio.
+- Las pruebas usan gates controlables y ningún sleep real.
+- No cambian Functions, Firestore Rules, Storage Rules ni datos Firebase live.
+
+## Decisiones y trabajo relacionados
+
+- ADR-0003: servicios backend Firebase.
+- ADR-0007: autorización Firebase por roles y despliegue por fases.
+- ADR-0008: operaciones móviles de sesión acotadas y barreras de cleanup.
+- Issue de GitHub [#217](https://github.com/JFrancoG/ReguertaPlus/issues/217).
+
+## Referencias
+
+- [Swift Evolution SE-0306: Actors](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0306-actors.md)
+- [Firebase: gestionar tokens de registro FCM](https://firebase.google.com/docs/cloud-messaging/manage-tokens)
+- [Firebase Android: `FirebaseMessaging`](https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/FirebaseMessaging)

--- a/docs/decisions/0009-require-process-live-push-authorization.md
+++ b/docs/decisions/0009-require-process-live-push-authorization.md
@@ -1,0 +1,158 @@
+# ADR-0009: Require Process-Live Authorization for Account Push Registration
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-28
+
+## Context
+
+Reguerta caches a device identifier, the latest FCM registration token, and an
+authorized account context so token refreshes can be associated with the
+correct member. ADR-0007 keeps the published Firebase clients on a phased
+authorization rollout, so a mobile callback cannot rely on strict Rules to
+reject every stale registration yet.
+
+Issue #214 added encrypted storage, exact `memberId + authUid + environment +
+lease` contexts, and repository revalidation. A remaining lifecycle gap still
+allowed a fresh process to combine restored Firebase Auth and disk state and
+upload a token before the application had revalidated the authorized member.
+Android could also receive an FCM callback while logout cleanup was waiting for
+older session work. On iOS, the messaging callback could adopt a Keychain
+context into a newly created coordinator.
+
+A persisted context proves only what an earlier process authorized. It is not
+evidence that the current process has completed member resolution, active-state
+validation, and session ownership.
+
+## Decision Drivers
+
+- Stop token association as soon as the local session loses authorization.
+- Never reconstruct upload authority from Firebase Auth and disk state alone.
+- Preserve token caching so a later valid login can catch up without losing a
+  refresh callback.
+- Apply the same member, UID, environment, lease, and lifecycle checks on
+  Android and iOS.
+- Remain compatible with published clients and the phased Firebase rollout.
+- Avoid backend, Rules, Functions, or live-data changes in this cut.
+
+## Decision
+
+Account-scoped push registration requires a **process-live authorization** in
+addition to Firebase Auth and encrypted persisted state.
+
+That authorization contains the exact member, Auth UID, environment, and
+session lease established by the current authorized-session flow. It also
+retains a live process/session fence: atomic generations on Android and the
+session-ownership closure on iOS. Every upload must prove all of the following
+at the repository checkpoints immediately before a write:
+
+1. The process-live authorization still owns the operation.
+2. The current Firebase UID matches the authorized UID.
+3. The persisted context still matches the member, UID, environment, and lease.
+4. The latest cached token still matches the token being written.
+5. The process/session fence still reports the authorized session as current.
+
+The token callback always normalizes and stores the latest token. Without a
+process-live authorization it performs no account upload. The next fully
+authorized login may use that cached token during its bounded registration.
+
+Android shares a process-local authorization registry between the authorized
+device registrar and `FirebaseMessagingService`. Logout and terminal session
+recovery invalidate it synchronously, before asynchronous persistent cleanup.
+The registry uses an atomic generation: an activation permit obtained before
+logout cannot reactivate authorization after logout has advanced the
+generation.
+
+iOS stores the context and its `@MainActor @Sendable` session fence as one actor
+state value. The messaging callback never adopts a Keychain context into a
+fresh coordinator. The fence is evaluated both before upload and through the
+repository's revalidation callback so actor reentrancy at an `await` cannot
+turn an obsolete authorization into a write.
+
+The known Android encrypted legacy shape containing `member_id`, `environment`,
+and `lease_id` but no `auth_uid` is migrated fail-closed by deleting only the
+authorized-context keys. Device ID and cached token remain non-authorizing
+catch-up data. Any other partial shape remains a typed corruption error.
+
+Registration, storage, and cleanup failures remain best-effort for product
+continuity: they are reported or logged without blocking local sign-out. The
+in-memory invalidation itself is synchronous and does not depend on network or
+encrypted storage availability.
+
+## Considered Options
+
+### Trust persisted context when Firebase Auth restores the same UID
+
+Rejected. It would authorize a callback before the current process revalidates
+member activity, routing, and session ownership.
+
+### Disable token refresh uploads entirely
+
+Rejected. It would prevent stale writes but also leave valid sessions with
+outdated push credentials.
+
+### Perform remote token deletion and backend unlink during logout now
+
+Deferred. It requires a durable retry policy, compatibility with the currently
+published apps and sender, and a coordinated decision between the legacy token
+model and the newer Firebase Installation ID registration model.
+
+## Consequences
+
+### Positive
+
+- Cold starts cannot silently regain account push-write authority from disk.
+- Logout fences callbacks before persistent cleanup or Firebase sign-out
+  finishes.
+- Replaced leases and environments cannot commit a late token update.
+- Both clients retain the latest token for a later authorized catch-up.
+- No Firebase deployment or live-data mutation is required.
+
+### Negative
+
+- A process restart requires the application to complete authorization again
+  before token uploads resume.
+- Mobile lifecycle code now maintains an additional in-memory generation/fence.
+- Remote token records for a signed-out account are not removed by this
+  decision.
+
+## Revocation Boundary and Deferred Work
+
+This decision revokes **local authorization to create or update account push
+associations**. It does not yet provide absolute remote revocation. The sender
+may still hold a previously registered token, and FCM may already have accepted
+messages for delivery. Therefore the product must not promise zero late
+notifications after logout.
+
+Remote unlink, durable retry, sender TTL policy, Android auto-init policy, and
+the migration from deprecated token APIs to Firebase Installation ID
+`register`/`unregister` remain deferred until the shared Firebase clients can be
+coordinated safely.
+
+## Implementation and Verification
+
+- Android deterministically tests cold process state, UID/context mismatch,
+  lease and environment replacement, invalidation during a suspended write,
+  activation-generation races, immediate logout fencing, and legacy migration.
+- iOS deterministically tests cold-process Keychain state, a valid callback
+  after live registration, and session-fence invalidation during a suspended
+  repository write.
+- Tests use controllable gates and no real sleeps.
+- No Functions, Firestore Rules, Storage Rules, or live Firebase data change.
+
+## Related Decisions and Work
+
+- ADR-0003: Firebase backend services.
+- ADR-0007: phased Firebase role-based authorization.
+- ADR-0008: bounded mobile session operations and cleanup barriers.
+- GitHub issue [#217](https://github.com/JFrancoG/ReguertaPlus/issues/217).
+
+## References
+
+- [Swift Evolution SE-0306: Actors](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0306-actors.md)
+- [Firebase: Manage FCM registration tokens](https://firebase.google.com/docs/cloud-messaging/manage-tokens)
+- [Firebase Android: `FirebaseMessaging`](https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/FirebaseMessaging)

--- a/ios/Reguerta/Reguerta/Data/Devices/FirebaseAuthorizedDeviceCoordinator.swift
+++ b/ios/Reguerta/Reguerta/Data/Devices/FirebaseAuthorizedDeviceCoordinator.swift
@@ -11,6 +11,11 @@ nonisolated struct AuthorizedDeviceSessionContext: Codable, Equatable, Sendable 
     let lease: AuthorizedDeviceSessionLease
 }
 
+nonisolated private struct AuthorizedDeviceProcessAuthorization: Sendable {
+    let context: AuthorizedDeviceSessionContext
+    let sessionFence: @MainActor @Sendable () -> Bool
+}
+
 actor FirebaseAuthorizedDeviceCoordinator: AuthorizedDeviceRegistrar {
     private static let logger = Logger(
         subsystem: "com.reguerta.app",
@@ -24,7 +29,7 @@ actor FirebaseAuthorizedDeviceCoordinator: AuthorizedDeviceRegistrar {
     private let currentAuthUidProvider: @MainActor @Sendable () -> String?
     private let deviceProvider: @MainActor @Sendable (String?, Int64) -> RegisteredDevice
     private let retryDelay: @Sendable () async throws -> Void
-    private var activeContext: AuthorizedDeviceSessionContext?
+    private var activeAuthorization: AuthorizedDeviceProcessAuthorization?
     private var generation: UInt64 = 0
 
     init(
@@ -118,11 +123,15 @@ private extension FirebaseAuthorizedDeviceCoordinator {
             environment: command.environment,
             lease: command.lease
         )
-        activeContext = context
+        let authorization = AuthorizedDeviceProcessAuthorization(
+            context: context,
+            sessionFence: isSessionCurrent
+        )
+        activeAuthorization = authorization
 
         guard await isSessionCurrent() else {
-            if activeContext == context {
-                activeContext = nil
+            if isActive(authorization, generation: operationGeneration) {
+                activeAuthorization = nil
             }
             return .skipped
         }
@@ -131,67 +140,79 @@ private extension FirebaseAuthorizedDeviceCoordinator {
         try await keychainStore.remove(.legacyAuthorizedMemberId)
 
         guard try await isCurrentOrDiscardContext(
-            context,
-            generation: operationGeneration,
-            sessionFence: isSessionCurrent
+            authorization,
+            generation: operationGeneration
         ) else {
             return .skipped
         }
 
         let token = try await fetchTokenWithRetry()
-        guard try await isCurrentOrDiscardContext(
-            context,
+        guard try await isCurrentRegistration(
+            authorization,
             generation: operationGeneration,
-            sessionFence: isSessionCurrent
+            expectedToken: token
         ) else {
             return .skipped
         }
 
-        let nowMillis = nowMillisProvider()
-        let device = await deviceProvider(token, nowMillis)
-        guard try await isCurrentOrDiscardContext(
-            context,
+        guard try await writeDeviceRegistration(
+            authorization,
             generation: operationGeneration,
-            sessionFence: isSessionCurrent
-        ) else {
-            return .skipped
-        }
-
-        _ = try await repository.register(
-            memberId: context.memberId,
-            environment: context.environment,
-            device: device,
-            isRegistrationCurrent: { [weak self] in
-                guard let self else { return false }
-                return try await self.isCurrent(
-                    context,
-                    generation: operationGeneration,
-                    sessionFence: isSessionCurrent
-                )
-            }
-        )
-
-        guard try await isCurrent(
-            context,
-            generation: operationGeneration,
-            sessionFence: isSessionCurrent
+            token: token
         ) else {
             return .skipped
         }
         return .registered
     }
 
-    private func isCurrentOrDiscardContext(
-        _ context: AuthorizedDeviceSessionContext,
+    private func writeDeviceRegistration(
+        _ authorization: AuthorizedDeviceProcessAuthorization,
         generation operationGeneration: UInt64,
-        sessionFence: @escaping @MainActor @Sendable () -> Bool
+        token: String?
+    ) async throws -> Bool {
+        let nowMillis = nowMillisProvider()
+        let device = await deviceProvider(token, nowMillis)
+        guard try await isCurrentRegistration(
+            authorization,
+            generation: operationGeneration,
+            expectedToken: token
+        ) else {
+            return false
+        }
+
+        let context = authorization.context
+        _ = try await repository.register(
+            memberId: context.memberId,
+            environment: context.environment,
+            device: device,
+            isRegistrationCurrent: { [weak self] in
+                guard let self else { return false }
+                return try await self.isCurrentRegistration(
+                    authorization,
+                    generation: operationGeneration,
+                    expectedToken: token
+                )
+            }
+        )
+        return try await isCurrentRegistration(
+            authorization,
+            generation: operationGeneration,
+            expectedToken: token
+        )
+    }
+
+    private func isCurrentOrDiscardContext(
+        _ authorization: AuthorizedDeviceProcessAuthorization,
+        generation operationGeneration: UInt64
     ) async throws -> Bool {
         guard try await isCurrent(
-            context,
-            generation: operationGeneration,
-            sessionFence: sessionFence
+            authorization,
+            generation: operationGeneration
         ) else {
-            try await discardContextIfOwned(context)
+            try await discardContextIfOwned(
+                authorization.context,
+                generation: operationGeneration
+            )
             return false
         }
         return true
@@ -202,31 +223,29 @@ private extension FirebaseAuthorizedDeviceCoordinator {
         try await keychainStore.saveString(normalizedToken, for: .fcmToken)
         guard let normalizedToken else { return }
 
-        let initialGeneration = generation
-        guard let context = try await keychainStore.load(
-            AuthorizedDeviceSessionContext.self,
-            for: .authorizedDeviceContext
-        ) else {
+        guard let authorization = activeAuthorization else {
+            _ = try await keychainStore.load(
+                AuthorizedDeviceSessionContext.self,
+                for: .authorizedDeviceContext
+            )
             return
         }
-        guard generation == initialGeneration else { return }
-        if let activeContext, activeContext != context {
-            return
-        }
-        activeContext = context
+        let context = authorization.context
         let operationGeneration = generation
 
-        guard try await isCurrentPersisted(
-            context,
-            generation: operationGeneration
+        guard try await isCurrentRegistration(
+            authorization,
+            generation: operationGeneration,
+            expectedToken: normalizedToken
         ) else {
             return
         }
         let nowMillis = nowMillisProvider()
         let device = await deviceProvider(normalizedToken, nowMillis)
-        guard try await isCurrentPersisted(
-            context,
-            generation: operationGeneration
+        guard try await isCurrentRegistration(
+            authorization,
+            generation: operationGeneration,
+            expectedToken: normalizedToken
         ) else {
             return
         }
@@ -237,9 +256,10 @@ private extension FirebaseAuthorizedDeviceCoordinator {
             device: device,
             isRegistrationCurrent: { [weak self] in
                 guard let self else { return false }
-                return try await self.isCurrentPersisted(
-                    context,
-                    generation: operationGeneration
+                return try await self.isCurrentRegistration(
+                    authorization,
+                    generation: operationGeneration,
+                    expectedToken: normalizedToken
                 )
             }
         )
@@ -249,10 +269,10 @@ private extension FirebaseAuthorizedDeviceCoordinator {
         ifOwnedBy lease: AuthorizedDeviceSessionLease
     ) async throws {
         let expectedContext: AuthorizedDeviceSessionContext
-        if let activeContext {
-            guard activeContext.lease == lease else { return }
-            expectedContext = activeContext
-            self.activeContext = nil
+        if let activeAuthorization {
+            guard activeAuthorization.context.lease == lease else { return }
+            expectedContext = activeAuthorization.context
+            self.activeAuthorization = nil
             generation &+= 1
         } else {
             generation &+= 1
@@ -266,7 +286,7 @@ private extension FirebaseAuthorizedDeviceCoordinator {
             }
             guard
                 generation == clearGeneration,
-                activeContext == nil,
+                activeAuthorization == nil,
                 storedContext.lease == lease
             else {
                 return
@@ -307,42 +327,67 @@ private extension FirebaseAuthorizedDeviceCoordinator {
     }
 
     private func isCurrent(
-        _ context: AuthorizedDeviceSessionContext,
-        generation operationGeneration: UInt64,
-        sessionFence: @escaping @MainActor @Sendable () -> Bool
-    ) async throws -> Bool {
-        guard generation == operationGeneration, activeContext == context else { return false }
-        guard await sessionFence() else { return false }
-        guard generation == operationGeneration, activeContext == context else { return false }
-        return try await isCurrentPersisted(
-            context,
-            generation: operationGeneration
-        )
-    }
-
-    private func isCurrentPersisted(
-        _ context: AuthorizedDeviceSessionContext,
+        _ authorization: AuthorizedDeviceProcessAuthorization,
         generation operationGeneration: UInt64
     ) async throws -> Bool {
-        guard generation == operationGeneration, activeContext == context else { return false }
+        let context = authorization.context
+        guard isActive(authorization, generation: operationGeneration) else { return false }
+        guard await authorization.sessionFence() else { return false }
+        guard isActive(authorization, generation: operationGeneration) else { return false }
         guard await currentAuthUidProvider() == context.authUid else { return false }
-        guard generation == operationGeneration, activeContext == context else { return false }
+        guard isActive(authorization, generation: operationGeneration) else { return false }
         let persistedContext = try await keychainStore.load(
             AuthorizedDeviceSessionContext.self,
             for: .authorizedDeviceContext
         )
-        return generation == operationGeneration &&
-            activeContext == context &&
-            persistedContext == context
+        guard
+            isActive(authorization, generation: operationGeneration),
+            persistedContext == context,
+            await authorization.sessionFence()
+        else {
+            return false
+        }
+        return isActive(authorization, generation: operationGeneration)
     }
 
-    private func discardContextIfOwned(_ context: AuthorizedDeviceSessionContext) async throws {
+    private func isCurrentRegistration(
+        _ authorization: AuthorizedDeviceProcessAuthorization,
+        generation operationGeneration: UInt64,
+        expectedToken: String?
+    ) async throws -> Bool {
+        guard try await isCurrent(
+            authorization,
+            generation: operationGeneration
+        ) else {
+            return false
+        }
+        let persistedToken = try await keychainStore.loadString(for: .fcmToken)
+        guard persistedToken == expectedToken else { return false }
+        return try await isCurrent(
+            authorization,
+            generation: operationGeneration
+        )
+    }
+
+    private func isActive(
+        _ authorization: AuthorizedDeviceProcessAuthorization,
+        generation operationGeneration: UInt64
+    ) -> Bool {
+        generation == operationGeneration &&
+            activeAuthorization?.context == authorization.context
+    }
+
+    private func discardContextIfOwned(
+        _ context: AuthorizedDeviceSessionContext,
+        generation operationGeneration: UInt64
+    ) async throws {
         _ = try await keychainStore.remove(
             .authorizedDeviceContext,
             ifMatching: context
         )
-        if activeContext == context {
-            activeContext = nil
+        if generation == operationGeneration,
+           activeAuthorization?.context == context {
+            activeAuthorization = nil
         }
     }
 

--- a/ios/Reguerta/ReguertaTests/P217AuthorizedDeviceProcessAuthorizationTests.swift
+++ b/ios/Reguerta/ReguertaTests/P217AuthorizedDeviceProcessAuthorizationTests.swift
@@ -1,0 +1,276 @@
+import Foundation
+import Security
+import Synchronization
+import Testing
+@testable import Reguerta
+
+@MainActor
+struct P217AuthorizedDeviceProcessAuthorizationTests {
+    @Test
+    func coldProcessStoresTokenWithoutAdoptingPersistedAuthorization() async throws {
+        let harness = makeHarness()
+        let context = AuthorizedDeviceSessionContext(
+            memberId: "member-a",
+            authUid: "uid-a",
+            environment: .develop,
+            lease: AuthorizedDeviceSessionLease()
+        )
+        try await harness.store.save(context, for: .authorizedDeviceContext)
+
+        try await harness.coordinator.updateRegistrationToken(" token-b ")
+
+        #expect(try await harness.store.loadString(for: .fcmToken) == "token-b")
+        #expect(harness.repository.registrations.isEmpty)
+    }
+
+    @Test
+    func liveAuthorizationAllowsSubsequentTokenRefresh() async throws {
+        let sessionFence = P217CurrentSessionFence(true)
+        let harness = makeHarness()
+
+        let result = try await harness.coordinator.register(
+            command: command(),
+            isSessionCurrent: { sessionFence.value }
+        )
+        try await harness.coordinator.updateRegistrationToken("token-b")
+
+        #expect(result == .registered)
+        #expect(harness.repository.registrations.map(\.fcmToken) == ["token", "token-b"])
+    }
+
+    @Test
+    func sessionFenceInvalidationDuringTokenUploadPreventsCommit() async throws {
+        let started = P217TestSignal()
+        let release = P217TestGate()
+        let repository = P217RecordingDeviceRegistrationRepository(
+            suspendedToken: "token-b",
+            started: started,
+            release: release
+        )
+        let sessionFence = P217CurrentSessionFence(true)
+        let harness = makeHarness(repository: repository)
+
+        _ = try await harness.coordinator.register(
+            command: command(),
+            isSessionCurrent: { sessionFence.value }
+        )
+        let update = Task {
+            try await harness.coordinator.updateRegistrationToken("token-b")
+        }
+        await started.wait()
+        sessionFence.value = false
+        await release.open()
+        try await update.value
+
+        #expect(repository.registrations.map(\.fcmToken) == ["token"])
+    }
+
+    @Test
+    func supersededTokenUpdateCannotCommitAfterTheNewestToken() async throws {
+        let started = P217TestSignal()
+        let release = P217TestGate()
+        let repository = P217RecordingDeviceRegistrationRepository(
+            suspendedToken: "token-a",
+            started: started,
+            release: release
+        )
+        let sessionFence = P217CurrentSessionFence(true)
+        let harness = makeHarness(repository: repository)
+        _ = try await harness.coordinator.register(
+            command: command(),
+            isSessionCurrent: { sessionFence.value }
+        )
+
+        let firstUpdate = Task {
+            try await harness.coordinator.updateRegistrationToken("token-a")
+        }
+        await started.wait()
+        try await harness.coordinator.updateRegistrationToken("token-b")
+        await release.open()
+        try await firstUpdate.value
+
+        #expect(repository.registrations.map(\.fcmToken) == ["token", "token-b"])
+        #expect(try await harness.store.loadString(for: .fcmToken) == "token-b")
+    }
+
+    private func makeHarness(
+        repository: P217RecordingDeviceRegistrationRepository =
+            P217RecordingDeviceRegistrationRepository()
+    ) -> P217CoordinatorHarness {
+        let store = KeychainStore(
+            client: P217InMemoryKeychainClient(),
+            service: "tests.p217.keychain"
+        )
+        let coordinator = FirebaseAuthorizedDeviceCoordinator(
+            repository: repository,
+            keychainStore: store,
+            nowMillisProvider: { 1_000 },
+            tokenProvider: { "token" },
+            currentAuthUidProvider: { "uid-a" },
+            deviceProvider: { token, nowMillis in
+                RegisteredDevice(
+                    deviceId: "device-test",
+                    platform: "ios",
+                    appVersion: "1.0",
+                    osVersion: "26.0",
+                    apiLevel: nil,
+                    manufacturer: "Apple",
+                    model: "iPhone",
+                    fcmToken: token,
+                    firstSeenAtMillis: nowMillis,
+                    lastSeenAtMillis: nowMillis,
+                    tokenUpdatedAtMillis: token == nil ? nil : nowMillis
+                )
+            },
+            retryDelay: {}
+        )
+        return P217CoordinatorHarness(
+            coordinator: coordinator,
+            repository: repository,
+            store: store
+        )
+    }
+
+    private func command() -> AuthorizedDeviceRegistrationCommand {
+        AuthorizedDeviceRegistrationCommand(
+            memberId: "member-a",
+            authUid: "uid-a",
+            environment: .develop,
+            lease: AuthorizedDeviceSessionLease()
+        )
+    }
+}
+
+nonisolated private struct P217CoordinatorHarness: Sendable {
+    let coordinator: FirebaseAuthorizedDeviceCoordinator
+    let repository: P217RecordingDeviceRegistrationRepository
+    let store: KeychainStore
+}
+
+nonisolated private struct P217RecordedDeviceRegistration: Equatable, Sendable {
+    let fcmToken: String?
+}
+
+@MainActor
+private final class P217RecordingDeviceRegistrationRepository: DeviceRegistrationRepository {
+    private let suspendedToken: String?
+    private let started: P217TestSignal?
+    private let release: P217TestGate?
+    var registrations: [P217RecordedDeviceRegistration] = []
+
+    init(
+        suspendedToken: String? = nil,
+        started: P217TestSignal? = nil,
+        release: P217TestGate? = nil
+    ) {
+        self.suspendedToken = suspendedToken
+        self.started = started
+        self.release = release
+    }
+
+    func register(
+        memberId: String,
+        environment: SessionEnvironment,
+        device: RegisteredDevice,
+        isRegistrationCurrent: @escaping @Sendable () async throws -> Bool
+    ) async throws -> RegisteredDevice {
+        guard try await isRegistrationCurrent() else {
+            throw DeviceRegistrationRepositoryError.staleSession
+        }
+        if suspendedToken != nil, device.fcmToken == suspendedToken {
+            await started?.signal()
+            await release?.wait()
+        }
+        guard try await isRegistrationCurrent() else {
+            throw DeviceRegistrationRepositoryError.staleSession
+        }
+        registrations.append(
+            P217RecordedDeviceRegistration(fcmToken: device.fcmToken)
+        )
+        return device
+    }
+}
+
+@MainActor
+private final class P217CurrentSessionFence {
+    var value: Bool
+
+    init(_ value: Bool) {
+        self.value = value
+    }
+}
+
+nonisolated private final class P217InMemoryKeychainClient: KeychainClient {
+    private let storage = Mutex<[String: Data]>([:])
+
+    func read(service: String, account: String) -> KeychainReadResult {
+        storage.withLock { values in
+            guard let data = values[account] else {
+                return KeychainReadResult(status: errSecItemNotFound, data: nil)
+            }
+            return KeychainReadResult(status: errSecSuccess, data: data)
+        }
+    }
+
+    func update(service: String, account: String, data: Data) -> OSStatus {
+        storage.withLock { values in
+            guard values[account] != nil else { return errSecItemNotFound }
+            values[account] = data
+            return errSecSuccess
+        }
+    }
+
+    func add(service: String, account: String, data: Data) -> OSStatus {
+        storage.withLock { values in
+            guard values[account] == nil else { return errSecDuplicateItem }
+            values[account] = data
+            return errSecSuccess
+        }
+    }
+
+    func delete(service: String, account: String) -> OSStatus {
+        storage.withLock { values in
+            values.removeValue(forKey: account) == nil ? errSecItemNotFound : errSecSuccess
+        }
+    }
+}
+
+private actor P217TestSignal {
+    private var isSignaled = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func signal() {
+        guard !isSignaled else { return }
+        isSignaled = true
+        let pendingWaiters = waiters
+        waiters.removeAll()
+        pendingWaiters.forEach { $0.resume() }
+    }
+
+    func wait() async {
+        if isSignaled { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+}
+
+private actor P217TestGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let pendingWaiters = waiters
+        waiters.removeAll()
+        pendingWaiters.forEach { $0.resume() }
+    }
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- require process-live session authorization before Android and iOS push token writes
- invalidate authorization synchronously during logout and environment routing
- migrate the exact legacy Android context shape fail-closed while preserving non-authorizing device data
- document the local-revocation boundary and deferred remote unlink, retry, TTL, and FID work in ADR-0009 (EN/ES)

## Root cause and impact

Persisted device context could be reused before the current process had revalidated a live authorized session. This allowed stale token-refresh work to approach repository writes after cold start or during logout cleanup. The new process fence prevents those uploads on both platforms.

## Validation

- Android: `./gradlew app:testDebugUnitTest app:lintDebug --no-daemon`
- Android instrumentation: 14/14 on `emulator-5554` (`Pixel_8_Pro_API_35`)
- iOS via Xcode MCP: 523 passed, 0 failed, 1 skipped; focused P101/P217 suite 11/11
- SwiftLint: no warnings in touched files
- independent Android, iOS, and cross-platform audits: no pending findings
- `git diff --check`: clean

## Firebase scope

No changes or deployments to Functions, Rules, backend configuration, or live data. Remote token unlink, durable retry, TTL policy, and FID migration remain deferred while active app generations share the Firebase project.

Refs #217