### PR TITLE
refactor(ios): reduce existential erasure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- 2026-08-02 | ♻️ refactor(ios): reduce existential erasure
 - 2026-07-29 | ♻️ refactor(ios): clear SwiftLint warnings
 - 2026-07-24 | ♻️ refactor(ios): split large feature files
 - 2026-07-12 | ♻️ refactor(ios): clear SwiftLint warnings

--- a/docs-es/architecture/README.md
+++ b/docs-es/architecture/README.md
@@ -12,6 +12,30 @@ Estructura general:
 - Dominio: casos de uso / reglas de negocio
 - Datos: repositorios y data sources
 
+## Politica de abstraccion de tipos Swift
+
+En iOS se elige la abstraccion mas estrecha que conserve el contrato real:
+
+- Usar un tipo concreto cuando la composicion fija una implementacion y ese limite no admite sustitucion.
+- Usar un parametro generico o `some Protocol` cuando cada instancia tiene un unico tipo concreto conocido estaticamente.
+- Usar `any Protocol` solo para sustitucion en runtime, almacenamiento heterogeneo o una frontera deliberadamente no generica.
+
+No quitar solo la palabra `any` como limpieza. Un nombre de protocolo usado como tipo sigue siendo existencial en los modos del lenguaje que aun permiten la grafia implicita. En particular, se mantiene `any Error` cuando una frontera acepta deliberadamente errores heterogeneos; si el contrato esta cerrado, se usa un error concreto o `throws(ErrorConcreto)`.
+
+En revisiones enfocadas se usa el diagnostico opt-in `ExistentialType` de Swift para inventariar el coste de los existenciales. Cada aviso se clasifica en vez de convertir el diagnostico en un gate de cero warnings, porque tambien senala fronteras validas de inyeccion y valores heterogeneos. Las reglas regex de SwiftLint no deben prohibir `any` globalmente: no pueden determinar si el borrado de tipo en runtime es necesario.
+
+### Auditoria de existenciales
+
+La auditoria opt-in se ejecuta desde la raiz del repositorio:
+
+```bash
+ios/Reguerta/scripts/audit-swift-existentials.sh
+```
+
+El modo `--diff`, usado por defecto, muestra solo los diagnosticos situados en lineas Swift modificadas desde el ancestro comun con `origin/main`. Se puede usar `--base <git-ref>` para elegir otra referencia de comparacion o `--all` para inventariar todos los diagnosticos del codigo del proyecto. El script compila la app y los targets de tests en un Derived Data temporal y aislado, permite los warnings y elimina despues ese directorio.
+
+La auditoria es informativa: encontrar avisos termina correctamente para que cada existencial se clasifique segun su contrato. Los argumentos invalidos, los errores de Git o del informe y los fallos de compilacion terminan con error. Requiere Xcode y Python 3.
+
 Servicios de backend:
 - Base de datos: Firebase Firestore
 - Autenticacion: Firebase Authentication

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -12,6 +12,30 @@ High-level structure:
 - Domain: Use cases / business rules
 - Data: Repositories and data sources
 
+## Swift type abstraction policy
+
+For iOS, choose the narrowest abstraction that preserves the real contract:
+
+- Use a concrete type when composition fixes one implementation and that boundary does not support substitution.
+- Use a generic parameter or `some Protocol` when each instance has one statically known concrete type.
+- Use `any Protocol` only for runtime substitution, heterogeneous storage, or a deliberately non-generic boundary.
+
+Do not remove only the `any` keyword as a cleanup. A protocol name used as a type remains an existential in language modes that still allow the implicit spelling. In particular, keep `any Error` when a boundary intentionally accepts heterogeneous errors; use a concrete error or typed throws when the contract is closed.
+
+During focused reviews, use Swift's opt-in `ExistentialType` diagnostic to inventory existential costs. Classify each warning instead of turning the diagnostic into a zero-warning gate, because valid dependency-injection boundaries and heterogeneous values are also reported. SwiftLint regex rules must not globally prohibit `any`: they cannot determine whether runtime type erasure is required.
+
+### Existential audit
+
+Run the opt-in audit from the repository root:
+
+```bash
+ios/Reguerta/scripts/audit-swift-existentials.sh
+```
+
+The default `--diff` mode reports only diagnostics on Swift lines changed from the merge base with `origin/main`. Use `--base <git-ref>` to select another comparison ref, or `--all` to inventory all project-source diagnostics. The script builds the app and test targets in an isolated temporary Derived Data directory with warnings allowed, then removes that directory.
+
+The audit is informational: findings exit successfully so that every existential can be classified by contract. Invalid arguments, Git/reporting errors, and build failures exit unsuccessfully. Xcode and Python 3 are required.
+
 Backend services:
 - Database: Firebase Firestore
 - Auth: Firebase Authentication

--- a/ios/Reguerta/Reguerta/App/ReguertaAppEnvironment.swift
+++ b/ios/Reguerta/Reguerta/App/ReguertaAppEnvironment.swift
@@ -171,7 +171,7 @@ private func makeUITestingAccessRootViewModel(
 
 private struct LiveRootDependencies {
     let db: Firestore
-    let memberRepository: any MemberRepository
+    let memberRepository: FirestoreMemberRepository
     let authSessionProvider: FirebaseAuthSessionProvider
     let functionsClient: AuthenticatedFirebaseFunctionsClient
     let memberAdministrationRepository: FirebaseMemberAdministrationRepository

--- a/ios/Reguerta/Reguerta/Data/Access/ChainedMemberRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/ChainedMemberRepository.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-actor ChainedMemberRepository: LocalMemberRepository {
-    private let primary: any LocalMemberRepository
-    private let fallback: any LocalMemberRepository
+actor ChainedMemberRepository<Primary: LocalMemberRepository, Fallback: LocalMemberRepository>: LocalMemberRepository {
+    private let primary: Primary
+    private let fallback: Fallback
 
-    init(primary: any LocalMemberRepository, fallback: any LocalMemberRepository) {
+    init(primary: Primary, fallback: Fallback) {
         self.primary = primary
         self.fallback = fallback
     }

--- a/ios/Reguerta/Reguerta/Data/Calendar/ChainedDeliveryCalendarRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Calendar/ChainedDeliveryCalendarRepository.swift
@@ -1,8 +1,9 @@
 import Foundation
 
-struct ChainedDeliveryCalendarRepository: DeliveryCalendarRepository {
-    let primary: any DeliveryCalendarRepository
-    let fallback: any DeliveryCalendarRepository
+struct ChainedDeliveryCalendarRepository<Primary: DeliveryCalendarRepository, Fallback: DeliveryCalendarRepository>:
+    DeliveryCalendarRepository {
+    let primary: Primary
+    let fallback: Fallback
 
     func defaultDeliveryDayOfWeek() async throws -> DeliveryWeekday {
         try await primary.defaultDeliveryDayOfWeek()

--- a/ios/Reguerta/Reguerta/Data/Commitments/ChainedSeasonalCommitmentRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Commitments/ChainedSeasonalCommitmentRepository.swift
@@ -1,10 +1,13 @@
 import Foundation
 
-actor ChainedSeasonalCommitmentRepository: SeasonalCommitmentRepository {
-    private let primary: any SeasonalCommitmentRepository
-    private let fallback: any SeasonalCommitmentRepository
+actor ChainedSeasonalCommitmentRepository<
+    Primary: SeasonalCommitmentRepository,
+    Fallback: SeasonalCommitmentRepository
+>: SeasonalCommitmentRepository {
+    private let primary: Primary
+    private let fallback: Fallback
 
-    init(primary: any SeasonalCommitmentRepository, fallback: any SeasonalCommitmentRepository) {
+    init(primary: Primary, fallback: Fallback) {
         self.primary = primary
         self.fallback = fallback
     }

--- a/ios/Reguerta/Reguerta/Data/News/ChainedNewsRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/News/ChainedNewsRepository.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-actor ChainedNewsRepository: NewsRepository {
-    private let primary: any NewsRepository
-    private let fallback: any NewsRepository
+actor ChainedNewsRepository<Primary: NewsRepository, Fallback: NewsRepository>: NewsRepository {
+    private let primary: Primary
+    private let fallback: Fallback
 
-    init(primary: any NewsRepository, fallback: any NewsRepository) {
+    init(primary: Primary, fallback: Fallback) {
         self.primary = primary
         self.fallback = fallback
     }

--- a/ios/Reguerta/Reguerta/Data/Notifications/ChainedNotificationRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Notifications/ChainedNotificationRepository.swift
@@ -1,10 +1,11 @@
 import Foundation
 
-actor ChainedNotificationRepository: NotificationRepository {
-    private let primary: any NotificationRepository
-    private let fallback: any NotificationRepository
+actor ChainedNotificationRepository<Primary: NotificationRepository, Fallback: NotificationRepository>:
+    NotificationRepository {
+    private let primary: Primary
+    private let fallback: Fallback
 
-    init(primary: any NotificationRepository, fallback: any NotificationRepository) {
+    init(primary: Primary, fallback: Fallback) {
         self.primary = primary
         self.fallback = fallback
     }

--- a/ios/Reguerta/Reguerta/Data/Products/ChainedProductRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Products/ChainedProductRepository.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-actor ChainedProductRepository: ProductRepository {
-    private let primary: any ProductRepository
-    private let fallback: any ProductRepository
+actor ChainedProductRepository<Primary: ProductRepository, Fallback: ProductRepository>: ProductRepository {
+    private let primary: Primary
+    private let fallback: Fallback
 
-    init(primary: any ProductRepository, fallback: any ProductRepository) {
+    init(primary: Primary, fallback: Fallback) {
         self.primary = primary
         self.fallback = fallback
     }

--- a/ios/Reguerta/Reguerta/Data/Profiles/ChainedSharedProfileRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Profiles/ChainedSharedProfileRepository.swift
@@ -1,12 +1,13 @@
 import Foundation
 
-final class ChainedSharedProfileRepository: @unchecked Sendable, SharedProfileRepository {
-    private let primary: any SharedProfileRepository
-    private let fallback: any SharedProfileRepository
+final class ChainedSharedProfileRepository<Primary: SharedProfileRepository, Fallback: SharedProfileRepository>:
+    @unchecked Sendable, SharedProfileRepository {
+    private let primary: Primary
+    private let fallback: Fallback
 
     init(
-        primary: any SharedProfileRepository,
-        fallback: any SharedProfileRepository
+        primary: Primary,
+        fallback: Fallback
     ) {
         self.primary = primary
         self.fallback = fallback

--- a/ios/Reguerta/Reguerta/Data/ShiftPlanningRequests/ChainedShiftPlanningRequestRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/ShiftPlanningRequests/ChainedShiftPlanningRequestRepository.swift
@@ -1,8 +1,11 @@
 import Foundation
 
-struct ChainedShiftPlanningRequestRepository: ShiftPlanningRequestRepository {
-    let primary: any ShiftPlanningRequestRepository
-    let fallback: any ShiftPlanningRequestRepository
+struct ChainedShiftPlanningRequestRepository<
+    Primary: ShiftPlanningRequestRepository,
+    Fallback: ShiftPlanningRequestRepository
+>: ShiftPlanningRequestRepository {
+    let primary: Primary
+    let fallback: Fallback
 
     func submit(request: ShiftPlanningRequest) async throws -> ShiftPlanningRequest {
         try await primary.submit(request: request)

--- a/ios/Reguerta/Reguerta/Data/ShiftSwapRequests/ChainedShiftSwapRequestRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/ShiftSwapRequests/ChainedShiftSwapRequestRepository.swift
@@ -1,8 +1,11 @@
 import Foundation
 
-struct ChainedShiftSwapRequestRepository: ShiftSwapRequestRepository {
-    let primary: any ShiftSwapRequestRepository
-    let fallback: any ShiftSwapRequestRepository
+struct ChainedShiftSwapRequestRepository<
+    Primary: ShiftSwapRequestRepository,
+    Fallback: ShiftSwapRequestRepository
+>: ShiftSwapRequestRepository {
+    let primary: Primary
+    let fallback: Fallback
 
     func allShiftSwapRequests() async throws -> [ShiftSwapRequest] {
         try await primary.allShiftSwapRequests()

--- a/ios/Reguerta/Reguerta/Data/Shifts/ChainedShiftRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Shifts/ChainedShiftRepository.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-struct ChainedShiftRepository: ShiftRepository {
-    let primary: any ShiftRepository
-    let fallback: any ShiftRepository
+struct ChainedShiftRepository<Primary: ShiftRepository, Fallback: ShiftRepository>: ShiftRepository {
+    let primary: Primary
+    let fallback: Fallback
 
     func allShifts() async throws -> [ShiftAssignment] {
         try await primary.allShifts()

--- a/ios/Reguerta/ReguertaTests/ReguertaNewsNotificationsViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaNewsNotificationsViewModelTests.swift
@@ -469,7 +469,7 @@ private struct NewsImagePipelineTestError: Error {}
 private actor NewsMockImagePipelineManager: ImagePipelineManager {
     enum ResultMode {
         case success(String)
-        case failure(any Error)
+        case failure(NewsImagePipelineTestError)
     }
 
     private let result: ResultMode

--- a/ios/Reguerta/ReguertaTests/ReguertaProductsViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaProductsViewModelTests.swift
@@ -444,7 +444,7 @@ private enum ProductMutationTestError: Error {
 private actor MockImagePipelineManager: ImagePipelineManager {
     enum ResultMode {
         case success(String)
-        case failure(any Error)
+        case failure(ImagePipelineError)
     }
 
     private let result: ResultMode

--- a/ios/Reguerta/ReguertaTests/ReguertaSharedProfileViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaSharedProfileViewModelTests.swift
@@ -320,7 +320,7 @@ private struct SharedProfileImagePipelineTestError: Error {}
 private final class SharedProfileMockImagePipelineManager: ImagePipelineManager {
     enum ResultMode {
         case success(String)
-        case failure(any Error)
+        case failure(SharedProfileImagePipelineTestError)
     }
 
     private let result: ResultMode

--- a/ios/Reguerta/scripts/audit-swift-existentials.sh
+++ b/ios/Reguerta/scripts/audit-swift-existentials.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: audit-swift-existentials.sh [--diff | --all] [--base <git-ref>]
+
+Runs Swift's opt-in ExistentialType diagnostic for the iOS app and test targets.
+
+  --diff       Report diagnostics only on Swift lines changed from the merge base
+               with origin/main (default).
+  --all        Report every project-source diagnostic.
+  --base REF   Compare --diff with the merge base of REF instead of origin/main.
+  --help       Show this help.
+
+This is an informational audit. Findings do not make the command fail; invalid
+arguments, Git errors, build failures, and report-processing errors do.
+EOF
+}
+
+fail() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+mode="diff"
+mode_was_set=false
+base_ref="origin/main"
+base_was_set=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --diff)
+            [[ "$mode_was_set" == false ]] || fail "choose --diff or --all only once"
+            mode="diff"
+            mode_was_set=true
+            shift
+            ;;
+        --all)
+            [[ "$mode_was_set" == false ]] || fail "choose --diff or --all only once"
+            mode="all"
+            mode_was_set=true
+            shift
+            ;;
+        --base)
+            [[ "$base_was_set" == false ]] || fail "provide --base only once"
+            [[ $# -ge 2 && -n "$2" ]] || fail "--base requires a Git ref"
+            base_ref="$2"
+            base_was_set=true
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown argument: $1"
+            ;;
+    esac
+done
+
+[[ "$mode" == "diff" || "$base_was_set" == false ]] || fail "--base can only be used with --diff"
+
+command -v git >/dev/null 2>&1 || fail "git is required"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required"
+command -v xcodebuild >/dev/null 2>&1 || fail "xcodebuild is required"
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+ios_dir=$(cd "$script_dir/.." && pwd -P)
+repo_root=$(git -C "$ios_dir" rev-parse --show-toplevel 2>/dev/null) || fail "the script is not inside a Git worktree"
+
+project_path="$ios_dir/Reguerta.xcodeproj"
+[[ -d "$project_path" ]] || fail "Xcode project not found at $project_path"
+
+merge_base=""
+if [[ "$mode" == "diff" ]]; then
+    git -C "$repo_root" rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null || fail "invalid base ref: $base_ref"
+    merge_base=$(git -C "$repo_root" merge-base "$base_ref" HEAD) || fail "no merge base found for $base_ref and HEAD"
+    [[ -n "$merge_base" ]] || fail "no merge base found for $base_ref and HEAD"
+fi
+
+audit_tmp=$(mktemp -d "${TMPDIR:-/tmp}/reguerta-existential-audit.XXXXXX") || fail "could not create a temporary directory"
+
+cleanup() {
+    local directory_name
+    directory_name=$(basename "$audit_tmp")
+    if [[ -d "$audit_tmp" && "$directory_name" == reguerta-existential-audit.* ]]; then
+        rm -rf -- "$audit_tmp"
+    fi
+}
+trap cleanup EXIT
+
+audit_log="$audit_tmp/xcodebuild.log"
+
+echo "Building Reguerta with Swift ExistentialType diagnostics enabled..."
+if ! xcodebuild -quiet \
+    -project "$project_path" \
+    -scheme Reguerta \
+    -configuration Debug \
+    -destination 'generic/platform=iOS Simulator' \
+    -derivedDataPath "$audit_tmp/DerivedData" \
+    build-for-testing \
+    'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' \
+    'SWIFT_SUPPRESS_WARNINGS=NO' \
+    'OTHER_SWIFT_FLAGS=$(inherited) -Wwarning ExistentialType' \
+    >"$audit_log" 2>&1; then
+    cat "$audit_log" >&2
+    fail "xcodebuild failed; the existential report was not generated"
+fi
+
+python3 - "$audit_log" "$repo_root" "$ios_dir" "$mode" "$merge_base" "$base_ref" <<'PYTHON'
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def fail(message):
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def git(repo_root, *arguments):
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *arguments],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        fail(detail or f"git {' '.join(arguments)} failed")
+    return result.stdout
+
+
+def relative_to(path, parent):
+    try:
+        return path.relative_to(parent)
+    except ValueError:
+        return None
+
+
+def changed_swift_lines(repo_root, merge_base):
+    changed = {}
+    tracked_output = git(repo_root, "diff", "--name-only", "-z", merge_base, "--")
+    untracked_output = git(repo_root, "ls-files", "--others", "--exclude-standard", "-z", "--")
+
+    tracked_paths = [Path(os.fsdecode(item)) for item in tracked_output.split(b"\0") if item]
+    untracked_paths = [Path(os.fsdecode(item)) for item in untracked_output.split(b"\0") if item]
+
+    hunk_pattern = re.compile(rb"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+    for relative_path in tracked_paths:
+        if relative_path.suffix != ".swift":
+            continue
+        absolute_path = repo_root / relative_path
+        if not absolute_path.is_file():
+            continue
+        diff = git(
+            repo_root,
+            "diff",
+            "--unified=0",
+            "--no-color",
+            "--no-ext-diff",
+            "--no-renames",
+            merge_base,
+            "--",
+            str(relative_path),
+        )
+        line_numbers = changed.setdefault(relative_path.as_posix(), set())
+        for line in diff.splitlines():
+            match = hunk_pattern.match(line)
+            if match is None:
+                continue
+            start = int(match.group(1))
+            count = int(match.group(2)) if match.group(2) is not None else 1
+            line_numbers.update(range(start, start + count))
+
+    for relative_path in untracked_paths:
+        if relative_path.suffix != ".swift":
+            continue
+        absolute_path = repo_root / relative_path
+        if not absolute_path.is_file():
+            continue
+        try:
+            line_count = len(absolute_path.read_bytes().splitlines())
+        except OSError as error:
+            fail(f"could not read untracked file {relative_path}: {error}")
+        changed[relative_path.as_posix()] = set(range(1, line_count + 1))
+
+    return changed
+
+
+if len(sys.argv) != 7:
+    fail("internal argument error")
+
+log_path = Path(sys.argv[1])
+repo_root = Path(sys.argv[2]).resolve()
+ios_dir = Path(sys.argv[3]).resolve()
+mode = sys.argv[4]
+merge_base = sys.argv[5]
+base_ref = sys.argv[6]
+
+source_roots = tuple(
+    (ios_dir / directory).resolve()
+    for directory in ("Reguerta", "ReguertaTests", "ReguertaUITests")
+)
+ansi_pattern = re.compile(r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+diagnostic_pattern = re.compile(
+    r"^(?P<path>.+\.swift):(?P<line>\d+):(?P<column>\d+): warning: "
+    r"(?P<message>.+)$"
+)
+
+try:
+    log_lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+except OSError as error:
+    fail(f"could not read xcodebuild output: {error}")
+
+diagnostics = set()
+for raw_line in log_lines:
+    line = ansi_pattern.sub("", raw_line).strip()
+    match = diagnostic_pattern.match(line)
+    if match is None:
+        continue
+
+    # xcodebuild currently removes the diagnostic identifier that swiftc prints,
+    # so retain the stable diagnostic category and its central wording instead.
+    message = match.group("message")
+    identifier = " [#ExistentialType]"
+    if message.endswith(identifier):
+        message = message[:-len(identifier)]
+    if not message.startswith("Performance: ") or " uses an existential" not in message:
+        continue
+
+    source_path = Path(match.group("path"))
+    if not source_path.is_absolute():
+        source_path = ios_dir / source_path
+    source_path = source_path.resolve()
+    if not any(relative_to(source_path, root) is not None for root in source_roots):
+        continue
+
+    repo_relative = relative_to(source_path, repo_root)
+    if repo_relative is None:
+        continue
+    diagnostics.add(
+        (
+            repo_relative.as_posix(),
+            int(match.group("line")),
+            int(match.group("column")),
+            message,
+        )
+    )
+
+ordered_diagnostics = sorted(diagnostics)
+selected_diagnostics = ordered_diagnostics
+if mode == "diff":
+    changed = changed_swift_lines(repo_root, merge_base)
+    selected_diagnostics = [
+        diagnostic
+        for diagnostic in ordered_diagnostics
+        if diagnostic[1] in changed.get(diagnostic[0], set())
+    ]
+
+for path, line, column, message in selected_diagnostics:
+    print(f"{path}:{line}:{column}: warning: {message} [#ExistentialType]")
+
+if mode == "diff":
+    print(
+        "Existential audit completed: "
+        f"{len(selected_diagnostics)} diagnostic(s) on Swift lines changed from "
+        f"the merge base of {base_ref} ({merge_base[:12]}); "
+        f"{len(ordered_diagnostics)} total project diagnostic(s)."
+    )
+else:
+    print(
+        "Existential audit completed: "
+        f"{len(ordered_diagnostics)} total project diagnostic(s)."
+    )
+PYTHON


### PR DESCRIPTION
## Summary

- narrows fixed composition and closed test-error contracts to concrete types
- makes the 10 audited `Chained*Repository` wrappers generic over their primary and fallback implementations
- documents the concrete/generic/existential policy in English and Spanish
- adds an opt-in `ExistentialType` audit with diff and full-inventory modes

## Why

The iOS codebase used existential type erasure at several boundaries where each instance actually preserves one concrete implementation. This change removes only the cases with demonstrated static identity and keeps runtime substitution, heterogeneous error, Firestore `Any`, and stable DI boundaries explicit.

## Validation

- `git diff --check`
- SwiftLint 0.61.0 strict: 338 files, 0 violations
- focused repository/error tests
- full `ReguertaTests` suite on iPhone 17: exit 0
- existential audit positive probe: one diagnostic, deduplicated across simulator architectures
- final diff audit: 0 diagnostics on changed Swift lines
- independent iOS review: no findings

Xcode MCP was attempted first but the shared build cache was blocked by a stale FirebaseSessions PCM. Build-for-testing and tests passed with isolated temporary Derived Data.

## Residual risk

- nine generic chained wrappers currently have no iOS callers; inference will be exercised when they are composed again
- the pre-existing `@unchecked Sendable` on `ChainedSharedProfileRepository` is unchanged
- no SwiftUI or accessibility surface changed

Closes #234