### PR TITLE
💄 style(ios): normalize Swift declarations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,9 +104,13 @@ When skipped, explicitly state why in the final handoff.
 ### Swift Signature Formatting
 
 - Use 120 columns, including indentation, as the preferred maximum Swift line width.
-- Keep a `func`, `init`, or `subscript` declaration on one line when its complete signature fits within 120 columns and has at most three simple parameters. Count attributes, `async`/`throws`, the return type, and the opening brace when present.
+- Keep a `func`, `init`, or `subscript` declaration on one line when its complete signature fits within 120 columns and has at most three simple parameters. Count attributes only when they share the declaration line; also count `async`/`throws`, the return type, and the opening brace when present.
+- Treat a declaration attribute placed on its own line, whether single-line or multiline, as a separate layout unit. Apply the 120-column and parameter-complexity rules to the declaration header after those attributes. A separated attribute does not by itself require a vertical parameter list.
 - Use vertical formatting for four or more parameters or for complex signatures containing closures or function types, nested generics or tuples, closure attributes, multiline default values, or generic requirements. Put one parameter on each line, align the closing delimiter with the declaration, and avoid hybrid wrapping.
-- Apply this rule to new code and touched signatures. Keep historical formatting cleanup in separate, non-functional changes.
+- Keep `let` and `var` declarations, including their type annotation, on one line when the complete declaration fits within 120 columns and has no multiline initializer. A function type, `@Sendable`, or a short generic does not require fragmentation by itself.
+- Keep a `guard condition else { exit }` statement on one line when it fits within 120 columns and `exit` is one simple immediate transfer such as `return`, `return nil`, `return false`, `continue`, `break`, or a simple `throw`. Retain multiline form for comments, multiline conditions, complex calls, or additional logic; do not extend this exception to `if`, loops, or effectful closures.
+- Keep a complete function on one line only when it is a genuinely trivial pure predicate, accessor, adapter, or test double whose single obvious expression fits with the signature. Keep business operations, mutations, `await`, `try`, control flow, and effectful calls multiline.
+- Apply these rules to new and touched declarations. Keep historical formatting cleanup in separate, non-functional changes.
 
 ## Execution Style
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,7 @@ All notable changes to this project will be documented in this file.
 
 ### Maintenance
 
+- 2026-08-05 | 💄 style(ios): normalize Swift declarations
 - 2026-08-02 | 🔧 chore(ios): enforce Swift line width
 - 2026-07-30 | 📦 build(android): update Navigation 3 to 1.1.5
 - 2026-07-29 | 📦 build(android): configure release signing

--- a/ios/Reguerta/Reguerta/App/BylawsFeatureDependencies.swift
+++ b/ios/Reguerta/Reguerta/App/BylawsFeatureDependencies.swift
@@ -41,10 +41,7 @@ private struct PreviewBylawsConsultant: BylawsConsulting {
         configuredCapability
     }
 
-    func consult(
-        question: String,
-        responseLanguage: BylawsResponseLanguage
-    ) async throws -> BylawsConsultationResult {
+    func consult(question: String, responseLanguage: BylawsResponseLanguage) async throws -> BylawsConsultationResult {
         BylawsConsultationResult(
             summary: responseLanguage == .english
                 ? "Local preview summary for: \(question)"

--- a/ios/Reguerta/Reguerta/App/BylawsPreviewSupport.swift
+++ b/ios/Reguerta/Reguerta/App/BylawsPreviewSupport.swift
@@ -109,8 +109,7 @@ extension BylawsConsultationResult {
 private struct PreviewBylawsDocumentProvider: BylawsDocumentProviding {
     let pdfURL: URL
 
-    @MainActor
-    func bundledPdfURL() -> URL? {
+    @MainActor func bundledPdfURL() -> URL? {
         pdfURL
     }
 }
@@ -122,7 +121,12 @@ private final class BylawsPreviewSeed {
     var excerpt: String
     var pdfPath: String
 
-    init(sourceID: String, title: String, excerpt: String, pdfPath: String) {
+    init(
+        sourceID: String,
+        title: String,
+        excerpt: String,
+        pdfPath: String
+    ) {
         self.sourceID = sourceID
         self.title = title
         self.excerpt = excerpt

--- a/ios/Reguerta/Reguerta/App/ReguertaAppEnvironment.swift
+++ b/ios/Reguerta/Reguerta/App/ReguertaAppEnvironment.swift
@@ -135,9 +135,7 @@ private struct UITestingAccessRootDependencies {
     let nowMillisProvider: @MainActor () -> Int64
 }
 
-private func makeUITestingAccessRootViewModel(
-    _ dependencies: UITestingAccessRootDependencies
-) -> AccessRootViewModel {
+private func makeUITestingAccessRootViewModel(_ dependencies: UITestingAccessRootDependencies) -> AccessRootViewModel {
     AccessRootViewModel(
         sessionViewModel: dependencies.sessionViewModel,
         feedbackCenter: dependencies.feedbackCenter,

--- a/ios/Reguerta/Reguerta/Data/Access/FirebaseAuthSessionProvider.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/FirebaseAuthSessionProvider.swift
@@ -148,8 +148,7 @@ struct FirebaseAuthSessionProvider: AuthSessionProvider {
         return try await refreshedUser.getIDTokenResult(forcingRefresh: forcingRefresh).token
     }
 
-    @discardableResult
-    func signOut() -> Bool {
+    @discardableResult func signOut() -> Bool {
         do {
             try auth.signOut()
             return true
@@ -212,8 +211,7 @@ private enum FirebaseIDTokenError: Error {
     case noAuthenticatedUser
 }
 
-@MainActor
-private func sendVerificationEmail(to user: User) async -> Bool {
+@MainActor private func sendVerificationEmail(to user: User) async -> Bool {
     do {
         try await user.sendEmailVerification()
         return true
@@ -226,8 +224,7 @@ private func normalizedEmail(_ email: String) -> String {
     email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 }
 
-@MainActor
-func mapFirebaseAuthError(_ error: Error) -> AuthSignInFailureReason {
+@MainActor func mapFirebaseAuthError(_ error: Error) -> AuthSignInFailureReason {
     let nsError = error as NSError
     guard let code = AuthErrorCode(rawValue: nsError.code) else {
         return .unknown
@@ -255,8 +252,7 @@ func mapFirebaseAuthError(_ error: Error) -> AuthSignInFailureReason {
     }
 }
 
-@MainActor
-private func isExpiredSessionError(_ error: Error) -> Bool {
+@MainActor private func isExpiredSessionError(_ error: Error) -> Bool {
     let nsError = error as NSError
     guard let code = AuthErrorCode(rawValue: nsError.code) else {
         return false

--- a/ios/Reguerta/Reguerta/Data/Access/FirestoreMemberRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/FirestoreMemberRepository.swift
@@ -5,10 +5,7 @@ final class FirestoreMemberRepository: @unchecked Sendable, MemberRepository {
     private let db: Firestore
     private let environment: ReguertaFirestoreEnvironment?
 
-    init(
-        db: Firestore = Firestore.firestore(),
-        environment: ReguertaFirestoreEnvironment? = nil
-    ) {
+    init(db: Firestore = Firestore.firestore(), environment: ReguertaFirestoreEnvironment? = nil) {
         self.db = db
         self.environment = environment
     }
@@ -152,10 +149,7 @@ extension FirestoreMemberRepository {
         )
     }
 
-    static func mergingAuthenticatedMember(
-        _ authenticatedMember: Member,
-        into directoryMembers: [Member]
-    ) -> [Member] {
+    static func mergingAuthenticatedMember(_ authenticatedMember: Member, into directoryMembers: [Member]) -> [Member] {
         directoryMembers.filter { $0.id != authenticatedMember.id } + [authenticatedMember]
     }
 }
@@ -299,22 +293,14 @@ private extension FirestoreMemberRepository {
         return normalized
     }
 
-    private static func requiredString(
-        _ data: [String: Any],
-        field: String,
-        resource: String
-    ) throws -> String {
+    private static func requiredString(_ data: [String: Any], field: String, resource: String) throws -> String {
         guard let value = try optionalString(data, keys: [field], resource: resource) else {
             throw RepositoryError.invalidData(resource: resource)
         }
         return value
     }
 
-    private static func optionalString(
-        _ data: [String: Any],
-        keys: [String],
-        resource: String
-    ) throws -> String? {
+    private static func optionalString(_ data: [String: Any], keys: [String], resource: String) throws -> String? {
         for key in keys {
             guard let rawValue = data[key], !(rawValue is NSNull) else { continue }
             guard let value = rawValue as? String else {
@@ -326,11 +312,7 @@ private extension FirestoreMemberRepository {
         return nil
     }
 
-    private static func requiredBool(
-        _ data: [String: Any],
-        field: String,
-        resource: String
-    ) throws -> Bool {
+    private static func requiredBool(_ data: [String: Any], field: String, resource: String) throws -> Bool {
         guard let rawValue = data[field], let value = rawValue as? Bool else {
             throw RepositoryError.invalidData(resource: resource)
         }
@@ -353,11 +335,7 @@ private extension FirestoreMemberRepository {
         return defaultValue
     }
 
-    private static func optionalMap(
-        _ data: [String: Any],
-        field: String,
-        resource: String
-    ) throws -> [String: Any]? {
+    private static func optionalMap(_ data: [String: Any], field: String, resource: String) throws -> [String: Any]? {
         guard let rawValue = data[field], !(rawValue is NSNull) else { return nil }
         guard let value = rawValue as? [String: Any] else {
             throw RepositoryError.invalidData(resource: resource)

--- a/ios/Reguerta/Reguerta/Data/Access/MockAuthSessionProvider.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/MockAuthSessionProvider.swift
@@ -53,8 +53,7 @@ final class MockAuthSessionProvider: AuthSessionProvider {
         return "mock-token-\(currentPrincipal.uid)"
     }
 
-    @discardableResult
-    func signOut() -> Bool {
+    @discardableResult func signOut() -> Bool {
         currentPrincipal = nil
         return true
     }

--- a/ios/Reguerta/Reguerta/Data/Bylaws/BundledBylawsDocumentProvider.swift
+++ b/ios/Reguerta/Reguerta/Data/Bylaws/BundledBylawsDocumentProvider.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 nonisolated struct BundledBylawsDocumentProvider: BylawsDocumentProviding {
-    @MainActor
-    func bundledPdfURL() -> URL? {
+    @MainActor func bundledPdfURL() -> URL? {
         resolveBundledBylawsURL(
             fileName: "reguerta-estatutos",
             fileExtension: "pdf"

--- a/ios/Reguerta/Reguerta/Data/Bylaws/BundledBylawsKnowledgeDataSource.swift
+++ b/ios/Reguerta/Reguerta/Data/Bylaws/BundledBylawsKnowledgeDataSource.swift
@@ -89,10 +89,7 @@ nonisolated private struct BylawsKnowledgePayload: Decodable {
     }
 }
 
-nonisolated func resolveBundledBylawsURL(
-    fileName: String,
-    fileExtension: String
-) -> URL? {
+nonisolated func resolveBundledBylawsURL(fileName: String, fileExtension: String) -> URL? {
     let subdirectories = ["bylaws", "Resources/bylaws", "Resources"]
     for bundle in [Bundle.main] {
         for subdirectory in subdirectories {

--- a/ios/Reguerta/Reguerta/Data/Bylaws/FoundationModelsBylawsSummaryGenerator.swift
+++ b/ios/Reguerta/Reguerta/Data/Bylaws/FoundationModelsBylawsSummaryGenerator.swift
@@ -39,9 +39,7 @@ nonisolated struct FoundationModelsBylawsSummaryGenerator: BylawsSummaryGenerati
         """
     }
 
-    func capability(
-        for responseLanguage: BylawsResponseLanguage
-    ) async -> BylawsConsultationCapability {
+    func capability(for responseLanguage: BylawsResponseLanguage) async -> BylawsConsultationCapability {
         let model = SystemLanguageModel.default
         guard model.availability == .available,
               model.supportsLocale(Locale(identifier: "es_ES")),
@@ -79,9 +77,7 @@ nonisolated struct FoundationModelsBylawsSummaryGenerator: BylawsSummaryGenerati
         }
     }
 
-    static func consultationError(
-        for error: LanguageModelSession.GenerationError
-    ) -> BylawsConsultationError {
+    static func consultationError(for error: LanguageModelSession.GenerationError) -> BylawsConsultationError {
         switch error {
         case .assetsUnavailable, .unsupportedLanguageOrLocale:
             .modelUnavailable

--- a/ios/Reguerta/Reguerta/Data/Bylaws/SpanishBylawsArticleRetriever.swift
+++ b/ios/Reguerta/Reguerta/Data/Bylaws/SpanishBylawsArticleRetriever.swift
@@ -1,11 +1,7 @@
 import Foundation
 
 nonisolated struct SpanishBylawsArticleRetriever: BylawsRetrieving {
-    func retrieve(
-        question: String,
-        in articles: [BylawsArticle],
-        maxResults: Int
-    ) -> [BylawsRetrievedArticle] {
+    func retrieve(question: String, in articles: [BylawsArticle], maxResults: Int) -> [BylawsRetrievedArticle] {
         guard maxResults > 0 else { return [] }
 
         let normalizedQuestion = normalize(question)

--- a/ios/Reguerta/Reguerta/Data/Calendar/FirestoreDeliveryCalendarRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Calendar/FirestoreDeliveryCalendarRepository.swift
@@ -5,10 +5,7 @@ final class FirestoreDeliveryCalendarRepository: @unchecked Sendable, DeliveryCa
     private let db: Firestore
     private let environment: ReguertaFirestoreEnvironment?
 
-    init(
-        db: Firestore = Firestore.firestore(),
-        environment: ReguertaFirestoreEnvironment? = nil
-    ) {
+    init(db: Firestore = Firestore.firestore(), environment: ReguertaFirestoreEnvironment? = nil) {
         self.db = db
         self.environment = environment
     }

--- a/ios/Reguerta/Reguerta/Data/Commitments/FirestoreSeasonalCommitmentRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Commitments/FirestoreSeasonalCommitmentRepository.swift
@@ -41,10 +41,7 @@ final class FirestoreSeasonalCommitmentRepository: @unchecked Sendable, Seasonal
     private let db: Firestore
     private let environment: ReguertaFirestoreEnvironment?
 
-    init(
-        db: Firestore = Firestore.firestore(),
-        environment: ReguertaFirestoreEnvironment? = nil
-    ) {
+    init(db: Firestore = Firestore.firestore(), environment: ReguertaFirestoreEnvironment? = nil) {
         self.db = db
         self.environment = environment
     }
@@ -266,11 +263,7 @@ final class FirestoreSeasonalCommitmentRepository: @unchecked Sendable, Seasonal
         return nil
     }
 
-    private static func optionalBool(
-        _ data: [String: Any],
-        field: String,
-        default defaultValue: Bool
-    ) throws -> Bool {
+    private static func optionalBool(_ data: [String: Any], field: String, default defaultValue: Bool) throws -> Bool {
         guard let value = data[field] else { return defaultValue }
         if value is NSNull { return defaultValue }
         guard let bool = value as? Bool else { throw invalidDocumentError }

--- a/ios/Reguerta/Reguerta/Data/Devices/FirebaseAuthorizedDeviceCoordinator.swift
+++ b/ios/Reguerta/Reguerta/Data/Devices/FirebaseAuthorizedDeviceCoordinator.swift
@@ -265,9 +265,7 @@ private extension FirebaseAuthorizedDeviceCoordinator {
         )
     }
 
-    private func performAuthorizationClear(
-        ifOwnedBy lease: AuthorizedDeviceSessionLease
-    ) async throws {
+    private func performAuthorizationClear(ifOwnedBy lease: AuthorizedDeviceSessionLease) async throws {
         let expectedContext: AuthorizedDeviceSessionContext
         if let activeAuthorization {
             guard activeAuthorization.context.lease == lease else { return }
@@ -398,8 +396,7 @@ private extension FirebaseAuthorizedDeviceCoordinator {
     }
 }
 
-@MainActor
-private func fetchFirebaseMessagingToken() async throws -> String? {
+@MainActor private func fetchFirebaseMessagingToken() async throws -> String? {
     try await withCheckedThrowingContinuation { continuation in
         Messaging.messaging().token { token, error in
             if let error {
@@ -411,8 +408,7 @@ private func fetchFirebaseMessagingToken() async throws -> String? {
     }
 }
 
-@MainActor
-private func makeCurrentIOSDevice(token: String?, nowMillis: Int64) -> RegisteredDevice {
+@MainActor private func makeCurrentIOSDevice(token: String?, nowMillis: Int64) -> RegisteredDevice {
     RegisteredDevice(
         deviceId: UIDevice.current.identifierForVendor?.uuidString ?? "ios-\(UIDevice.current.model)",
         platform: "ios",

--- a/ios/Reguerta/Reguerta/Data/Firestore/ReguertaFirestorePath.swift
+++ b/ios/Reguerta/Reguerta/Data/Firestore/ReguertaFirestorePath.swift
@@ -23,10 +23,7 @@ enum ReguertaRuntimeEnvironment {
         sessionOverride ?? baseFirestoreEnvironment
     }
 
-    static func applySessionEnvironment(
-        _ environment: ReguertaFirestoreEnvironment,
-        lease: SessionEnvironmentLease
-    ) {
+    static func applySessionEnvironment(_ environment: ReguertaFirestoreEnvironment, lease: SessionEnvironmentLease) {
         sessionOverride = environment == baseFirestoreEnvironment ? nil : environment
         sessionEnvironmentLease = lease
     }
@@ -89,10 +86,7 @@ struct ReguertaFirestorePath: Sendable {
         "\(resolvedEnvironment.rawValue)/\(collection.pathComponent)"
     }
 
-    func documentPath(
-        in collection: ReguertaFirestoreCollection,
-        documentId: String
-    ) -> String {
+    func documentPath(in collection: ReguertaFirestoreCollection, documentId: String) -> String {
         "\(collectionPath(collection))/\(documentId)"
     }
 }

--- a/ios/Reguerta/Reguerta/Data/Freshness/FirestoreCriticalDataRefresher.swift
+++ b/ios/Reguerta/Reguerta/Data/Freshness/FirestoreCriticalDataRefresher.swift
@@ -130,11 +130,7 @@ struct FirestoreCriticalDataRefresher: CriticalDataRefreshing {
 }
 
 private extension FirestoreCriticalDataRefresher {
-    private func refreshMember(
-        id: String,
-        scope: CriticalDataRefreshScope,
-        resource: String
-    ) async throws -> Member {
+    private func refreshMember(id: String, scope: CriticalDataRefreshScope, resource: String) async throws -> Member {
         let users = db.reguertaCollection(.users, environment: scope.environment)
         do {
             let snapshot = try await users.document(id)
@@ -292,11 +288,7 @@ private extension FirestoreCriticalDataRefresher {
         }
     }
 
-    private func refreshOwnedQuery(
-        path: String,
-        ownerField: String,
-        memberID: String
-    ) async throws {
+    private func refreshOwnedQuery(path: String, ownerField: String, memberID: String) async throws {
         _ = try await db.collection(path)
             .whereField(ownerField, isEqualTo: memberID)
             .getDocuments(source: .server)
@@ -316,10 +308,7 @@ private extension FirestoreCriticalDataRefresher {
         }
     }
 
-    private func legacyCollectionPath(
-        named collectionName: String,
-        environment: SessionEnvironment
-    ) -> String {
+    private func legacyCollectionPath(named collectionName: String, environment: SessionEnvironment) -> String {
         "\(environment.rawValue)/collections/\(collectionName)"
     }
 }

--- a/ios/Reguerta/Reguerta/Data/Media/FirebaseImagePipelineManager.swift
+++ b/ios/Reguerta/Reguerta/Data/Media/FirebaseImagePipelineManager.swift
@@ -6,10 +6,7 @@ final class FirebaseImagePipelineManager: @unchecked Sendable, ImagePipelineMana
     private let storage: Storage
     private let jpegCompressionQuality: CGFloat
 
-    init(
-        storage: Storage = Storage.storage(),
-        jpegCompressionQuality: CGFloat = 0.82
-    ) {
+    init(storage: Storage = Storage.storage(), jpegCompressionQuality: CGFloat = 0.82) {
         self.storage = storage
         self.jpegCompressionQuality = jpegCompressionQuality
     }
@@ -88,11 +85,7 @@ final class FirebaseImagePipelineManager: @unchecked Sendable, ImagePipelineMana
         return trimmed.isEmpty ? fallback : trimmed
     }
 
-    private func uploadData(
-        _ data: Data,
-        metadata: StorageMetadata,
-        to reference: StorageReference
-    ) async throws {
+    private func uploadData(_ data: Data, metadata: StorageMetadata, to reference: StorageReference) async throws {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             reference.putData(data, metadata: metadata) { _, error in
                 if let error {

--- a/ios/Reguerta/Reguerta/Data/Media/ImagePipelineSizingContract.swift
+++ b/ios/Reguerta/Reguerta/Data/Media/ImagePipelineSizingContract.swift
@@ -12,11 +12,7 @@ struct CropSquare: Equatable, Sendable {
 }
 
 enum ImagePipelineSizingContract {
-    static func scaledDimensions(
-        sourceWidth: Int,
-        sourceHeight: Int,
-        targetShortSidePx: Int
-    ) -> PixelSize? {
+    static func scaledDimensions(sourceWidth: Int, sourceHeight: Int, targetShortSidePx: Int) -> PixelSize? {
         guard sourceWidth > 0, sourceHeight > 0, targetShortSidePx > 0 else {
             return nil
         }
@@ -27,11 +23,7 @@ enum ImagePipelineSizingContract {
         return PixelSize(width: scaledWidth, height: scaledHeight)
     }
 
-    static func centerCropSquare(
-        sourceWidth: Int,
-        sourceHeight: Int,
-        targetSidePx: Int
-    ) -> CropSquare? {
+    static func centerCropSquare(sourceWidth: Int, sourceHeight: Int, targetSidePx: Int) -> CropSquare? {
         guard sourceWidth >= targetSidePx,
               sourceHeight >= targetSidePx,
               targetSidePx > 0 else {

--- a/ios/Reguerta/Reguerta/Data/News/FirestoreNewsRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/News/FirestoreNewsRepository.swift
@@ -6,10 +6,7 @@ final class FirestoreNewsRepository: @unchecked Sendable, NewsRepository {
     private let db: Firestore
     private let environment: ReguertaFirestoreEnvironment?
 
-    init(
-        db: Firestore = Firestore.firestore(),
-        environment: ReguertaFirestoreEnvironment? = nil
-    ) {
+    init(db: Firestore = Firestore.firestore(), environment: ReguertaFirestoreEnvironment? = nil) {
         self.db = db
         self.environment = environment
     }
@@ -130,22 +127,14 @@ private enum FirestoreNewsDocumentDecoder {
         )
     }
 
-    private static func requiredString(
-        _ data: [String: Any],
-        field: String,
-        resource: String
-    ) throws -> String {
+    private static func requiredString(_ data: [String: Any], field: String, resource: String) throws -> String {
         guard let value = try optionalString(data, field: field, resource: resource) else {
             throw RepositoryError.invalidData(resource: resource)
         }
         return value
     }
 
-    private static func optionalString(
-        _ data: [String: Any],
-        field: String,
-        resource: String
-    ) throws -> String? {
+    private static func optionalString(_ data: [String: Any], field: String, resource: String) throws -> String? {
         guard let value = data[field] else { return nil }
         if value is NSNull { return nil }
         guard let string = value as? String else {
@@ -158,11 +147,7 @@ private enum FirestoreNewsDocumentDecoder {
         return normalized
     }
 
-    private static func requiredBool(
-        _ data: [String: Any],
-        field: String,
-        resource: String
-    ) throws -> Bool {
+    private static func requiredBool(_ data: [String: Any], field: String, resource: String) throws -> Bool {
         guard let number = data[field] as? NSNumber,
               CFGetTypeID(number) == CFBooleanGetTypeID() else {
             throw RepositoryError.invalidData(resource: resource)

--- a/ios/Reguerta/Reguerta/Data/Notifications/FirestoreNotificationRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Notifications/FirestoreNotificationRepository.swift
@@ -19,10 +19,7 @@ final class FirestoreNotificationRepository: @unchecked Sendable, NotificationRe
     private let db: Firestore
     private let environment: ReguertaFirestoreEnvironment?
 
-    init(
-        db: Firestore = Firestore.firestore(),
-        environment: ReguertaFirestoreEnvironment? = nil
-    ) {
+    init(db: Firestore = Firestore.firestore(), environment: ReguertaFirestoreEnvironment? = nil) {
         self.db = db
         self.environment = environment
     }
@@ -327,33 +324,21 @@ private enum FirestoreNotificationDocumentDecoder {
         }
     }
 
-    private static func exactRequiredString(
-        _ data: [String: Any],
-        field: String,
-        resource: String
-    ) throws -> String {
+    private static func exactRequiredString(_ data: [String: Any], field: String, resource: String) throws -> String {
         guard let string = data[field] as? String, !string.isEmpty else {
             throw RepositoryError.invalidData(resource: resource)
         }
         return string
     }
 
-    private static func requiredString(
-        _ data: [String: Any],
-        field: String,
-        resource: String
-    ) throws -> String {
+    private static func requiredString(_ data: [String: Any], field: String, resource: String) throws -> String {
         guard let value = try optionalString(data, field: field, resource: resource) else {
             throw RepositoryError.invalidData(resource: resource)
         }
         return value
     }
 
-    private static func optionalString(
-        _ data: [String: Any],
-        field: String,
-        resource: String
-    ) throws -> String? {
+    private static func optionalString(_ data: [String: Any], field: String, resource: String) throws -> String? {
         guard let value = data[field] else { return nil }
         if value is NSNull { return nil }
         guard let string = value as? String else {

--- a/ios/Reguerta/Reguerta/Data/Notifications/IOSPushNotificationPermissionProvider.swift
+++ b/ios/Reguerta/Reguerta/Data/Notifications/IOSPushNotificationPermissionProvider.swift
@@ -14,8 +14,7 @@ struct IOSPushNotificationPermissionProvider: PushNotificationPermissionProvider
         }
     }
 
-    @MainActor
-    func openSettings() {
+    @MainActor func openSettings() {
         guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else {
             return
         }

--- a/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderCheckout.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderCheckout.swift
@@ -137,9 +137,7 @@ func buildMyOrderCheckoutLineSnapshots(
     }
 }
 
-func resolveMyOrderCheckoutWriteTargets(
-    firestorePath: ReguertaFirestorePath
-) -> [MyOrderCheckoutWriteTarget] {
+func resolveMyOrderCheckoutWriteTargets(firestorePath: ReguertaFirestorePath) -> [MyOrderCheckoutWriteTarget] {
     [
         (
             orders: firestorePath.collectionPath(.orders),
@@ -228,10 +226,7 @@ func submitMyOrderCheckout(
     return serverOrderSnapshot.exists
 }
 
-private func buildMyOrderCheckoutBatch(
-    _ content: MyOrderCheckoutBatchContent,
-    db: Firestore
-) -> WriteBatch {
+private func buildMyOrderCheckoutBatch(_ content: MyOrderCheckoutBatchContent, db: Firestore) -> WriteBatch {
     let batch = db.batch()
     batch.setData(
         myOrderCheckoutOrderPayload(
@@ -263,10 +258,7 @@ private func buildMyOrderCheckoutBatch(
     return batch
 }
 
-nonisolated func myOrderOwnedWeekQueryScopes(
-    memberId: String,
-    weekKey: String
-) -> [MyOrderOwnedWeekQueryScope] {
+nonisolated func myOrderOwnedWeekQueryScopes(memberId: String, weekKey: String) -> [MyOrderOwnedWeekQueryScope] {
     ["userId", "memberId"].map { ownerField in
         MyOrderOwnedWeekQueryScope(
             ownerField: ownerField,
@@ -276,10 +268,7 @@ nonisolated func myOrderOwnedWeekQueryScopes(
     }
 }
 
-nonisolated func resolveMyOrderCheckoutDocumentId(
-    newOrderId: String,
-    existingOrderIds: [String]
-) throws -> String {
+nonisolated func resolveMyOrderCheckoutDocumentId(newOrderId: String, existingOrderIds: [String]) throws -> String {
     let normalizedExistingIds = normalizedUniqueMyOrderIds(existingOrderIds)
     switch normalizedExistingIds.count {
     case 0:
@@ -409,10 +398,7 @@ func myOrderCheckoutLinePayload(
     ]
 }
 
-func myOrderSnapshotsMatch(
-    _ lhs: MyOrderCartSnapshot,
-    _ rhs: MyOrderCartSnapshot
-) -> Bool {
+func myOrderSnapshotsMatch(_ lhs: MyOrderCartSnapshot, _ rhs: MyOrderCartSnapshot) -> Bool {
     lhs.selectedQuantities == rhs.selectedQuantities &&
         lhs.selectedEcoBasketOptions == rhs.selectedEcoBasketOptions
 }

--- a/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderPreviousOrder.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderPreviousOrder.swift
@@ -129,9 +129,7 @@ func fetchOrderSummarySnapshot(
     return nil
 }
 
-func resolvePreviousOrderReadTargets(
-    firestorePath: ReguertaFirestorePath
-) -> [MyOrderCheckoutWriteTarget] {
+func resolvePreviousOrderReadTargets(firestorePath: ReguertaFirestorePath) -> [MyOrderCheckoutWriteTarget] {
     [
         (
             orders: firestorePath.collectionPath(.orders),
@@ -218,10 +216,7 @@ private func fetchPreviousOrderLineDocuments(
     )
 }
 
-nonisolated func myOrderCandidateOrderIds(
-    deterministicOrderId: String,
-    discoveredOrderIds: [String]
-) -> [String] {
+nonisolated func myOrderCandidateOrderIds(deterministicOrderId: String, discoveredOrderIds: [String]) -> [String] {
     normalizedUniqueMyOrderIds([deterministicOrderId] + discoveredOrderIds)
 }
 
@@ -296,10 +291,7 @@ func myOrderProducerStatusesByVendor(from data: [String: Any]) -> [String: Produ
     }
 }
 
-func myOrderPackagingLine(
-    from data: [String: Any],
-    locale: Locale = reguertaPresentationLocale()
-) -> String {
+func myOrderPackagingLine(from data: [String: Any], locale: Locale = reguertaPresentationLocale()) -> String {
     let containerName = ((data["packContainerName"] as? String)?
         .trimmingCharacters(in: .whitespacesAndNewlines))
         .flatMap { $0.isEmpty ? nil : $0 }

--- a/ios/Reguerta/Reguerta/Data/Orders/FirestoreOrdersRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/FirestoreOrdersRepository.swift
@@ -5,10 +5,7 @@ struct FirestoreOrdersRepository: OrdersRepository {
     private let db: Firestore
     private let environment: ReguertaFirestoreEnvironment?
 
-    init(
-        db: Firestore,
-        environment: ReguertaFirestoreEnvironment? = nil
-    ) {
+    init(db: Firestore, environment: ReguertaFirestoreEnvironment? = nil) {
         self.db = db
         self.environment = environment
     }
@@ -48,10 +45,7 @@ struct FirestoreOrdersRepository: OrdersRepository {
         )
     }
 
-    func orderSummarySnapshot(
-        currentMember: Member?,
-        weekKey: String
-    ) async throws -> MyOrderPreviousOrderSnapshot? {
+    func orderSummarySnapshot(currentMember: Member?, weekKey: String) async throws -> MyOrderPreviousOrderSnapshot? {
         try await fetchOrderSummarySnapshot(
             currentMember: currentMember,
             weekKey: weekKey,
@@ -60,10 +54,7 @@ struct FirestoreOrdersRepository: OrdersRepository {
         )
     }
 
-    func myOrderProducerStatuses(
-        currentMember: Member?,
-        weekKey: String
-    ) async -> MyOrderProducerStatusSnapshot {
+    func myOrderProducerStatuses(currentMember: Member?, weekKey: String) async -> MyOrderProducerStatusSnapshot {
         await loadMyOrderProducerStatuses(
             currentMember: currentMember,
             weekKey: weekKey,
@@ -72,10 +63,7 @@ struct FirestoreOrdersRepository: OrdersRepository {
         )
     }
 
-    func receivedOrdersSnapshot(
-        producerId: String,
-        targetWeekKey: String
-    ) async throws -> ReceivedOrdersSnapshot? {
+    func receivedOrdersSnapshot(producerId: String, targetWeekKey: String) async throws -> ReceivedOrdersSnapshot? {
         try await fetchReceivedOrdersSnapshotForProducer(
             producerId: producerId,
             targetWeekKey: targetWeekKey,
@@ -92,10 +80,7 @@ struct FirestoreOrdersRepository: OrdersRepository {
         )
     }
 
-    func receivedOrdersHistorySnapshot(
-        producerId: String,
-        weekKey: String
-    ) async throws -> ReceivedOrdersSnapshot? {
+    func receivedOrdersHistorySnapshot(producerId: String, weekKey: String) async throws -> ReceivedOrdersSnapshot? {
         try await fetchReceivedOrdersSnapshotForProducer(
             producerId: producerId,
             targetWeekKey: weekKey,

--- a/ios/Reguerta/Reguerta/Data/Orders/FirestoreReceivedOrdersData.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/FirestoreReceivedOrdersData.swift
@@ -107,9 +107,7 @@ func updateReceivedOrderProducerStatus(
     return lastFailure
 }
 
-private func receivedOrderlineReadTargets(
-    firestorePath: ReguertaFirestorePath
-) -> [String] {
+private func receivedOrderlineReadTargets(firestorePath: ReguertaFirestorePath) -> [String] {
     [
         firestorePath.collectionPath(.orderlines)
     ]
@@ -245,9 +243,7 @@ private func buildReceivedOrdersSnapshot(
     )
 }
 
-private func buildReceivedOrdersProductRows(
-    from lines: [ReceivedOrderLineRecord]
-) -> [ReceivedOrdersProductRow] {
+private func buildReceivedOrdersProductRows(from lines: [ReceivedOrderLineRecord]) -> [ReceivedOrdersProductRow] {
     Dictionary(grouping: lines, by: \.productId)
         .compactMap { productId, grouped -> ReceivedOrdersProductRow? in
             guard let first = grouped.first else { return nil }
@@ -298,9 +294,7 @@ private func buildReceivedOrdersMemberGroups(
         }
 }
 
-private func buildReceivedOrdersMemberLines(
-    from lines: [ReceivedOrderLineRecord]
-) -> [ReceivedOrdersMemberLine] {
+private func buildReceivedOrdersMemberLines(from lines: [ReceivedOrderLineRecord]) -> [ReceivedOrdersMemberLine] {
     lines.map { line in
         ReceivedOrdersMemberLine(
             id: "\(line.orderId)|\(line.productId)",
@@ -326,10 +320,7 @@ private func receivedOrdersGeneralTotal(from lines: [ReceivedOrderLineRecord]) -
     }
 }
 
-private func receivedOrderStatus(
-    from data: [String: Any],
-    producerId: String
-) -> ProducerOrderStatus {
+private func receivedOrderStatus(from data: [String: Any], producerId: String) -> ProducerOrderStatus {
     if let statusesByVendor = data["producerStatusesByVendor"] as? [String: Any],
        let statusValue = statusesByVendor[producerId] as? String {
         return ProducerOrderStatus.from(statusValue)

--- a/ios/Reguerta/Reguerta/Data/Orders/InMemoryOrdersRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/InMemoryOrdersRepository.swift
@@ -70,10 +70,7 @@ actor InMemoryOrdersRepository: OrdersRepository {
         return Array(explicitKeys.union(seededKeys)).sorted()
     }
 
-    func orderSummarySnapshot(
-        currentMember: Member?,
-        weekKey: String
-    ) async throws -> MyOrderPreviousOrderSnapshot? {
+    func orderSummarySnapshot(currentMember: Member?, weekKey: String) async throws -> MyOrderPreviousOrderSnapshot? {
         if let previousOrderError {
             throw previousOrderError
         }
@@ -81,10 +78,7 @@ actor InMemoryOrdersRepository: OrdersRepository {
         return previousOrdersByWeekKey[weekKey]
     }
 
-    func myOrderProducerStatuses(
-        currentMember: Member?,
-        weekKey: String
-    ) async -> MyOrderProducerStatusSnapshot {
+    func myOrderProducerStatuses(currentMember: Member?, weekKey: String) async -> MyOrderProducerStatusSnapshot {
         guard let memberId = currentMember?.id else {
             return MyOrderProducerStatusSnapshot(byVendor: [:], legacyStatus: .unread)
         }
@@ -92,10 +86,7 @@ actor InMemoryOrdersRepository: OrdersRepository {
             ?? MyOrderProducerStatusSnapshot(byVendor: [:], legacyStatus: .unread)
     }
 
-    func receivedOrdersSnapshot(
-        producerId: String,
-        targetWeekKey: String
-    ) async throws -> ReceivedOrdersSnapshot? {
+    func receivedOrdersSnapshot(producerId: String, targetWeekKey: String) async throws -> ReceivedOrdersSnapshot? {
         if let receivedOrdersError {
             throw receivedOrdersError
         }
@@ -115,10 +106,7 @@ actor InMemoryOrdersRepository: OrdersRepository {
         return Array(explicitKeys.union(seededKeys)).sorted()
     }
 
-    func receivedOrdersHistorySnapshot(
-        producerId: String,
-        weekKey: String
-    ) async throws -> ReceivedOrdersSnapshot? {
+    func receivedOrdersHistorySnapshot(producerId: String, weekKey: String) async throws -> ReceivedOrdersSnapshot? {
         try await receivedOrdersSnapshot(producerId: producerId, targetWeekKey: weekKey)
     }
 
@@ -146,11 +134,7 @@ actor InMemoryOrdersRepository: OrdersRepository {
         previousOrderError = error
     }
 
-    func setProducerStatuses(
-        _ snapshot: MyOrderProducerStatusSnapshot,
-        memberId: String,
-        weekKey: String
-    ) {
+    func setProducerStatuses(_ snapshot: MyOrderProducerStatusSnapshot, memberId: String, weekKey: String) {
         producerStatusesByMemberWeek[producerStatusKey(memberId: memberId, weekKey: weekKey)] = snapshot
     }
 
@@ -158,11 +142,7 @@ actor InMemoryOrdersRepository: OrdersRepository {
         submitResult = result
     }
 
-    func setReceivedOrdersSnapshot(
-        _ snapshot: ReceivedOrdersSnapshot,
-        producerId: String,
-        weekKey: String
-    ) {
+    func setReceivedOrdersSnapshot(_ snapshot: ReceivedOrdersSnapshot, producerId: String, weekKey: String) {
         receivedSnapshotsByProducerWeek[receivedKey(producerId: producerId, weekKey: weekKey)] = snapshot
     }
 

--- a/ios/Reguerta/Reguerta/Data/Orders/MyOrderPersistenceHelpers.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/MyOrderPersistenceHelpers.swift
@@ -6,10 +6,7 @@ let myOrderCartOptionsSuffix = ".eco_options"
 let myOrderConfirmedQuantitiesSuffix = ".confirmed_quantities"
 let myOrderConfirmedOptionsSuffix = ".confirmed_eco_options"
 
-func readMyOrderCartSnapshot(
-    userDefaults: UserDefaults = .standard,
-    storageKey: String
-) -> MyOrderCartSnapshot {
+func readMyOrderCartSnapshot(userDefaults: UserDefaults = .standard, storageKey: String) -> MyOrderCartSnapshot {
     let quantitiesKey = "\(myOrderCartStoragePrefix).\(storageKey)\(myOrderCartQuantitiesSuffix)"
     let optionsKey = "\(myOrderCartStoragePrefix).\(storageKey)\(myOrderCartOptionsSuffix)"
 
@@ -62,10 +59,7 @@ func persistMyOrderCartSnapshot(
     }
 }
 
-func readMyOrderConfirmedSnapshot(
-    userDefaults: UserDefaults = .standard,
-    storageKey: String
-) -> MyOrderCartSnapshot {
+func readMyOrderConfirmedSnapshot(userDefaults: UserDefaults = .standard, storageKey: String) -> MyOrderCartSnapshot {
     let quantitiesKey = "\(myOrderCartStoragePrefix).\(storageKey)\(myOrderConfirmedQuantitiesSuffix)"
     let optionsKey = "\(myOrderCartStoragePrefix).\(storageKey)\(myOrderConfirmedOptionsSuffix)"
 

--- a/ios/Reguerta/Reguerta/Data/Products/FirestoreProductRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Products/FirestoreProductRepository.swift
@@ -5,10 +5,7 @@ final class FirestoreProductRepository: @unchecked Sendable, ProductRepository {
     private let db: Firestore
     private let environment: ReguertaFirestoreEnvironment?
 
-    init(
-        db: Firestore = Firestore.firestore(),
-        environment: ReguertaFirestoreEnvironment? = nil
-    ) {
+    init(db: Firestore = Firestore.firestore(), environment: ReguertaFirestoreEnvironment? = nil) {
         self.db = db
         self.environment = environment
     }
@@ -220,11 +217,7 @@ final class FirestoreProductRepository: @unchecked Sendable, ProductRepository {
         return value
     }
 
-    private static func optionalBool(
-        _ data: [String: Any],
-        field: String,
-        default defaultValue: Bool
-    ) throws -> Bool {
+    private static func optionalBool(_ data: [String: Any], field: String, default defaultValue: Bool) throws -> Bool {
         guard let value = data[field] else { return defaultValue }
         if value is NSNull { return defaultValue }
         guard let bool = value as? Bool else { throw invalidDocumentError }

--- a/ios/Reguerta/Reguerta/Data/Profiles/ChainedSharedProfileRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Profiles/ChainedSharedProfileRepository.swift
@@ -5,10 +5,7 @@ final class ChainedSharedProfileRepository<Primary: SharedProfileRepository, Fal
     private let primary: Primary
     private let fallback: Fallback
 
-    init(
-        primary: Primary,
-        fallback: Fallback
-    ) {
+    init(primary: Primary, fallback: Fallback) {
         self.primary = primary
         self.fallback = fallback
     }

--- a/ios/Reguerta/Reguerta/Data/Profiles/FirestoreSharedProfileRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Profiles/FirestoreSharedProfileRepository.swift
@@ -5,10 +5,7 @@ final class FirestoreSharedProfileRepository: @unchecked Sendable, SharedProfile
     private let db: Firestore
     private let environment: ReguertaFirestoreEnvironment?
 
-    init(
-        db: Firestore = Firestore.firestore(),
-        environment: ReguertaFirestoreEnvironment? = nil
-    ) {
+    init(db: Firestore = Firestore.firestore(), environment: ReguertaFirestoreEnvironment? = nil) {
         self.db = db
         self.environment = environment
     }

--- a/ios/Reguerta/Reguerta/Data/Security/KeychainStore.swift
+++ b/ios/Reguerta/Reguerta/Data/Security/KeychainStore.swift
@@ -79,10 +79,7 @@ actor KeychainStore {
     private let client: any KeychainClient
     private let service: String
 
-    init(
-        client: any KeychainClient = SystemKeychainClient(),
-        service: String = "com.reguerta.app.secure-storage"
-    ) {
+    init(client: any KeychainClient = SystemKeychainClient(), service: String = "com.reguerta.app.secure-storage") {
         self.client = client
         self.service = service
     }
@@ -118,7 +115,10 @@ actor KeychainStore {
         }
     }
 
-    func save<Value: Encodable & Sendable>(_ value: Value, for key: KeychainKey) throws {
+    func save<Value: Encodable & Sendable>(
+        _ value: Value,
+        for key: KeychainKey
+    ) throws {
         let data: Data
         do {
             data = try JSONEncoder().encode(value)

--- a/ios/Reguerta/Reguerta/Data/ShiftPlanningRequests/FirestoreShiftPlanningRequestRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/ShiftPlanningRequests/FirestoreShiftPlanningRequestRepository.swift
@@ -10,10 +10,7 @@ final class FirestoreShiftPlanningRequestRepository: @unchecked Sendable, ShiftP
     private let db: Firestore
     private let environment: ReguertaFirestoreEnvironment?
 
-    init(
-        db: Firestore = Firestore.firestore(),
-        environment: ReguertaFirestoreEnvironment? = nil
-    ) {
+    init(db: Firestore = Firestore.firestore(), environment: ReguertaFirestoreEnvironment? = nil) {
         self.db = db
         self.environment = environment
     }

--- a/ios/Reguerta/Reguerta/Data/Shifts/FirestoreShiftRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Shifts/FirestoreShiftRepository.swift
@@ -5,10 +5,7 @@ final class FirestoreShiftRepository: @unchecked Sendable, ShiftRepository {
     private let db: Firestore
     private let environment: ReguertaFirestoreEnvironment?
 
-    init(
-        db: Firestore = Firestore.firestore(),
-        environment: ReguertaFirestoreEnvironment? = nil
-    ) {
+    init(db: Firestore = Firestore.firestore(), environment: ReguertaFirestoreEnvironment? = nil) {
         self.db = db
         self.environment = environment
     }

--- a/ios/Reguerta/Reguerta/Data/Startup/FirestoreStartupVersionPolicyRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Startup/FirestoreStartupVersionPolicyRepository.swift
@@ -5,10 +5,7 @@ final class FirestoreStartupVersionPolicyRepository: @unchecked Sendable, Startu
     private let db: Firestore
     private let environment: ReguertaFirestoreEnvironment?
 
-    init(
-        db: Firestore = Firestore.firestore(),
-        environment: ReguertaFirestoreEnvironment? = nil
-    ) {
+    init(db: Firestore = Firestore.firestore(), environment: ReguertaFirestoreEnvironment? = nil) {
         self.db = db
         self.environment = environment
     }
@@ -31,10 +28,7 @@ final class FirestoreStartupVersionPolicyRepository: @unchecked Sendable, Startu
         }
     }
 
-    nonisolated static func policy(
-        for platform: StartupPlatform,
-        data: [String: Any]
-    ) throws -> StartupVersionPolicy {
+    nonisolated static func policy(for platform: StartupPlatform, data: [String: Any]) throws -> StartupVersionPolicy {
         guard let versions = data["versions"] as? [String: Any],
               let platformPolicy = versions[platform.rawValue] as? [String: Any],
               let currentVersion = platformPolicy.requiredString(for: "current"),

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaButton/ReguertaButtonView.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaButton/ReguertaButtonView.swift
@@ -86,8 +86,7 @@ private struct ReguertaContrastPreservingButtonStyle: ButtonStyle {
 }
 
 private extension View {
-    @ViewBuilder
-    func reguertaOptionalAccessibilityIdentifier(_ identifier: String?) -> some View {
+    @ViewBuilder func reguertaOptionalAccessibilityIdentifier(_ identifier: String?) -> some View {
         if let identifier {
             accessibilityIdentifier(identifier)
         } else {

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaDialog/ReguertaDialogView.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaDialog/ReguertaDialogView.swift
@@ -90,7 +90,10 @@ private enum ReguertaDialogCoordinateSpace {
 private struct ReguertaDialogCardFramePreferenceKey: PreferenceKey {
     static let defaultValue = CGRect.infinite
 
-    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+    static func reduce(
+        value: inout CGRect,
+        nextValue: () -> CGRect
+    ) {
         value = nextValue()
     }
 }
@@ -164,10 +167,7 @@ private struct ReguertaDialogActionsView: View {
         }
     }
 
-    private func dialogActionButton(
-        _ action: ReguertaDialogAction,
-        variant: ReguertaButtonVariant
-    ) -> some View {
+    private func dialogActionButton(_ action: ReguertaDialogAction, variant: ReguertaButtonVariant) -> some View {
         reguertaButton(
             LocalizedStringKey(action.title),
             variant: variant,

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaFloatingActionButton/ReguertaFloatingActionButtonView.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaFloatingActionButton/ReguertaFloatingActionButtonView.swift
@@ -92,8 +92,7 @@ func reguertaFloatingActionButton(
 }
 
 private extension View {
-    @ViewBuilder
-    func reguertaOptionalAccessibilityIdentifier(_ identifier: String?) -> some View {
+    @ViewBuilder func reguertaOptionalAccessibilityIdentifier(_ identifier: String?) -> some View {
         if let identifier {
             accessibilityIdentifier(identifier)
         } else {

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaInputField/ReguertaInputFieldView.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaInputField/ReguertaInputFieldView.swift
@@ -211,8 +211,7 @@ private struct ReguertaInputMessageView: View {
 }
 
 private extension View {
-    @ViewBuilder
-    func reguertaOptionalAccessibilityIdentifier(_ identifier: String?) -> some View {
+    @ViewBuilder func reguertaOptionalAccessibilityIdentifier(_ identifier: String?) -> some View {
         if let identifier {
             accessibilityIdentifier(identifier)
         } else {

--- a/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaScreenHeader/ReguertaScreenHeaderViewModel.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/Components/ReguertaScreenHeader/ReguertaScreenHeaderViewModel.swift
@@ -92,11 +92,7 @@ struct ReguertaScreenHeaderViewModel {
 }
 
 extension View {
-    @ViewBuilder
-    func reguertaHeaderGlassButton(
-        isEnabled: Bool,
-        colorScheme: ColorScheme
-    ) -> some View {
+    @ViewBuilder func reguertaHeaderGlassButton(isEnabled: Bool, colorScheme: ColorScheme) -> some View {
         let shape = Circle()
         let isDarkMode = colorScheme == .dark
         let tint = isDarkMode ? Color.black.opacity(0.36) : Color.white.opacity(0.42)
@@ -116,8 +112,7 @@ extension View {
         }
     }
 
-    @ViewBuilder
-    func reguertaHeaderAccessibilityIdentifier(_ identifier: String?) -> some View {
+    @ViewBuilder func reguertaHeaderAccessibilityIdentifier(_ identifier: String?) -> some View {
         if let identifier {
             accessibilityIdentifier(identifier)
         } else {

--- a/ios/Reguerta/Reguerta/DesignSystem/ReguertaTheme.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/ReguertaTheme.swift
@@ -147,7 +147,9 @@ struct ReguertaTheme<Content: View>: View {
     @Environment(\.colorScheme) private var colorScheme
     private let content: () -> Content
 
-    init(@ViewBuilder content: @escaping () -> Content) {
+    init(
+        @ViewBuilder content: @escaping () -> Content
+    ) {
         self.content = content
     }
 

--- a/ios/Reguerta/Reguerta/Domain/Bylaws/BylawsContracts.swift
+++ b/ios/Reguerta/Reguerta/Domain/Bylaws/BylawsContracts.swift
@@ -5,11 +5,7 @@ nonisolated protocol BylawsKnowledgeProviding: Sendable {
 }
 
 nonisolated protocol BylawsRetrieving: Sendable {
-    func retrieve(
-        question: String,
-        in articles: [BylawsArticle],
-        maxResults: Int
-    ) -> [BylawsRetrievedArticle]
+    func retrieve(question: String, in articles: [BylawsArticle], maxResults: Int) -> [BylawsRetrievedArticle]
 }
 
 nonisolated protocol BylawsQuestionScopeClassifying: Sendable {
@@ -19,20 +15,13 @@ nonisolated protocol BylawsQuestionScopeClassifying: Sendable {
 nonisolated protocol BylawsSummaryGenerating: Sendable {
     var modelIdentifier: String { get }
 
-    func capability(
-        for responseLanguage: BylawsResponseLanguage
-    ) async -> BylawsConsultationCapability
+    func capability(for responseLanguage: BylawsResponseLanguage) async -> BylawsConsultationCapability
     func summarize(_ request: BylawsSummaryRequest) async throws -> String
 }
 
 nonisolated protocol BylawsConsulting: Sendable {
-    func capability(
-        for responseLanguage: BylawsResponseLanguage
-    ) async -> BylawsConsultationCapability
-    func consult(
-        question: String,
-        responseLanguage: BylawsResponseLanguage
-    ) async throws -> BylawsConsultationResult
+    func capability(for responseLanguage: BylawsResponseLanguage) async -> BylawsConsultationCapability
+    func consult(question: String, responseLanguage: BylawsResponseLanguage) async throws -> BylawsConsultationResult
 }
 
 nonisolated protocol BylawsDocumentProviding: Sendable {

--- a/ios/Reguerta/Reguerta/Domain/Bylaws/ConsultBylawsUseCase.swift
+++ b/ios/Reguerta/Reguerta/Domain/Bylaws/ConsultBylawsUseCase.swift
@@ -6,9 +6,7 @@ nonisolated struct ConsultBylawsUseCase: BylawsConsulting {
     private let questionScopeClassifier: any BylawsQuestionScopeClassifying
     private let summaryGenerator: any BylawsSummaryGenerating
 
-    func capability(
-        for responseLanguage: BylawsResponseLanguage
-    ) async -> BylawsConsultationCapability {
+    func capability(for responseLanguage: BylawsResponseLanguage) async -> BylawsConsultationCapability {
         await summaryGenerator.capability(for: responseLanguage)
     }
 
@@ -26,10 +24,7 @@ nonisolated struct ConsultBylawsUseCase: BylawsConsulting {
     /// - Throws: `BylawsConsultationError` when the model is unavailable, evidence is absent,
     ///   the question is clearly unrelated, or generated output fails validation; cancellation
     ///   is propagated as `CancellationError`.
-    func consult(
-        question: String,
-        responseLanguage: BylawsResponseLanguage
-    ) async throws -> BylawsConsultationResult {
+    func consult(question: String, responseLanguage: BylawsResponseLanguage) async throws -> BylawsConsultationResult {
         try Task.checkCancellation()
         guard await summaryGenerator.capability(for: responseLanguage) == .localModel else {
             throw BylawsConsultationError.modelUnavailable
@@ -88,9 +83,7 @@ nonisolated struct ConsultBylawsUseCase: BylawsConsulting {
         }
     }
 
-    private func makeEvidence(
-        from matches: [BylawsRetrievedArticle]
-    ) -> [BylawsSourceEvidence] {
+    private func makeEvidence(from matches: [BylawsRetrievedArticle]) -> [BylawsSourceEvidence] {
         matches.map { match in
             BylawsSourceEvidence(
                 sourceID: match.article.id,

--- a/ios/Reguerta/Reguerta/Domain/Freshness/CriticalDataFreshnessModels.swift
+++ b/ios/Reguerta/Reguerta/Domain/Freshness/CriticalDataFreshnessModels.swift
@@ -118,16 +118,12 @@ struct NoOpCriticalDataRefresher: CriticalDataRefreshing {
 protocol CriticalDataFreshnessLocalRepository: Sendable {
     var writeGeneration: UInt64 { get }
     func getMetadata() -> CriticalDataFreshnessMetadata?
-    func saveMetadata(
-        _ metadata: CriticalDataFreshnessMetadata,
-        ifWriteGeneration writeGeneration: UInt64
-    ) -> Bool
+    func saveMetadata(_ metadata: CriticalDataFreshnessMetadata, ifWriteGeneration writeGeneration: UInt64) -> Bool
     func clear() throws
 }
 
 extension CriticalDataFreshnessLocalRepository {
-    @discardableResult
-    func saveMetadata(_ metadata: CriticalDataFreshnessMetadata) -> Bool {
+    @discardableResult func saveMetadata(_ metadata: CriticalDataFreshnessMetadata) -> Bool {
         saveMetadata(metadata, ifWriteGeneration: writeGeneration)
     }
 }

--- a/ios/Reguerta/Reguerta/Domain/Media/ImagePipelineManager.swift
+++ b/ios/Reguerta/Reguerta/Domain/Media/ImagePipelineManager.swift
@@ -29,17 +29,11 @@ enum ImagePipelineError: Error, Sendable {
 }
 
 protocol ImagePipelineManager: Sendable {
-    func processAndUpload(
-        imageData: Data,
-        request: ImageUploadRequest
-    ) async throws -> ImageUploadResult
+    func processAndUpload(imageData: Data, request: ImageUploadRequest) async throws -> ImageUploadResult
 }
 
 struct NoOpImagePipelineManager: ImagePipelineManager {
-    func processAndUpload(
-        imageData: Data,
-        request: ImageUploadRequest
-    ) async throws -> ImageUploadResult {
+    func processAndUpload(imageData: Data, request: ImageUploadRequest) async throws -> ImageUploadResult {
         throw ImagePipelineError.uploadFailed
     }
 }

--- a/ios/Reguerta/Reguerta/Domain/Notifications/PushNotificationPermissionProvider.swift
+++ b/ios/Reguerta/Reguerta/Domain/Notifications/PushNotificationPermissionProvider.swift
@@ -12,6 +12,5 @@ struct FixedPushNotificationPermissionProvider: PushNotificationPermissionProvid
         isActive
     }
 
-    @MainActor
-    func openSettings() {}
+    @MainActor func openSettings() {}
 }

--- a/ios/Reguerta/Reguerta/Domain/Orders/OrderHistoryWeek.swift
+++ b/ios/Reguerta/Reguerta/Domain/Orders/OrderHistoryWeek.swift
@@ -140,11 +140,7 @@ func orderHistoryWeekOption(
     return orderHistoryWeekOption(for: start, calendar: calendar, locale: locale)
 }
 
-private func orderHistoryWeekOption(
-    for weekStart: Date,
-    calendar: Calendar,
-    locale: Locale
-) -> OrderHistoryWeekOption {
+private func orderHistoryWeekOption(for weekStart: Date, calendar: Calendar, locale: Locale) -> OrderHistoryWeekOption {
     let weekEnd = calendar.date(byAdding: .day, value: 6, to: weekStart) ?? weekStart
     let weekNumber = calendar.component(.weekOfYear, from: weekStart)
     let weekYear = calendar.component(.yearForWeekOfYear, from: weekStart)

--- a/ios/Reguerta/Reguerta/Domain/Orders/OrdersRepository.swift
+++ b/ios/Reguerta/Reguerta/Domain/Orders/OrdersRepository.swift
@@ -19,27 +19,15 @@ protocol OrdersRepository {
 
     func orderHistoryWeekKeys(currentMember: Member?) async throws -> [String]
 
-    func orderSummarySnapshot(
-        currentMember: Member?,
-        weekKey: String
-    ) async throws -> MyOrderPreviousOrderSnapshot?
+    func orderSummarySnapshot(currentMember: Member?, weekKey: String) async throws -> MyOrderPreviousOrderSnapshot?
 
-    func myOrderProducerStatuses(
-        currentMember: Member?,
-        weekKey: String
-    ) async -> MyOrderProducerStatusSnapshot
+    func myOrderProducerStatuses(currentMember: Member?, weekKey: String) async -> MyOrderProducerStatusSnapshot
 
-    func receivedOrdersSnapshot(
-        producerId: String,
-        targetWeekKey: String
-    ) async throws -> ReceivedOrdersSnapshot?
+    func receivedOrdersSnapshot(producerId: String, targetWeekKey: String) async throws -> ReceivedOrdersSnapshot?
 
     func receivedOrdersHistoryWeekKeys(producerId: String) async throws -> [String]
 
-    func receivedOrdersHistorySnapshot(
-        producerId: String,
-        weekKey: String
-    ) async throws -> ReceivedOrdersSnapshot?
+    func receivedOrdersHistorySnapshot(producerId: String, weekKey: String) async throws -> ReceivedOrdersSnapshot?
 
     func updateReceivedOrderProducerStatus(
         orderId: String,

--- a/ios/Reguerta/Reguerta/Domain/Products/ProductDraft.swift
+++ b/ios/Reguerta/Reguerta/Domain/Products/ProductDraft.swift
@@ -75,11 +75,7 @@ struct ProductSaveInput: Equatable, Sendable {
 ///   - existing: The product being edited, or `nil` when creating one.
 ///   - nowMillis: The creation or update time in Unix milliseconds.
 /// - Returns: Parsed values ready for product construction, or `nil` when any invariant fails.
-func resolveProductSaveInput(
-    draft: ProductDraft,
-    existing: Product?,
-    nowMillis: Int64
-) -> ProductSaveInput? {
+func resolveProductSaveInput(draft: ProductDraft, existing: Product?, nowMillis: Int64) -> ProductSaveInput? {
     let draft = draft.normalized
     guard let price = draft.price.productPositiveDouble, !draft.name.isEmpty else {
         return nil
@@ -132,11 +128,7 @@ func resolveProductSaveInput(
 ///   - input: A value produced by `resolveProductSaveInput(draft:existing:nowMillis:)`.
 ///   - newProductId: The stable identifier to use only when creating a product.
 /// - Returns: A product that preserves edit identity and enforces role-derived flags.
-func buildProductToSave(
-    sessionMember: Member,
-    input: ProductSaveInput,
-    newProductId: String = ""
-) -> Product {
+func buildProductToSave(sessionMember: Member, input: ProductSaveInput, newProductId: String = "") -> Product {
     let canManageCommonPurchase = sessionMember.isCommonPurchaseManager && !sessionMember.isProducer
     let container = ProductContainerOption.matching(name: input.draft.packContainerName)
     let isBulk = container == .bulk

--- a/ios/Reguerta/Reguerta/Presentation/Auth/AuthErrorMapping.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/AuthErrorMapping.swift
@@ -11,11 +11,7 @@ struct AuthErrorPresentation: Sendable {
     let passwordErrorKey: String?
     let globalMessageKey: String?
 
-    init(
-        emailErrorKey: String? = nil,
-        passwordErrorKey: String? = nil,
-        globalMessageKey: String? = nil
-    ) {
+    init(emailErrorKey: String? = nil, passwordErrorKey: String? = nil, globalMessageKey: String? = nil) {
         self.emailErrorKey = emailErrorKey
         self.passwordErrorKey = passwordErrorKey
         self.globalMessageKey = globalMessageKey

--- a/ios/Reguerta/Reguerta/Presentation/Auth/ContentView+AuthOverlaysAndHandlers.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/ContentView+AuthOverlaysAndHandlers.swift
@@ -168,8 +168,7 @@ extension AccessRootRoutingView {
         }
     }
 
-    @ViewBuilder
-    private func startupVersionGateCard(_ content: StartupVersionGateCardContent) -> some View {
+    @ViewBuilder private func startupVersionGateCard(_ content: StartupVersionGateCardContent) -> some View {
         reguertaDialog(
             type: content.onSecondaryAction == nil ? .error : .info,
             title: l10n(content.titleKey),

--- a/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+AuthActions.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+AuthActions.swift
@@ -84,10 +84,7 @@ extension SessionViewModel {
         }
     }
 
-    private func applySignInResult(
-        _ result: AuthSignInResult,
-        generation: UInt64
-    ) async {
+    private func applySignInResult(_ result: AuthSignInResult, generation: UInt64) async {
         switch result {
         case .success(let principal):
             await applyAuthorizedSession(principal: principal, generation: generation)

--- a/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+AuthSessionSupport.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+AuthSessionSupport.swift
@@ -83,10 +83,7 @@ extension SessionViewModel {
         )
     }
 
-    func applyAuthorizedSession(
-        principal: AuthPrincipal,
-        generation: UInt64
-    ) async {
+    func applyAuthorizedSession(principal: AuthPrincipal, generation: UInt64) async {
         do {
             let result = try await resolveAuthorizedSession.execute(authPrincipal: principal)
             guard isCurrentSessionOperation(generation) else { return }

--- a/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+SessionOperationLifecycle.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+SessionOperationLifecycle.swift
@@ -1,10 +1,7 @@
 import Foundation
 
 extension SessionViewModel {
-    func applyLocalSessionTermination(
-        firebaseSignOutSucceeded: Bool,
-        showsExpiredDialog: Bool
-    ) {
+    func applyLocalSessionTermination(firebaseSignOutSucceeded: Bool, showsExpiredDialog: Bool) {
         let principalEmail = sessionOperationState == .idle
             ? currentPrincipalEmail
             : sessionOperationPrincipalEmail
@@ -58,8 +55,7 @@ extension SessionViewModel {
         )
     }
 
-    @discardableResult
-    func invalidateSessionOperation() -> Task<Void, Never>? {
+    @discardableResult func invalidateSessionOperation() -> Task<Void, Never>? {
         let invalidatedTask = sessionOperationTask
         invalidatedTask?.cancel()
         switch sessionOperationState {
@@ -150,8 +146,7 @@ extension SessionViewModel {
         sessionOperationState == .draining(generation: generation)
     }
 
-    @discardableResult
-    private func prepareForLocalSessionTermination() -> Bool {
+    @discardableResult private func prepareForLocalSessionTermination() -> Bool {
         let deviceSessionLease = authorizedDeviceSessionLease
         let hadOwnedSessionOperation = sessionOperationState != .idle
         authorizedDeviceSessionLease = nil
@@ -234,10 +229,7 @@ extension SessionViewModel {
         showUnauthorizedDialog = false
     }
 
-    private func startStandaloneSessionTerminationBarrier(
-        firebaseSignOutSucceeded: Bool,
-        principalEmail: String
-    ) {
+    private func startStandaloneSessionTerminationBarrier(firebaseSignOutSucceeded: Bool, principalEmail: String) {
         guard !firebaseSignOutSucceeded || sessionTerminationCleanupTask != nil else {
             return
         }
@@ -292,9 +284,7 @@ extension SessionViewModel {
         }
     }
 
-    private func appendSessionTerminationCleanup(
-        _ cleanupTask: Task<Bool, Never>?
-    ) {
+    private func appendSessionTerminationCleanup(_ cleanupTask: Task<Bool, Never>?) {
         guard let cleanupTask else { return }
         sessionTerminationCleanupGeneration &+= 1
         guard let previousCleanupTask = sessionTerminationCleanupTask else {

--- a/ios/Reguerta/Reguerta/Presentation/Bylaws/BylawsRouteView.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Bylaws/BylawsRouteView.swift
@@ -100,10 +100,7 @@ struct BylawsRouteView: View {
             .overlay(tokens.colors.borderSubtle)
     }
 
-    private func answerSection(
-        result: BylawsConsultationResult,
-        contentScrollsIndependently: Bool
-    ) -> some View {
+    private func answerSection(result: BylawsConsultationResult, contentScrollsIndependently: Bool) -> some View {
         BylawsAnswerSectionView(
             tokens: tokens,
             result: result,

--- a/ios/Reguerta/Reguerta/Presentation/Freshness/MyOrderFreshnessViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Freshness/MyOrderFreshnessViewModel.swift
@@ -129,8 +129,7 @@ final class MyOrderFreshnessViewModel {
         return canEnter
     }
 
-    @discardableResult
-    private func refresh(for identity: FreshnessSessionIdentity) -> FreshnessOperationHandle {
+    @discardableResult private func refresh(for identity: FreshnessSessionIdentity) -> FreshnessOperationHandle {
         invalidateFreshnessOperation()
         let generation = freshnessGeneration
         let metadataWriteGeneration = criticalDataFreshnessLocalRepository.writeGeneration
@@ -227,10 +226,7 @@ final class MyOrderFreshnessViewModel {
         )
     }
 
-    private func makeFreshnessTimeoutTask(
-        identity: FreshnessSessionIdentity,
-        generation: UInt64
-    ) -> Task<Void, Never> {
+    private func makeFreshnessTimeoutTask(identity: FreshnessSessionIdentity, generation: UInt64) -> Task<Void, Never> {
         let sleeper = sleeper
         let timeout = timeout
         return Task { @MainActor [weak self, sleeper] in
@@ -257,10 +253,7 @@ final class MyOrderFreshnessViewModel {
         state = .idle
     }
 
-    private func shouldRefresh(
-        from previousMode: SessionMode,
-        identity: FreshnessSessionIdentity
-    ) -> Bool {
+    private func shouldRefresh(from previousMode: SessionMode, identity: FreshnessSessionIdentity) -> Bool {
         switch previousMode {
         case .signedOut:
             return true
@@ -271,8 +264,7 @@ final class MyOrderFreshnessViewModel {
         }
     }
 
-    @discardableResult
-    private func invalidateFreshnessOperation() -> Task<Void, Never>? {
+    @discardableResult private func invalidateFreshnessOperation() -> Task<Void, Never>? {
         let invalidatedOperation = freshnessOperationTask
         invalidatedOperation?.cancel()
         freshnessTimeoutTask?.cancel()
@@ -282,10 +274,7 @@ final class MyOrderFreshnessViewModel {
         return invalidatedOperation
     }
 
-    private func isCurrentFreshnessOperation(
-        _ generation: UInt64,
-        identity: FreshnessSessionIdentity
-    ) -> Bool {
+    private func isCurrentFreshnessOperation(_ generation: UInt64, identity: FreshnessSessionIdentity) -> Bool {
         !Task.isCancelled &&
             generation == freshnessGeneration &&
             currentIdentity == identity

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeDrawerComponents.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeDrawerComponents.swift
@@ -188,11 +188,7 @@ struct HomeDrawerContentView: View {
             .padding(.vertical, tokens.spacing.xs)
     }
 
-    private func homeDrawerItem(
-        _ systemImage: String,
-        titleKey: String,
-        destination: HomeDestination
-    ) -> some View {
+    private func homeDrawerItem(_ systemImage: String, titleKey: String, destination: HomeDestination) -> some View {
         Button {
             onNavigate(destination)
         } label: {

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeFeatureRoutes.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeFeatureRoutes.swift
@@ -198,8 +198,7 @@ extension AccessRootRoutingView {
         )
     }
 
-    @ViewBuilder
-    func placeholderRoute(subtitleKey: String) -> some View {
+    @ViewBuilder func placeholderRoute(subtitleKey: String) -> some View {
         reguertaCard {
             VStack(alignment: .leading, spacing: tokens.spacing.md) {
                 Text(localizedKey(subtitleKey))
@@ -210,7 +209,9 @@ extension AccessRootRoutingView {
     }
 
     @ViewBuilder
-    func cardContainer<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+    func cardContainer<Content: View>(
+        @ViewBuilder content: () -> Content
+    ) -> some View {
         content()
             .padding(tokens.spacing.lg)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellRoute.swift
@@ -127,8 +127,7 @@ extension AccessRootRoutingView {
         }
     }
 
-    @ViewBuilder
-    func homeCheckoutDialog(_ alert: MyOrderCheckoutAlert) -> some View {
+    @ViewBuilder func homeCheckoutDialog(_ alert: MyOrderCheckoutAlert) -> some View {
         switch alert {
         case .missingCommitments(let names):
             homeCheckoutErrorDialog(

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeWeeklySummaryResolution.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeWeeklySummaryResolution.swift
@@ -181,10 +181,7 @@ private func resolveHomeTargetWeekStart(
         : currentWeekStart
 }
 
-private func resolveHomeTargetDeliveryShift(
-    shifts: [ShiftAssignment],
-    targetWeekKey: String
-) -> ShiftAssignment? {
+private func resolveHomeTargetDeliveryShift(shifts: [ShiftAssignment], targetWeekKey: String) -> ShiftAssignment? {
     shifts
         .filter { $0.type == .delivery }
         .first { shift in
@@ -208,10 +205,7 @@ private func resolveHomeTargetMarketShift(
         .min { $0.dateMillis < $1.dateMillis }
 }
 
-private func resolveHomeNextScheduledMarketDate(
-    onOrAfter today: Date,
-    calendar: Calendar
-) -> Date? {
+private func resolveHomeNextScheduledMarketDate(onOrAfter today: Date, calendar: Calendar) -> Date? {
     let monthComponents = calendar.dateComponents([.year, .month], from: today)
     guard var monthStart = calendar.date(from: monthComponents) else { return nil }
 
@@ -249,11 +243,7 @@ private func resolveHomeTargetDeliveryDate(
     )
 }
 
-private func homeDisplayNames(
-    for memberIds: [String],
-    members: [Member],
-    pendingLabel: String
-) -> [String] {
+private func homeDisplayNames(for memberIds: [String], members: [Member], pendingLabel: String) -> [String] {
     let names = memberIds.map { memberId in
         members.first(where: { $0.id == memberId })?.displayName ?? memberId
     }
@@ -277,17 +267,11 @@ func resolveHomeOrderState(
     return .notStarted
 }
 
-func resolveHomeDisplayedOrderState(
-    isConsultaPhase: Bool,
-    orderState: HomeOrderStateDisplay
-) -> HomeOrderStateDisplay {
+func resolveHomeDisplayedOrderState(isConsultaPhase: Bool, orderState: HomeOrderStateDisplay) -> HomeOrderStateDisplay {
     isConsultaPhase ? .consultation : orderState
 }
 
-func formatHomeTopBarDate(
-    nowMillis: Int64,
-    locale: Locale = .current
-) -> String {
+func formatHomeTopBarDate(nowMillis: Int64, locale: Locale = .current) -> String {
     let date = Date(timeIntervalSince1970: TimeInterval(nowMillis) / 1_000)
     let formatter = DateFormatter()
     formatter.locale = locale
@@ -309,10 +293,7 @@ private func resolveHomeCalendarDeliveryDate(
     return calendar.date(byAdding: .day, value: 2, to: weekStart) ?? weekStart
 }
 
-private func resolveHomeEffectiveDeliveryDate(
-    weekStart: Date,
-    context: HomeWeeklySummaryResolutionContext
-) -> Date {
+private func resolveHomeEffectiveDeliveryDate(weekStart: Date, context: HomeWeeklySummaryResolutionContext) -> Date {
     resolveHomeCalendarDeliveryDate(
         weekStart: weekStart,
         deliveryCalendarOverrides: context.deliveryCalendarOverrides,

--- a/ios/Reguerta/Reguerta/Presentation/News/NewsNotificationsFeatureViewModel+Actions.swift
+++ b/ios/Reguerta/Reguerta/Presentation/News/NewsNotificationsFeatureViewModel+Actions.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 extension NewsNotificationsFeatureViewModel {
-    func updateNewsDraft(_ update: (inout NewsDraft) -> Void) {
+    func updateNewsDraft(
+        _ update: (inout NewsDraft) -> Void
+    ) {
         var draft = newsDraft
         update(&draft)
         guard draft != newsDraft else { return }
@@ -9,7 +11,9 @@ extension NewsNotificationsFeatureViewModel {
         newsDraftRevision &+= 1
     }
 
-    func updateNotificationDraft(_ update: (inout NotificationDraft) -> Void) {
+    func updateNotificationDraft(
+        _ update: (inout NotificationDraft) -> Void
+    ) {
         var draft = notificationDraft
         update(&draft)
         guard draft != notificationDraft else { return }
@@ -17,8 +21,7 @@ extension NewsNotificationsFeatureViewModel {
         notificationDraftRevision &+= 1
     }
 
-    @discardableResult
-    func startCreatingNews() -> Bool {
+    @discardableResult func startCreatingNews() -> Bool {
         guard let context = captureAuthorizedSessionContext() else { return false }
         guard context.canPublishNews else {
             feedbackCenter.show(AccessL10nKey.feedbackOnlyAdminPublishNews)
@@ -31,8 +34,7 @@ extension NewsNotificationsFeatureViewModel {
         return true
     }
 
-    @discardableResult
-    func startEditingNews(newsId: String) -> Bool {
+    @discardableResult func startEditingNews(newsId: String) -> Bool {
         guard let context = captureAuthorizedSessionContext() else { return false }
         guard context.canPublishNews else {
             feedbackCenter.show(AccessL10nKey.feedbackOnlyAdminEditNews)
@@ -52,8 +54,7 @@ extension NewsNotificationsFeatureViewModel {
         editingNewsId = nil
     }
 
-    @discardableResult
-    func closeNewsSaveConfirmation() -> String? {
+    @discardableResult func closeNewsSaveConfirmation() -> String? {
         guard let confirmation = pendingNewsSaveConfirmation else { return nil }
         pendingNewsSaveConfirmation = nil
         clearNewsEditor()
@@ -61,8 +62,7 @@ extension NewsNotificationsFeatureViewModel {
         return confirmation.newsId
     }
 
-    @discardableResult
-    func startCreatingNotification() -> Bool {
+    @discardableResult func startCreatingNotification() -> Bool {
         guard let context = captureAuthorizedSessionContext() else { return false }
         guard context.canSendAdminNotifications else {
             feedbackCenter.show(AccessL10nKey.feedbackOnlyAdminSendNotification)

--- a/ios/Reguerta/Reguerta/Presentation/News/NewsNotificationsFeatureViewModel+CommunityState.swift
+++ b/ios/Reguerta/Reguerta/Presentation/News/NewsNotificationsFeatureViewModel+CommunityState.swift
@@ -69,8 +69,7 @@ extension NewsNotificationsFeatureViewModel {
         )
     }
 
-    @discardableResult
-    func upsertConfirmedNotification(_ event: NotificationEvent, member: Member) -> Bool {
+    @discardableResult func upsertConfirmedNotification(_ event: NotificationEvent, member: Member) -> Bool {
         notificationsFeed.removeAll { $0.id == event.id }
         guard event.isVisible(to: member) else {
             pendingConfirmedNotifications[event.id] = nil

--- a/ios/Reguerta/Reguerta/Presentation/News/NewsNotificationsFeatureViewModel+Loading.swift
+++ b/ios/Reguerta/Reguerta/Presentation/News/NewsNotificationsFeatureViewModel+Loading.swift
@@ -37,9 +37,7 @@ extension NewsNotificationsFeatureViewModel {
         }
     }
 
-    func handleEnvironmentRoutingTransition(
-        _ transition: SessionEnvironmentRoutingTransition
-    ) {
+    func handleEnvironmentRoutingTransition(_ transition: SessionEnvironmentRoutingTransition) {
         guard transition.generation > environmentRoutingGeneration else { return }
         environmentRoutingGeneration = transition.generation
         sessionIdentityEpoch &+= 1
@@ -50,9 +48,7 @@ extension NewsNotificationsFeatureViewModel {
         currentEnvironment = transition.environment
     }
 
-    func refreshNews(
-        failureFeedbackOwnership: NewsConvergenceFeedbackOwnership? = nil
-    ) async {
+    func refreshNews(failureFeedbackOwnership: NewsConvergenceFeedbackOwnership? = nil) async {
         guard let context = captureAuthorizedSessionContext() else { return }
 
         let operationId = beginNewsRefreshOperation()
@@ -75,9 +71,7 @@ extension NewsNotificationsFeatureViewModel {
         finishNewsRefreshOperation(operationId, context: context)
     }
 
-    func refreshNotifications(
-        failureFeedbackOwnership: NotificationMutationEditorOwnership? = nil
-    ) async {
+    func refreshNotifications(failureFeedbackOwnership: NotificationMutationEditorOwnership? = nil) async {
         guard let context = captureAuthorizedSessionContext() else { return }
 
         let operationId = beginNotificationsRefreshOperation()
@@ -247,10 +241,7 @@ extension NewsNotificationsFeatureViewModel {
 }
 
 private extension NewsNotificationsFeatureViewModel {
-    func storedContextMatches(
-        _ session: AuthorizedSession,
-        environment: SessionEnvironment
-    ) -> Bool {
+    func storedContextMatches(_ session: AuthorizedSession, environment: SessionEnvironment) -> Bool {
         guard let currentSession,
               let currentMember,
               let currentEnvironment else {
@@ -359,17 +350,11 @@ private extension NewsNotificationsFeatureViewModel {
         return nextNotificationsRefreshOperationId
     }
 
-    func isCurrentNotificationsRefresh(
-        _ operationId: UInt64,
-        context: SessionContext
-    ) -> Bool {
+    func isCurrentNotificationsRefresh(_ operationId: UInt64, context: SessionContext) -> Bool {
         activeNotificationsRefreshOperationId == operationId && isCurrentSession(context)
     }
 
-    func finishNotificationsRefreshOperation(
-        _ operationId: UInt64,
-        context: SessionContext
-    ) {
+    func finishNotificationsRefreshOperation(_ operationId: UInt64, context: SessionContext) {
         guard isCurrentNotificationsRefresh(operationId, context: context) else { return }
         activeNotificationsRefreshOperationId = nil
         isLoadingNotifications = false
@@ -381,25 +366,16 @@ private extension NewsNotificationsFeatureViewModel {
         return nextNotificationsRouteOperationId
     }
 
-    func isCurrentNotificationsRoute(
-        _ operationId: UInt64,
-        context: SessionContext
-    ) -> Bool {
+    func isCurrentNotificationsRoute(_ operationId: UInt64, context: SessionContext) -> Bool {
         activeNotificationsRouteOperationId == operationId && isCurrentSession(context)
     }
 
-    func finishNotificationsRouteOperation(
-        _ operationId: UInt64,
-        context: SessionContext
-    ) {
+    func finishNotificationsRouteOperation(_ operationId: UInt64, context: SessionContext) {
         guard isCurrentNotificationsRoute(operationId, context: context) else { return }
         activeNotificationsRouteOperationId = nil
     }
 
-    func refreshPushNotificationPermission(
-        showDialogIfInactive: Bool,
-        context: SessionContext
-    ) async {
+    func refreshPushNotificationPermission(showDialogIfInactive: Bool, context: SessionContext) async {
         nextPermissionRefreshOperationId &+= 1
         let operationId = nextPermissionRefreshOperationId
         activePermissionRefreshOperationId = operationId

--- a/ios/Reguerta/Reguerta/Presentation/News/NewsNotificationsFeatureViewModel+MutationLifecycle.swift
+++ b/ios/Reguerta/Reguerta/Presentation/News/NewsNotificationsFeatureViewModel+MutationLifecycle.swift
@@ -77,10 +77,7 @@ extension NewsNotificationsFeatureViewModel {
         )
     }
 
-    func notificationEventForSend(
-        draft: NotificationDraft,
-        context: SessionContext
-    ) -> NotificationEvent {
+    func notificationEventForSend(draft: NotificationDraft, context: SessionContext) -> NotificationEvent {
         NotificationEvent(
             id: "",
             title: draft.title,
@@ -125,17 +122,11 @@ extension NewsNotificationsFeatureViewModel {
         return nextNotificationMutationOperationId
     }
 
-    func isCurrentNotificationMutation(
-        _ operationId: UInt64,
-        context: SessionContext
-    ) -> Bool {
+    func isCurrentNotificationMutation(_ operationId: UInt64, context: SessionContext) -> Bool {
         activeNotificationMutationOperationId == operationId && isCurrentSession(context)
     }
 
-    func finishNotificationMutationOperation(
-        _ operationId: UInt64,
-        context: SessionContext
-    ) {
+    func finishNotificationMutationOperation(_ operationId: UInt64, context: SessionContext) {
         guard activeNotificationMutationOperationId == operationId else { return }
         activeNotificationMutationOperationId = nil
         guard isCurrentSession(context) else { return }
@@ -191,17 +182,13 @@ extension NewsNotificationsFeatureViewModel {
         return ownsEditor
     }
 
-    func scheduleNewsConvergence(
-        feedbackOwnership: NewsConvergenceFeedbackOwnership
-    ) {
+    func scheduleNewsConvergence(feedbackOwnership: NewsConvergenceFeedbackOwnership) {
         Task { [weak self] in
             await self?.refreshNews(failureFeedbackOwnership: feedbackOwnership)
         }
     }
 
-    func scheduleNotificationsConvergence(
-        feedbackOwnership: NotificationMutationEditorOwnership
-    ) {
+    func scheduleNotificationsConvergence(feedbackOwnership: NotificationMutationEditorOwnership) {
         Task { [weak self] in
             await self?.refreshNotifications(failureFeedbackOwnership: feedbackOwnership)
         }
@@ -226,9 +213,7 @@ extension NewsNotificationsFeatureViewModel {
         )
     }
 
-    func isCurrentNotificationMutationEditor(
-        _ ownership: NotificationMutationEditorOwnership
-    ) -> Bool {
+    func isCurrentNotificationMutationEditor(_ ownership: NotificationMutationEditorOwnership) -> Bool {
         captureNotificationMutationEditorOwnership() == ownership
     }
 
@@ -237,9 +222,7 @@ extension NewsNotificationsFeatureViewModel {
             pendingNewsDeletionId == ownership.newsID
     }
 
-    func canPublishNewsConvergenceFeedback(
-        for ownership: NewsConvergenceFeedbackOwnership
-    ) -> Bool {
+    func canPublishNewsConvergenceFeedback(for ownership: NewsConvergenceFeedbackOwnership) -> Bool {
         switch ownership {
         case .editor(let editorOwnership):
             isCurrentNewsMutationEditor(editorOwnership)

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteBadges.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteBadges.swift
@@ -1,11 +1,7 @@
 import SwiftUI
 
 extension MyOrderRouteView {
-    @ViewBuilder
-    func badge(
-        _ title: LocalizedStringKey,
-        usesCompactFont: Bool = false
-    ) -> some View {
+    @ViewBuilder func badge(_ title: LocalizedStringKey, usesCompactFont: Bool = false) -> some View {
         Text(title)
             .font(
                 usesCompactFont

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteOverlays.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteOverlays.swift
@@ -134,8 +134,7 @@ extension MyOrderRouteView {
         }
     }
 
-    @ViewBuilder
-    func selectedProductCard(_ product: Product) -> some View {
+    @ViewBuilder func selectedProductCard(_ product: Product) -> some View {
         let quantity = viewModel.quantity(for: product)
         let selectedOption = viewModel.selectedEcoBasketOption(for: product)
 
@@ -187,8 +186,7 @@ extension MyOrderRouteView {
         }
     }
 
-    @ViewBuilder
-    func checkoutDialog(_ alert: MyOrderCheckoutAlert) -> some View {
+    @ViewBuilder func checkoutDialog(_ alert: MyOrderCheckoutAlert) -> some View {
         switch alert {
         case .missingCommitments(let names):
             checkoutErrorDialog(

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteSections.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+MyOrderRouteSections.swift
@@ -229,8 +229,7 @@ extension MyOrderRouteView {
         .ignoresSafeArea(.container, edges: .bottom)
     }
 
-    @ViewBuilder
-    func producerHeader(_ group: MyOrderProducerGroup) -> some View {
+    @ViewBuilder func producerHeader(_ group: MyOrderProducerGroup) -> some View {
         HStack(spacing: tokens.spacing.sm) {
             Spacer(minLength: 0)
             Text(group.companyName)
@@ -256,8 +255,7 @@ extension MyOrderRouteView {
         }
     }
 
-    @ViewBuilder
-    func productCard(_ product: Product) -> some View {
+    @ViewBuilder func productCard(_ product: Product) -> some View {
         let quantity = viewModel.quantity(for: product)
         let stockLabel = stockLabel(for: product)
 
@@ -316,8 +314,7 @@ extension MyOrderRouteView {
         }
     }
 
-    @ViewBuilder
-    func productImage(_ product: Product) -> some View {
+    @ViewBuilder func productImage(_ product: Product) -> some View {
         let imageSize = CGFloat(72.resize)
         if let imageURL = product.productImageUrl, let url = URL(string: imageURL), imageURL.isNotEmpty {
             AsyncImage(url: url) { phase in
@@ -341,12 +338,7 @@ extension MyOrderRouteView {
         }
     }
 
-    @ViewBuilder
-    func quantityControls(
-        product: Product,
-        quantity: Int,
-        isEditable: Bool
-    ) -> some View {
+    @ViewBuilder func quantityControls(product: Product, quantity: Int, isEditable: Bool) -> some View {
         if !isEditable {
             readOnlyQuantityControls(product: product, quantity: quantity)
         } else if quantity == 0 {
@@ -356,8 +348,7 @@ extension MyOrderRouteView {
         }
     }
 
-    @ViewBuilder
-    func readOnlyQuantityControls(product: Product, quantity: Int) -> some View {
+    @ViewBuilder func readOnlyQuantityControls(product: Product, quantity: Int) -> some View {
         if quantity > 0 {
             Text(quantityUnitText(product: product, quantity: quantity))
                 .font(tokens.typography.body.weight(.semibold))

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+ReceivedOrdersHistoryRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+ReceivedOrdersHistoryRoute.swift
@@ -164,8 +164,7 @@ struct ReceivedOrdersHistoryRouteView: View {
         }
     }
 
-    @ViewBuilder
-    private func infoCard(title: String, body: String) -> some View {
+    @ViewBuilder private func infoCard(title: String, body: String) -> some View {
         reguertaCard {
             VStack(alignment: .leading, spacing: tokens.spacing.sm) {
                 Text(title)

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+ReceivedOrdersParsing.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+ReceivedOrdersParsing.swift
@@ -32,10 +32,7 @@ extension ProducerOrderStatus {
     }
 }
 
-func receivedOrderLineRecord(
-    from data: [String: Any],
-    fallbackDocumentID: String
-) -> ReceivedOrderLineRecord? {
+func receivedOrderLineRecord(from data: [String: Any], fallbackDocumentID: String) -> ReceivedOrderLineRecord? {
     let orderId = receivedOrderString(from: data["orderId"]) ?? fallbackDocumentID
     let consumerId = receivedOrderString(from: data["userId"]) ?? "__consumer_unknown__"
     let consumerDisplayName = receivedOrderString(from: data["consumerDisplayName"]) ?? consumerId

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+ReceivedOrdersRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+ReceivedOrdersRoute.swift
@@ -137,8 +137,7 @@ private extension ReceivedOrdersRouteView {
         .overlay(shape.stroke(tokens.colors.actionPrimary.opacity(0.28), lineWidth: 1.resize))
     }
 
-    @ViewBuilder
-    func loadedContent(_ snapshot: ReceivedOrdersSnapshot) -> some View {
+    @ViewBuilder func loadedContent(_ snapshot: ReceivedOrdersSnapshot) -> some View {
         ReceivedOrdersSummaryContent(
             tokens: tokens,
             snapshot: snapshot,
@@ -200,8 +199,7 @@ private extension ReceivedOrdersRouteView {
         .custom("CabinSketch-Bold", size: 22.resize, relativeTo: .headline)
     }
 
-    @ViewBuilder
-    func productCard(_ row: ReceivedOrdersProductRow) -> some View {
+    @ViewBuilder func productCard(_ row: ReceivedOrdersProductRow) -> some View {
         reguertaListItemCard {
             HStack(alignment: .center, spacing: 0) {
                 receivedOrdersProductImage(urlString: row.productImageUrl)
@@ -277,8 +275,7 @@ private extension ReceivedOrdersRouteView {
         }
     }
 
-    @ViewBuilder
-    func memberLinesSection(_ group: ReceivedOrdersMemberGroup) -> some View {
+    @ViewBuilder func memberLinesSection(_ group: ReceivedOrdersMemberGroup) -> some View {
         VStack(alignment: .leading, spacing: tokens.spacing.sm) {
             ForEach(Array(group.lines.enumerated()), id: \.element.id) { _, line in
                 memberLineRow(line)
@@ -292,8 +289,7 @@ private extension ReceivedOrdersRouteView {
         }
     }
 
-    @ViewBuilder
-    func memberLineRow(_ line: ReceivedOrdersMemberLine) -> some View {
+    @ViewBuilder func memberLineRow(_ line: ReceivedOrdersMemberLine) -> some View {
         HStack(alignment: .center, spacing: tokens.spacing.sm) {
             VStack(alignment: .leading, spacing: 4.resize) {
                 Text(line.productName)
@@ -377,8 +373,7 @@ private extension ReceivedOrdersRouteView {
             .frame(width: 1.resize, height: height)
     }
 
-    @ViewBuilder
-    func totalBar(total: Double) -> some View {
+    @ViewBuilder func totalBar(total: Double) -> some View {
         let shape = RoundedRectangle(cornerRadius: 8.resize, style: .continuous)
 
         HStack {
@@ -400,8 +395,7 @@ private extension ReceivedOrdersRouteView {
         .allowsHitTesting(false)
     }
 
-    @ViewBuilder
-    func infoCard(title: String, body: String) -> some View {
+    @ViewBuilder func infoCard(title: String, body: String) -> some View {
         reguertaCard {
             VStack(alignment: .leading, spacing: tokens.spacing.sm) {
                 Text(title)
@@ -414,8 +408,7 @@ private extension ReceivedOrdersRouteView {
         }
     }
 
-    @ViewBuilder
-    func receivedOrdersProductImage(urlString: String?) -> some View {
+    @ViewBuilder func receivedOrdersProductImage(urlString: String?) -> some View {
         let imageSize = CGFloat(64.resize)
         if let urlString, let url = URL(string: urlString), urlString.isNotEmpty {
             AsyncImage(url: url) { phase in

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+ReceivedOrdersSummaryContent.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ContentView+ReceivedOrdersSummaryContent.swift
@@ -90,8 +90,7 @@ extension ReceivedOrdersSummaryContent {
         .custom("CabinSketch-Bold", size: 22.resize, relativeTo: .headline)
     }
 
-    @ViewBuilder
-    func productCard(_ row: ReceivedOrdersProductRow) -> some View {
+    @ViewBuilder func productCard(_ row: ReceivedOrdersProductRow) -> some View {
         reguertaListItemCard {
             HStack(alignment: .center, spacing: 0) {
                 receivedOrdersProductImage(urlString: row.productImageUrl)
@@ -171,8 +170,7 @@ extension ReceivedOrdersSummaryContent {
         }
     }
 
-    @ViewBuilder
-    func memberLinesSection(_ group: ReceivedOrdersMemberGroup) -> some View {
+    @ViewBuilder func memberLinesSection(_ group: ReceivedOrdersMemberGroup) -> some View {
         VStack(alignment: .leading, spacing: tokens.spacing.sm) {
             ForEach(Array(group.lines.enumerated()), id: \.element.id) { _, line in
                 memberLineRow(line)
@@ -191,8 +189,7 @@ extension ReceivedOrdersSummaryContent {
         }
     }
 
-    @ViewBuilder
-    func memberLineRow(_ line: ReceivedOrdersMemberLine) -> some View {
+    @ViewBuilder func memberLineRow(_ line: ReceivedOrdersMemberLine) -> some View {
         HStack(alignment: .center, spacing: tokens.spacing.sm) {
             VStack(alignment: .leading, spacing: 4.resize) {
                 Text(line.productName)
@@ -318,8 +315,7 @@ extension ReceivedOrdersSummaryContent {
             .frame(width: 1.resize, height: height)
     }
 
-    @ViewBuilder
-    func totalBar(total: Double) -> some View {
+    @ViewBuilder func totalBar(total: Double) -> some View {
         let shape = RoundedRectangle(cornerRadius: 8.resize, style: .continuous)
 
         HStack {
@@ -346,8 +342,7 @@ extension ReceivedOrdersSummaryContent {
         .allowsHitTesting(false)
     }
 
-    @ViewBuilder
-    func receivedOrdersProductImage(urlString: String?) -> some View {
+    @ViewBuilder func receivedOrdersProductImage(urlString: String?) -> some View {
         let imageSize = CGFloat(64.resize)
         if let urlString, let url = URL(string: urlString), urlString.isNotEmpty {
             AsyncImage(url: url) { phase in

--- a/ios/Reguerta/Reguerta/Presentation/Orders/MyOrderProducerParity.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/MyOrderProducerParity.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-func currentISOWeekProducerParity(
-    nowMillis: Int64 = Int64(Date().timeIntervalSince1970 * 1_000)
-) -> ProducerParity {
+func currentISOWeekProducerParity(nowMillis: Int64 = Int64(Date().timeIntervalSince1970 * 1_000)) -> ProducerParity {
     producerParityForISOWeek(nowMillis: nowMillis)
 }
 
@@ -15,10 +13,7 @@ func producerParityForISOWeek(nowMillis: Int64) -> ProducerParity {
 }
 
 extension Product {
-    func matchesCurrentProducerWeek(
-        membersById: [String: Member],
-        currentWeekParity: ProducerParity
-    ) -> Bool {
+    func matchesCurrentProducerWeek(membersById: [String: Member], currentWeekParity: ProducerParity) -> Bool {
         guard let producerParity = membersById[vendorId]?.producerParity else {
             return true
         }

--- a/ios/Reguerta/Reguerta/Presentation/Orders/MyOrdersHistoryRouteViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/MyOrdersHistoryRouteViewModel.swift
@@ -39,10 +39,7 @@ final class MyOrdersHistoryRouteViewModel {
     private var loadedHistoryIdentity: String?
     private var loadedWeekKey: String?
 
-    init(
-        sessionViewModel: SessionViewModel,
-        ordersRepository: any OrdersRepository
-    ) {
+    init(sessionViewModel: SessionViewModel, ordersRepository: any OrdersRepository) {
         self.sessionViewModel = sessionViewModel
         self.ordersRepository = ordersRepository
     }

--- a/ios/Reguerta/Reguerta/Presentation/Orders/ReceivedOrdersHistoryRouteViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/ReceivedOrdersHistoryRouteViewModel.swift
@@ -41,10 +41,7 @@ final class ReceivedOrdersHistoryRouteViewModel {
     private var loadedHistoryIdentity: String?
     private var loadedWeekKey: String?
 
-    init(
-        sessionViewModel: SessionViewModel,
-        ordersRepository: any OrdersRepository
-    ) {
+    init(sessionViewModel: SessionViewModel, ordersRepository: any OrdersRepository) {
         self.sessionViewModel = sessionViewModel
         self.ordersRepository = ordersRepository
     }

--- a/ios/Reguerta/Reguerta/Presentation/Products/ProductsRouteViewModel+Actions.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Products/ProductsRouteViewModel+Actions.swift
@@ -71,7 +71,9 @@ extension ProductsRouteViewModel {
         isUploadingImage = false
     }
 
-    func updateDraft(_ update: (inout ProductDraft) -> Void) {
+    func updateDraft(
+        _ update: (inout ProductDraft) -> Void
+    ) {
         var updatedDraft = draft
         update(&updatedDraft)
         draft = updatedDraft
@@ -144,8 +146,7 @@ extension ProductsRouteViewModel {
         }
     }
 
-    @discardableResult
-    func save() async -> Bool {
+    @discardableResult func save() async -> Bool {
         guard let request = prepareSaveRequest() else { return false }
         let saveOperationId = beginSaveOperation()
         defer { finishSaveOperation(saveOperationId, context: request.context) }
@@ -385,20 +386,14 @@ private extension ProductsRouteViewModel {
         return nextSaveOperationId
     }
 
-    func finishSaveOperation(
-        _ operationId: UInt64,
-        context: ProductsRouteSessionContext
-    ) {
+    func finishSaveOperation(_ operationId: UInt64, context: ProductsRouteSessionContext) {
         guard activeSaveOperationId == operationId else { return }
         activeSaveOperationId = nil
         guard isCurrentSession(context) else { return }
         isSaving = false
     }
 
-    func finishUploadOperation(
-        _ operationId: UInt64,
-        context: ProductsRouteSessionContext
-    ) {
+    func finishUploadOperation(_ operationId: UInt64, context: ProductsRouteSessionContext) {
         guard activeUploadOperationId == operationId else { return }
         activeUploadOperationId = nil
         guard isCurrentSession(context) else { return }

--- a/ios/Reguerta/Reguerta/Presentation/Products/ProductsRouteViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Products/ProductsRouteViewModel.swift
@@ -318,10 +318,7 @@ private extension ProductsRouteViewModel {
         appliedFreshnessSessionRevision = nil
     }
 
-    private func isCurrentOrderingRefresh(
-        _ context: ProductsRouteSessionContext,
-        generation: UInt64
-    ) -> Bool {
+    private func isCurrentOrderingRefresh(_ context: ProductsRouteSessionContext, generation: UInt64) -> Bool {
         generation == orderingRefreshGeneration && isCurrentSession(context)
     }
 
@@ -382,10 +379,7 @@ private extension ProductsRouteViewModel {
         isLoadingOrderingProducts = false
     }
 
-    private func mergeOrderingMembers(
-        _ members: [Member],
-        payload: CriticalDataRefreshPayload
-    ) -> [Member] {
+    private func mergeOrderingMembers(_ members: [Member], payload: CriticalDataRefreshPayload) -> [Member] {
         var merged = members
         if let authenticatedMember = payload.authenticatedMember {
             merged = merged.filter { $0.id != authenticatedMember.id } + [authenticatedMember]
@@ -396,10 +390,7 @@ private extension ProductsRouteViewModel {
         return merged
     }
 
-    private func applyRefreshedIdentityPayload(
-        _ payload: CriticalDataRefreshPayload,
-        to session: AuthorizedSession
-    ) {
+    private func applyRefreshedIdentityPayload(_ payload: CriticalDataRefreshPayload, to session: AuthorizedSession) {
         if let authenticatedMember = payload.authenticatedMember,
            session.authenticatedMember.canManageMembers,
            !authenticatedMember.canManageMembers {

--- a/ios/Reguerta/Reguerta/Presentation/Root/AccessRootViewModel+StartupGate.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Root/AccessRootViewModel+StartupGate.swift
@@ -112,8 +112,7 @@ private extension AccessRootViewModel {
         }
     }
 
-    @discardableResult
-    func invalidateStartupGateEvaluation() -> Task<Void, Never>? {
+    @discardableResult func invalidateStartupGateEvaluation() -> Task<Void, Never>? {
         let invalidatedOperation = startupGateOperationTask
         invalidatedOperation?.cancel()
         startupGateTimeoutTask?.cancel()
@@ -127,10 +126,7 @@ private extension AccessRootViewModel {
         !Task.isCancelled && generation == startupGateGeneration
     }
 
-    func publishStartupGateDecision(
-        _ decision: StartupVersionGateDecision,
-        generation: UInt64
-    ) {
+    func publishStartupGateDecision(_ decision: StartupVersionGateDecision, generation: UInt64) {
         guard generation == startupGateGeneration else { return }
         startupGateTimeoutTask?.cancel()
         startupGateTimeoutTask = nil
@@ -146,10 +142,7 @@ private extension AccessRootViewModel {
         continueFromSplashIfAllowed()
     }
 
-    func publishStartupGateFailure(
-        _ state: StartupGateUIState,
-        generation: UInt64
-    ) {
+    func publishStartupGateFailure(_ state: StartupGateUIState, generation: UInt64) {
         guard generation == startupGateGeneration else { return }
         startupGateTimeoutTask?.cancel()
         startupGateTimeoutTask = nil

--- a/ios/Reguerta/Reguerta/Presentation/Root/ReguertaImagePickerField.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Root/ReguertaImagePickerField.swift
@@ -299,7 +299,9 @@ private struct ReguertaCameraCaptureView: UIViewControllerRepresentable {
     final class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
         private let onCapture: (UIImage?) -> Void
 
-        init(onCapture: @escaping (UIImage?) -> Void) {
+        init(
+            onCapture: @escaping (UIImage?) -> Void
+        ) {
             self.onCapture = onCapture
         }
 

--- a/ios/Reguerta/Reguerta/Presentation/Root/SessionViewModelDependencies.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Root/SessionViewModelDependencies.swift
@@ -136,10 +136,7 @@ final class NoOpCriticalDataFreshnessLocalRepository: CriticalDataFreshnessLocal
 
     func getMetadata() -> CriticalDataFreshnessMetadata? { nil }
 
-    func saveMetadata(
-        _: CriticalDataFreshnessMetadata,
-        ifWriteGeneration _: UInt64
-    ) -> Bool { true }
+    func saveMetadata(_: CriticalDataFreshnessMetadata, ifWriteGeneration _: UInt64) -> Bool { true }
 
     func clear() throws {
         writeGeneration &+= 1

--- a/ios/Reguerta/Reguerta/Presentation/SharedProfile/ContentView+SharedProfileRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/SharedProfile/ContentView+SharedProfileRoute.swift
@@ -343,8 +343,7 @@ private extension SharedProfileHubRoute {
         .clipShape(RoundedRectangle(cornerRadius: tokens.radius.sm))
     }
 
-    @ViewBuilder
-    func sharedProfileDetailContent(_ profile: SharedProfile) -> some View {
+    @ViewBuilder func sharedProfileDetailContent(_ profile: SharedProfile) -> some View {
         let orientation = profilePhotoOrientations[profile.userId] ?? .landscape
         let hasPhoto = profile.photoUrl?.isEmpty == false
 
@@ -367,8 +366,7 @@ private extension SharedProfileHubRoute {
         }
     }
 
-    @ViewBuilder
-    func sharedProfileDetailPhoto(_ profile: SharedProfile) -> some View {
+    @ViewBuilder func sharedProfileDetailPhoto(_ profile: SharedProfile) -> some View {
         if let rawURL = profile.photoUrl, let url = URL(string: rawURL), !rawURL.isEmpty {
             AsyncImage(url: url) { phase in
                 switch phase {

--- a/ios/Reguerta/Reguerta/Presentation/SharedProfile/SharedProfileFeatureViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/SharedProfile/SharedProfileFeatureViewModel.swift
@@ -259,11 +259,7 @@ extension SharedProfileFeatureViewModel {
 }
 
 private extension SharedProfileFeatureViewModel {
-    private func applyProfiles(
-        _ fetchedProfiles: [SharedProfile],
-        currentMemberId: String,
-        updatesDraft: Bool
-    ) {
+    private func applyProfiles(_ fetchedProfiles: [SharedProfile], currentMemberId: String, updatesDraft: Bool) {
         profiles = fetchedProfiles.filter(\.hasVisibleContent)
         guard updatesDraft else { return }
         draft = fetchedProfiles.first { $0.userId == currentMemberId }?.toDraft() ?? SharedProfileDraft()
@@ -351,11 +347,7 @@ private extension SharedProfileFeatureViewModel {
         return nextUploadOperationId
     }
 
-    private func isCurrentUpload(
-        _ operationId: UInt64,
-        context: SessionContext,
-        revision: UInt64
-    ) -> Bool {
+    private func isCurrentUpload(_ operationId: UInt64, context: SessionContext, revision: UInt64) -> Bool {
         activeUploadOperationId == operationId && isCurrentEditor(context, revision: revision)
     }
 

--- a/ios/Reguerta/Reguerta/Presentation/Shifts/ShiftsFeatureSupport.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Shifts/ShiftsFeatureSupport.swift
@@ -89,11 +89,7 @@ struct ConfirmShiftSwapContext {
 }
 
 extension Array where Element == ShiftAssignment {
-    func nextAssignedShift(
-        memberId: String,
-        type: ShiftType,
-        nowMillis: Int64
-    ) -> ShiftAssignment? {
+    func nextAssignedShift(memberId: String, type: ShiftType, nowMillis: Int64) -> ShiftAssignment? {
         self
             .filter { $0.type == type && $0.dateMillis >= nowMillis && $0.isAssigned(to: memberId) }
             .min { $0.dateMillis < $1.dateMillis }
@@ -108,7 +104,10 @@ extension Array where Element == ShiftSwapRequest {
             .sorted { $0.requestedAtMillis > $1.requestedAtMillis }
     }
 
-    func visibleShiftSwapActivity(currentMemberId: String?, dismissedRequestIds: Set<String>) -> VisibleShiftSwapActivity {
+    func visibleShiftSwapActivity(
+        currentMemberId: String?,
+        dismissedRequestIds: Set<String>
+    ) -> VisibleShiftSwapActivity {
         guard let currentMemberId else {
             return VisibleShiftSwapActivity(
                 incoming: [],
@@ -159,7 +158,11 @@ extension Array where Element == ShiftSwapRequest {
 }
 
 extension ShiftAssignment {
-    func swapCandidates(allShifts: [ShiftAssignment], requesterUserId: String, nowMillis: Int64) -> [ShiftSwapCandidate] {
+    func swapCandidates(
+        allShifts: [ShiftAssignment],
+        requesterUserId: String,
+        nowMillis: Int64
+    ) -> [ShiftSwapCandidate] {
         let calendar = Calendar(identifier: .iso8601)
         let thresholdDate: Date
         if type == .delivery {

--- a/ios/Reguerta/Reguerta/Presentation/Shifts/ShiftsFeatureViewModel+Loading.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Shifts/ShiftsFeatureViewModel+Loading.swift
@@ -140,9 +140,7 @@ extension ShiftsFeatureViewModel {
         await refreshDeliveryCalendar()
     }
 
-    private func deliveryCalendarMutation(
-        for context: SessionContext
-    ) -> DeliveryCalendarMutation? {
+    private func deliveryCalendarMutation(for context: SessionContext) -> DeliveryCalendarMutation? {
         guard let weekKey = selectedDeliveryCalendarWeekKey else { return nil }
         if selectedDeliveryCalendarOverride != nil,
            selectedDeliveryCalendarWeekday == defaultDeliveryDayOfWeek {

--- a/ios/Reguerta/Reguerta/Presentation/Shifts/ShiftsFeatureViewModel+SwapActions.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Shifts/ShiftsFeatureViewModel+SwapActions.swift
@@ -1,7 +1,9 @@
 import Foundation
 
 extension ShiftsFeatureViewModel {
-    func updateShiftSwapDraft(_ update: (inout ShiftSwapDraft) -> Void) {
+    func updateShiftSwapDraft(
+        _ update: (inout ShiftSwapDraft) -> Void
+    ) {
         var draft = shiftSwapDraft
         update(&draft)
         shiftSwapDraft = draft
@@ -135,9 +137,7 @@ extension ShiftsFeatureViewModel {
 }
 
 private extension ShiftsFeatureViewModel {
-    func shiftSwapCreateSubmission(
-        for context: SessionContext
-    ) -> ShiftSwapCreateSubmission? {
+    func shiftSwapCreateSubmission(for context: SessionContext) -> ShiftSwapCreateSubmission? {
         let draft = shiftSwapDraft
         guard !draft.shiftId.isEmpty,
               let shift = shiftsFeed.first(where: { $0.id == draft.shiftId }),
@@ -251,10 +251,7 @@ private extension ShiftsFeatureViewModel {
         )
     }
 
-    func confirmShiftSwapContext(
-        requestId: String,
-        candidateShiftId: String
-    ) -> ConfirmShiftSwapContext? {
+    func confirmShiftSwapContext(requestId: String, candidateShiftId: String) -> ConfirmShiftSwapContext? {
         guard let session = authorizedSession else { return nil }
         guard let request = shiftSwapRequests.first(where: { $0.id == requestId }) else { return nil }
         guard let requestedShift = shiftsFeed.first(where: { $0.id == request.requestedShiftId }) else { return nil }

--- a/ios/Reguerta/Reguerta/Presentation/Users/ContentView+UsersRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Users/ContentView+UsersRoute.swift
@@ -100,8 +100,7 @@ struct UsersRouteView: View {
         }
     }
 
-    @ViewBuilder
-    private func userCardTextRows(_ member: Member) -> some View {
+    @ViewBuilder private func userCardTextRows(_ member: Member) -> some View {
         Text(member.displayName)
             .font(.custom("CabinSketch-Bold", size: 18.resize, relativeTo: .body))
             .foregroundStyle(tokens.colors.textPrimary)

--- a/ios/Reguerta/Reguerta/Presentation/Users/UsersFeatureSupport.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Users/UsersFeatureSupport.swift
@@ -50,10 +50,7 @@ extension MemberDraft {
         }
     }
 
-    mutating func setCommonPurchaseManagerSelection(
-        _ isSelected: Bool,
-        commonPurchasesCompanyName: String
-    ) {
+    mutating func setCommonPurchaseManagerSelection(_ isSelected: Bool, commonPurchasesCompanyName: String) {
         isCommonPurchaseManager = isSelected
         if isSelected {
             isProducer = true

--- a/ios/Reguerta/Reguerta/Presentation/Users/UsersFeatureViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Users/UsersFeatureViewModel.swift
@@ -266,11 +266,7 @@ private extension UsersFeatureViewModel {
         }
     }
 
-    func buildTargetMember(
-        editingMemberId: String?,
-        normalizedEmail: String,
-        roles: Set<MemberRole>
-    ) -> Member? {
+    func buildTargetMember(editingMemberId: String?, normalizedEmail: String, roles: Set<MemberRole>) -> Member? {
         if let editingMemberId {
             guard let existing = membersFeed.first(where: { $0.id == editingMemberId }) else {
                 return nil
@@ -306,11 +302,7 @@ private extension UsersFeatureViewModel {
         )
     }
 
-    func persistMember(
-        target: Member,
-        session: AuthorizedSession,
-        kind: MemberMutationKind
-    ) async -> Bool {
+    func persistMember(target: Member, session: AuthorizedSession, kind: MemberMutationKind) async -> Bool {
         let context = SessionContext(session: session, generation: sessionIdentityEpoch)
         guard isCurrentSession(context), activeMutationOperationId == nil else { return false }
         do {

--- a/ios/Reguerta/ReguertaTests/BylawsArticleRetrieverTests.swift
+++ b/ios/Reguerta/ReguertaTests/BylawsArticleRetrieverTests.swift
@@ -84,8 +84,7 @@ struct BylawsArticleRetrieverTests {
         )
     }
 
-    @Test("El recurso incluido respeta el schema v2")
-    func bundledIndexUsesSchemaV2() async throws {
+    @Test("El recurso incluido respeta el schema v2") func bundledIndexUsesSchemaV2() async throws {
         let index = try await BundledBylawsKnowledgeDataSource().loadIndex()
 
         #expect(index.schemaVersion == 2)
@@ -95,8 +94,7 @@ struct BylawsArticleRetrieverTests {
         #expect(index.articles.allSatisfy { !$0.searchAliases.isEmpty })
     }
 
-    @Test("Las quince preguntas canonicas pasan juntas")
-    func retrievesEveryCanonicalCase() async throws {
+    @Test("Las quince preguntas canonicas pasan juntas") func retrievesEveryCanonicalCase() async throws {
         let expectations: [(question: String, articles: [Int])] = [
             ("Condiciones que deben darse para poder modificar los estatutos.", [21]),
             ("¿Cómo se sustentará económicamente la asociación?", [18]),
@@ -146,8 +144,7 @@ struct BylawsArticleRetrieverTests {
         #expect(matches.isEmpty)
     }
 
-    @Test("Consultas no fundamentadas siguen sin evidencia")
-    func otherUnrelatedQuestionsHaveNoEvidence() async throws {
+    @Test("Consultas no fundamentadas siguen sin evidencia") func otherUnrelatedQuestionsHaveNoEvidence() async throws {
         let index = try await BundledBylawsKnowledgeDataSource().loadIndex()
         let retriever = SpanishBylawsArticleRetriever()
 
@@ -195,8 +192,7 @@ struct BylawsArticleRetrieverTests {
         )
     }
 
-    @Test("Un termino raro del cuerpo recupera su articulo")
-    func rareBodyTermRetrievesArticle() async throws {
+    @Test("Un termino raro del cuerpo recupera su articulo") func rareBodyTermRetrievesArticle() async throws {
         let index = try await BundledBylawsKnowledgeDataSource().loadIndex()
 
         let matches = SpanishBylawsArticleRetriever().retrieve(
@@ -208,8 +204,7 @@ struct BylawsArticleRetrieverTests {
         #expect(matches.first?.article.articleNumber == 3)
     }
 
-    @Test("Un articulo explicito recupera texto integro")
-    func explicitArticleRetrievesFullText() async throws {
+    @Test("Un articulo explicito recupera texto integro") func explicitArticleRetrievesFullText() async throws {
         let index = try await BundledBylawsKnowledgeDataSource().loadIndex()
 
         let match = try #require(

--- a/ios/Reguerta/ReguertaTests/BylawsFeatureViewModelConcurrencyTests.swift
+++ b/ios/Reguerta/ReguertaTests/BylawsFeatureViewModelConcurrencyTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct BylawsFeatureViewModelConcurrencyTests {
-    @Test("La ultima consulta reemplaza a una respuesta tardia")
-    func latestQuestionWins() async throws {
+    @Test("La ultima consulta reemplaza a una respuesta tardia") func latestQuestionWins() async throws {
         let consultant = ControlledBylawsConsultant()
         let viewModel = makeViewModel(consultant: consultant)
         await viewModel.prepare(responseLanguage: .spanish)
@@ -28,8 +27,7 @@ struct BylawsFeatureViewModelConcurrencyTests {
         #expect(viewModel.capability == .localModel)
     }
 
-    @Test("Limpiar cancela e invalida una respuesta tardia")
-    func clearInvalidatesInFlightAnswer() async {
+    @Test("Limpiar cancela e invalida una respuesta tardia") func clearInvalidatesInFlightAnswer() async {
         let consultant = ControlledBylawsConsultant()
         let viewModel = makeViewModel(consultant: consultant)
         await viewModel.prepare(responseLanguage: .spanish)
@@ -48,8 +46,7 @@ struct BylawsFeatureViewModelConcurrencyTests {
         #expect(viewModel.consultationMessageKey == nil)
     }
 
-    @Test("Salir de la ruta cancela e invalida una respuesta tardia")
-    func routeExitInvalidatesInFlightAnswer() async {
+    @Test("Salir de la ruta cancela e invalida una respuesta tardia") func routeExitInvalidatesInFlightAnswer() async {
         let consultant = ControlledBylawsConsultant()
         let viewModel = makeViewModel(consultant: consultant)
         await viewModel.prepare(responseLanguage: .spanish)
@@ -83,9 +80,7 @@ struct BylawsFeatureViewModelConcurrencyTests {
             )
         ]
     )
-    func contentFailureKeepsLocalConsultation(
-        expectation: BylawsFailurePresentationExpectation
-    ) async {
+    func contentFailureKeepsLocalConsultation(expectation: BylawsFailurePresentationExpectation) async {
         let consultant = ControlledBylawsConsultant()
         let viewModel = makeViewModel(consultant: consultant)
         await viewModel.prepare(responseLanguage: .spanish)
@@ -169,10 +164,7 @@ struct BylawsFeatureViewModelConcurrencyTests {
     }
 }
 
-@MainActor
-private func makeViewModel(
-    consultant: some BylawsConsulting
-) -> BylawsFeatureViewModel {
+@MainActor private func makeViewModel(consultant: some BylawsConsulting) -> BylawsFeatureViewModel {
     BylawsFeatureViewModel(
         feedbackCenter: GlobalFeedbackCenter(),
         consultant: consultant,
@@ -204,17 +196,12 @@ private actor ControlledBylawsConsultant: BylawsConsulting {
         self.configuredCapability = capability
     }
 
-    func capability(
-        for responseLanguage: BylawsResponseLanguage
-    ) -> BylawsConsultationCapability {
+    func capability(for responseLanguage: BylawsResponseLanguage) -> BylawsConsultationCapability {
         capabilityLanguages.append(responseLanguage)
         return configuredCapability
     }
 
-    func consult(
-        question: String,
-        responseLanguage: BylawsResponseLanguage
-    ) async throws -> BylawsConsultationResult {
+    func consult(question: String, responseLanguage: BylawsResponseLanguage) async throws -> BylawsConsultationResult {
         requests.append(question)
         consultationLanguages.append(responseLanguage)
         return try await withCheckedThrowingContinuation { continuation in
@@ -228,10 +215,7 @@ private actor ControlledBylawsConsultant: BylawsConsulting {
         }
     }
 
-    func completeRequest(
-        at index: Int,
-        with result: Result<BylawsConsultationResult, any Error>
-    ) {
+    func completeRequest(at index: Int, with result: Result<BylawsConsultationResult, any Error>) {
         continuations[index].resume(with: result)
     }
 }
@@ -246,8 +230,7 @@ struct BylawsFailurePresentationExpectation: Sendable, CustomTestStringConvertib
 private struct FixedConcurrencyTestBylawsDocumentProvider: BylawsDocumentProviding {
     let pdfURL: URL?
 
-    @MainActor
-    func bundledPdfURL() -> URL? {
+    @MainActor func bundledPdfURL() -> URL? {
         pdfURL
     }
 }

--- a/ios/Reguerta/ReguertaTests/BylawsRouteScrollModeTests.swift
+++ b/ios/Reguerta/ReguertaTests/BylawsRouteScrollModeTests.swift
@@ -4,8 +4,7 @@ import Testing
 @testable import Reguerta
 
 struct BylawsRouteScrollModeTests {
-    @Test("Sin respuesta se desplaza la pagina completa")
-    func noAnswerUsesFullPageScrolling() {
+    @Test("Sin respuesta se desplaza la pagina completa") func noAnswerUsesFullPageScrolling() {
         #expect(
             BylawsRouteScrollMode.resolve(
                 hasAnswer: false,
@@ -15,8 +14,7 @@ struct BylawsRouteScrollModeTests {
         )
     }
 
-    @Test("Con altura regular la respuesta posee el scroll")
-    func regularHeightUsesAnswerScrolling() {
+    @Test("Con altura regular la respuesta posee el scroll") func regularHeightUsesAnswerScrolling() {
         #expect(
             BylawsRouteScrollMode.resolve(
                 hasAnswer: true,
@@ -26,8 +24,7 @@ struct BylawsRouteScrollModeTests {
         )
     }
 
-    @Test("XX Large conserva el scroll exclusivo de la respuesta")
-    func xxLargeUsesAnswerScrolling() {
+    @Test("XX Large conserva el scroll exclusivo de la respuesta") func xxLargeUsesAnswerScrolling() {
         #expect(
             BylawsRouteScrollMode.resolve(
                 hasAnswer: true,
@@ -37,8 +34,7 @@ struct BylawsRouteScrollModeTests {
         )
     }
 
-    @Test("XXX Large desplaza la pagina completa")
-    func xxxLargeUsesFullPageScrolling() {
+    @Test("XXX Large desplaza la pagina completa") func xxxLargeUsesFullPageScrolling() {
         #expect(
             BylawsRouteScrollMode.resolve(
                 hasAnswer: true,
@@ -48,8 +44,7 @@ struct BylawsRouteScrollModeTests {
         )
     }
 
-    @Test("Los tamanos de accesibilidad desplazan la pagina completa")
-    func accessibilitySizeUsesFullPageScrolling() {
+    @Test("Los tamanos de accesibilidad desplazan la pagina completa") func accessibilitySizeUsesFullPageScrolling() {
         #expect(
             BylawsRouteScrollMode.resolve(
                 hasAnswer: true,
@@ -59,8 +54,7 @@ struct BylawsRouteScrollModeTests {
         )
     }
 
-    @Test("La altura compacta desplaza la pagina completa")
-    func compactHeightUsesFullPageScrolling() {
+    @Test("La altura compacta desplaza la pagina completa") func compactHeightUsesFullPageScrolling() {
         #expect(
             BylawsRouteScrollMode.resolve(
                 hasAnswer: true,
@@ -70,8 +64,7 @@ struct BylawsRouteScrollModeTests {
         )
     }
 
-    @Test("Una altura indeterminada desplaza la pagina completa")
-    func unspecifiedHeightUsesFullPageScrolling() {
+    @Test("Una altura indeterminada desplaza la pagina completa") func unspecifiedHeightUsesFullPageScrolling() {
         #expect(
             BylawsRouteScrollMode.resolve(
                 hasAnswer: true,

--- a/ios/Reguerta/ReguertaTests/ConsultBylawsUseCaseTests.swift
+++ b/ios/Reguerta/ReguertaTests/ConsultBylawsUseCaseTests.swift
@@ -4,8 +4,7 @@ import Testing
 @testable import Reguerta
 
 struct ConsultBylawsUseCaseTests {
-    @Test("No invoca el modelo cuando no esta disponible")
-    func unavailableModelStopsBeforeRetrieval() async {
+    @Test("No invoca el modelo cuando no esta disponible") func unavailableModelStopsBeforeRetrieval() async {
         let knowledge = RecordingBylawsKnowledgeProvider(index: .fixture)
         let generator = RecordingBylawsSummaryGenerator(capability: .pdfOnly)
         let useCase = ConsultBylawsUseCase(
@@ -58,8 +57,7 @@ struct ConsultBylawsUseCaseTests {
         #expect(request.evidence.first?.excerpt == BylawsKnowledgeIndex.fixture.articles[0].text)
     }
 
-    @Test("Una consulta claramente ajena no invoca el modelo")
-    func unrelatedQuestionStopsBeforeGeneration() async {
+    @Test("Una consulta claramente ajena no invoca el modelo") func unrelatedQuestionStopsBeforeGeneration() async {
         let generator = RecordingBylawsSummaryGenerator(capability: .localModel)
         let useCase = ConsultBylawsUseCase(
             knowledgeProvider: RecordingBylawsKnowledgeProvider(index: .fixture),
@@ -155,8 +153,7 @@ struct ConsultBylawsUseCaseTests {
         }
     }
 
-    @Test("El sentinel sin respaldo se presenta como evidencia insuficiente")
-    func noEvidenceSentinelIsMapped() async {
+    @Test("El sentinel sin respaldo se presenta como evidencia insuficiente") func noEvidenceSentinelIsMapped() async {
         let useCase = ConsultBylawsUseCase(
             knowledgeProvider: RecordingBylawsKnowledgeProvider(index: .fixture),
             retriever: SpanishBylawsArticleRetriever(),
@@ -220,8 +217,7 @@ struct ConsultBylawsUseCaseTests {
         }
     }
 
-    @Test("Propaga la cancelacion sin convertirla en respuesta")
-    func cancellationIsPropagated() async {
+    @Test("Propaga la cancelacion sin convertirla en respuesta") func cancellationIsPropagated() async {
         let generator = SuspendingBylawsSummaryGenerator()
         let useCase = ConsultBylawsUseCase(
             knowledgeProvider: RecordingBylawsKnowledgeProvider(index: .fixture),
@@ -267,11 +263,7 @@ private actor RecordingBylawsSummaryGenerator: BylawsSummaryGenerating {
 
     nonisolated let modelIdentifier = "test/local-model"
 
-    init(
-        capability: BylawsConsultationCapability,
-        summary: String = "Resumen de prueba",
-        error: (any Error)? = nil
-    ) {
+    init(capability: BylawsConsultationCapability, summary: String = "Resumen de prueba", error: (any Error)? = nil) {
         self.configuredCapability = capability
         self.configuredSummary = summary
         self.configuredError = error

--- a/ios/Reguerta/ReguertaTests/ControlledSessionAuthProvider.swift
+++ b/ios/Reguerta/ReguertaTests/ControlledSessionAuthProvider.swift
@@ -93,8 +93,7 @@ final class ControlledSessionAuthProvider: AuthSessionProvider {
         return result
     }
 
-    @discardableResult
-    func signOut() -> Bool {
+    @discardableResult func signOut() -> Bool {
         signOutCallCount += 1
         let succeeded = signOutResults.isEmpty ? true : signOutResults.removeFirst()
         if succeeded {

--- a/ios/Reguerta/ReguertaTests/CriticalDataFreshnessEnvironmentTests.swift
+++ b/ios/Reguerta/ReguertaTests/CriticalDataFreshnessEnvironmentTests.swift
@@ -6,8 +6,7 @@ import Testing
 @Suite(.timeLimit(.minutes(1)))
 @MainActor
 struct CriticalDataFreshnessEnvironmentTests {
-    @Test
-    func userDefaultsMetadataRoundTripsItsScope() {
+    @Test func userDefaultsMetadataRoundTripsItsScope() {
         let (suiteName, userDefaults) = isolatedUserDefaults(suffix: "roundtrip")
         defer { userDefaults.removePersistentDomain(forName: suiteName) }
         let repository = UserDefaultsCriticalDataFreshnessLocalRepository(userDefaults: userDefaults)
@@ -18,8 +17,7 @@ struct CriticalDataFreshnessEnvironmentTests {
         #expect(repository.getMetadata() == metadata)
     }
 
-    @Test
-    func userDefaultsRejectsLegacyAndInvalidEnvironmentMetadata() {
+    @Test func userDefaultsRejectsLegacyAndInvalidEnvironmentMetadata() {
         let (suiteName, userDefaults) = isolatedUserDefaults(suffix: "invalid-environment")
         defer { userDefaults.removePersistentDomain(forName: suiteName) }
         seedFreshnessValues(in: userDefaults)
@@ -32,8 +30,7 @@ struct CriticalDataFreshnessEnvironmentTests {
         #expect(repository.getMetadata() == nil)
     }
 
-    @Test
-    func userDefaultsClearRemovesAllFreshnessMetadata() throws {
+    @Test func userDefaultsClearRemovesAllFreshnessMetadata() throws {
         let (suiteName, userDefaults) = isolatedUserDefaults(suffix: "clear")
         defer { userDefaults.removePersistentDomain(forName: suiteName) }
         let repository = UserDefaultsCriticalDataFreshnessLocalRepository(userDefaults: userDefaults)
@@ -53,8 +50,7 @@ struct CriticalDataFreshnessEnvironmentTests {
         }
     }
 
-    @Test
-    func useCaseForwardsEnvironmentAndReturnsScopedMetadata() async throws {
+    @Test func useCaseForwardsEnvironmentAndReturnsScopedMetadata() async throws {
         let remoteRepository = RecordingFreshnessRemoteRepository(
             config: freshnessConfig(timestamp: 2_000)
         )
@@ -261,10 +257,7 @@ private typealias EnvironmentFreshnessTasks = (
     timeout: Task<Void, Never>
 )
 
-@MainActor
-private func ownedFreshnessTasks(
-    in viewModel: MyOrderFreshnessViewModel
-) -> EnvironmentFreshnessTasks? {
+@MainActor private func ownedFreshnessTasks(in viewModel: MyOrderFreshnessViewModel) -> EnvironmentFreshnessTasks? {
     guard let operation = viewModel.freshnessOperationTask,
           let timeout = viewModel.freshnessTimeoutTask else {
         Issue.record("Expected owned freshness tasks")
@@ -294,9 +287,7 @@ private actor RecordingFreshnessRemoteRepository: CriticalDataFreshnessRemoteRep
 private actor ControlledEnvironmentFreshnessRemoteRepository: CriticalDataFreshnessRemoteRepository {
     private var environments: [SessionEnvironment] = []
     private var continuations: [Int: CheckedContinuation<CriticalDataFreshnessConfig, Never>] = [:]
-    private var requestCountWaiters: [
-        (count: Int, continuation: CheckedContinuation<Void, Never>)
-    ] = []
+    private var requestCountWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
 
     func getConfig(environment: SessionEnvironment) async throws -> CriticalDataFreshnessConfig {
         let requestIndex = environments.count

--- a/ios/Reguerta/ReguertaTests/CriticalDataRefreshUseCaseTests.swift
+++ b/ios/Reguerta/ReguertaTests/CriticalDataRefreshUseCaseTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct CriticalDataRefreshUseCaseTests {
-    @Test
-    func timestampDeltaRefreshesOnlyChangedCollectionsBeforeReturningAcknowledgement() async throws {
+    @Test func timestampDeltaRefreshesOnlyChangedCollectionsBeforeReturningAcknowledgement() async throws {
         let originalTimestamps = criticalTimestamps(defaultValue: 1_000)
         var remoteTimestamps = originalTimestamps
         remoteTimestamps[.products] = 2_000
@@ -54,8 +53,7 @@ struct CriticalDataRefreshUseCaseTests {
         #expect(localRepository.getMetadata()?.acknowledgedTimestampsMillis == originalTimestamps)
     }
 
-    @Test
-    func expiredTTLRefreshesAllCriticalCollections() async throws {
+    @Test func expiredTTLRefreshesAllCriticalCollections() async throws {
         let timestamps = criticalTimestamps(defaultValue: 1_000)
         let scope = criticalRefreshScope()
         let refresher = RecordingCriticalDataRefresher()
@@ -82,8 +80,7 @@ struct CriticalDataRefreshUseCaseTests {
         #expect(await refresher.recordedCollections() == Set(CriticalCollection.allCases))
     }
 
-    @Test
-    func metadataFromAnotherMemberForcesFullRefresh() async throws {
+    @Test func metadataFromAnotherMemberForcesFullRefresh() async throws {
         let timestamps = criticalTimestamps(defaultValue: 1_000)
         let scope = criticalRefreshScope(memberID: "member-new")
         let refresher = RecordingCriticalDataRefresher()
@@ -110,8 +107,7 @@ struct CriticalDataRefreshUseCaseTests {
         #expect(await refresher.recordedCollections() == Set(CriticalCollection.allCases))
     }
 
-    @Test
-    func changedMemberVisibilityScopeForcesFullRefresh() async throws {
+    @Test func changedMemberVisibilityScopeForcesFullRefresh() async throws {
         let timestamps = criticalTimestamps(defaultValue: 1_000)
         let currentScope = criticalRefreshScope(canManageMembers: true)
         let refresher = RecordingCriticalDataRefresher()
@@ -138,8 +134,7 @@ struct CriticalDataRefreshUseCaseTests {
         #expect(await refresher.recordedCollections() == Set(CriticalCollection.allCases))
     }
 
-    @Test
-    func partialRefreshFailureReturnsNoAcknowledgement() async {
+    @Test func partialRefreshFailureReturnsNoAcknowledgement() async {
         let originalTimestamps = criticalTimestamps(defaultValue: 1_000)
         var remoteTimestamps = originalTimestamps
         remoteTimestamps[.orders] = 2_000
@@ -169,8 +164,7 @@ struct CriticalDataRefreshUseCaseTests {
         #expect(localRepository.getMetadata()?.acknowledgedTimestampsMillis == originalTimestamps)
     }
 
-    @Test
-    func currentTimestampsStillRefreshAncillaryOrderingDependencies() async throws {
+    @Test func currentTimestampsStillRefreshAncillaryOrderingDependencies() async throws {
         let timestamps = criticalTimestamps(defaultValue: 1_000)
         let scope = criticalRefreshScope()
         let selectedMember = member(id: scope.memberID, ecoCommitmentMode: .weekly)
@@ -214,10 +208,7 @@ private actor RecordingCriticalDataRefresher: CriticalDataRefreshing {
     private let payload: CriticalDataRefreshPayload
     private var collections: Set<CriticalCollection> = []
 
-    init(
-        fails: Bool = false,
-        payload: CriticalDataRefreshPayload = CriticalDataRefreshPayload()
-    ) {
+    init(fails: Bool = false, payload: CriticalDataRefreshPayload = CriticalDataRefreshPayload()) {
         self.fails = fails
         self.payload = payload
     }

--- a/ios/Reguerta/ReguertaTests/FCMTokenLoggingSecurityTests.swift
+++ b/ios/Reguerta/ReguertaTests/FCMTokenLoggingSecurityTests.swift
@@ -2,8 +2,7 @@ import Foundation
 import Testing
 
 struct FCMTokenLoggingSecurityTests {
-    @Test
-    func pushRegistrationDoesNotLogTokensOrPublicErrors() throws {
+    @Test func pushRegistrationDoesNotLogTokensOrPublicErrors() throws {
         let sources = try [appDelegateURL(), coordinatorURL()].map {
             try String(contentsOf: $0, encoding: .utf8)
         }

--- a/ios/Reguerta/ReguertaTests/FirebaseAuthSessionSecurityTests.swift
+++ b/ios/Reguerta/ReguertaTests/FirebaseAuthSessionSecurityTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct FirebaseAuthSessionSecurityTests {
-    @Test
-    func signUpKeepsSessionLockedWhenFirebaseSignOutFails() async {
+    @Test func signUpKeepsSessionLockedWhenFirebaseSignOutFails() async {
         let feedbackCenter = GlobalFeedbackCenter()
         let viewModel = SessionViewModel(
             repository: InMemoryMemberRepository(),
@@ -35,8 +34,7 @@ struct FirebaseAuthSessionSecurityTests {
         #expect(feedbackCenter.messageKey == AccessL10nKey.authInfoVerificationSent)
     }
 
-    @Test
-    func verificationResendKeepsSessionLockedWhenFirebaseSignOutFails() async {
+    @Test func verificationResendKeepsSessionLockedWhenFirebaseSignOutFails() async {
         let repository = InMemoryMemberRepository()
         let environmentRouter = FixedSessionEnvironmentRouter()
         let provider = TestAuthSessionProvider(
@@ -72,8 +70,7 @@ struct FirebaseAuthSessionSecurityTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.authInfoVerificationResent)
     }
 
-    @Test
-    func expiredSessionFailsClosedWhenFirebaseSignOutFails() async {
+    @Test func expiredSessionFailsClosedWhenFirebaseSignOutFails() async {
         let member = authenticatedMember()
         let viewModel = SessionViewModel(
             repository: InMemoryMemberRepository(items: [member]),
@@ -93,8 +90,7 @@ struct FirebaseAuthSessionSecurityTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.authErrorUnknown)
     }
 
-    @Test
-    func manualSignOutFailsClosedWhenFirebaseSignOutFails() {
+    @Test func manualSignOutFailsClosedWhenFirebaseSignOutFails() {
         let member = authenticatedMember()
         let viewModel = SessionViewModel(
             repository: InMemoryMemberRepository(items: [member]),
@@ -114,8 +110,7 @@ struct FirebaseAuthSessionSecurityTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.authErrorUnknown)
     }
 
-    @Test
-    func deviceRegistrationFailureIsAnExplicitBestEffortPolicy() async {
+    @Test func deviceRegistrationFailureIsAnExplicitBestEffortPolicy() async {
         let member = authenticatedMember()
         let repository = InMemoryMemberRepository(items: [member])
         let environmentRouter = FixedSessionEnvironmentRouter()

--- a/ios/Reguerta/ReguertaTests/FirebaseAuthenticationMutationFlowTests.swift
+++ b/ios/Reguerta/ReguertaTests/FirebaseAuthenticationMutationFlowTests.swift
@@ -124,8 +124,7 @@ struct FirebaseAuthenticationMutationFlowTests {
         }
     }
 
-    @Test("Un fallo previo a mutar Auth no cierra una sesión ajena")
-    func initialMutationFailureDoesNotSignOut() async {
+    @Test("Un fallo previo a mutar Auth no cierra una sesión ajena") func initialMutationFailureDoesNotSignOut() async {
         var signOutCallCount = 0
         let mutation: () async throws -> String = {
             throw FirebaseAuthenticationMutationTestError.initial

--- a/ios/Reguerta/ReguertaTests/FirebaseFunctionsSecurityBoundaryTests.swift
+++ b/ios/Reguerta/ReguertaTests/FirebaseFunctionsSecurityBoundaryTests.swift
@@ -6,8 +6,7 @@ import Testing
 
 @MainActor
 struct FirebaseFunctionsSecurityBoundaryTests {
-    @Test
-    func authenticatedClientPostsCodableBodyWithFreshBearerToken() async throws {
+    @Test func authenticatedClientPostsCodableBodyWithFreshBearerToken() async throws {
         let response = ResolveAuthorizedMemberResponse(
             authorized: true,
             memberId: "member_1",
@@ -128,8 +127,7 @@ struct FirebaseFunctionsSecurityBoundaryTests {
         }
     }
 
-    @Test
-    func authorizedSessionAppliesResolvedEnvironmentBeforeExactMemberRead() async throws {
+    @Test func authorizedSessionAppliesResolvedEnvironmentBeforeExactMemberRead() async throws {
         let member = Member(
             id: "member_1",
             displayName: "Member",
@@ -164,8 +162,7 @@ struct FirebaseFunctionsSecurityBoundaryTests {
         #expect(repository.requestedMemberIds == [member.id])
     }
 
-    @Test
-    func authorizedSessionRollsBackResolvedEnvironmentWhenExactMemberReadFails() async throws {
+    @Test func authorizedSessionRollsBackResolvedEnvironmentWhenExactMemberReadFails() async throws {
         let router = RecordingSessionEnvironmentRouter(baseEnvironment: .develop)
         let repository = EnvironmentRecordingMemberRepository(member: nil, router: router)
         let useCase = ResolveAuthorizedSessionUseCase(
@@ -194,8 +191,7 @@ struct FirebaseFunctionsSecurityBoundaryTests {
 }
 
 extension FirebaseFunctionsSecurityBoundaryTests {
-    @Test
-    func adminUpsertUsesBearerContractWithoutActorIdentityAndEncodesClears() async throws {
+    @Test func adminUpsertUsesBearerContractWithoutActorIdentityAndEncodesClears() async throws {
         let loader = RecordingHTTPDataLoader(
             data: try JSONEncoder().encode(
                 TestUpsertMemberResponse(
@@ -248,8 +244,7 @@ extension FirebaseFunctionsSecurityBoundaryTests {
         #expect(!json.contains("\"authUid\""))
     }
 
-    @Test
-    func adminUpsertRejectsResponseFromDifferentEnvironment() async throws {
+    @Test func adminUpsertRejectsResponseFromDifferentEnvironment() async throws {
         let loader = RecordingHTTPDataLoader(
             data: try JSONEncoder().encode(
                 TestUpsertMemberResponse(
@@ -287,8 +282,7 @@ extension FirebaseFunctionsSecurityBoundaryTests {
         }
     }
 
-    @Test
-    func shiftSwapRejectsMismatchedBackendAction() async throws {
+    @Test func shiftSwapRejectsMismatchedBackendAction() async throws {
         let loader = RecordingHTTPDataLoader(
             data: try JSONEncoder().encode(
                 TestShiftSwapTransitionResponse(
@@ -330,8 +324,7 @@ extension FirebaseFunctionsSecurityBoundaryTests {
         }
     }
 
-    @Test
-    func shiftSwapMapsFunctionCancellationToTaskCancellation() async {
+    @Test func shiftSwapMapsFunctionCancellationToTaskCancellation() async {
         let repository = FirestoreShiftSwapRequestRepository(
             db: Firestore.firestore(),
             environment: .develop,
@@ -361,8 +354,7 @@ extension FirebaseFunctionsSecurityBoundaryTests {
         }
     }
 
-    @Test
-    func publicMemberDirectoryMappingDropsSensitiveIdentityFields() throws {
+    @Test func publicMemberDirectoryMappingDropsSensitiveIdentityFields() throws {
         let member = try FirestoreMemberRepository.directoryMember(
             documentID: "producer_1",
             data: [
@@ -389,8 +381,7 @@ extension FirebaseFunctionsSecurityBoundaryTests {
         #expect(member.ecoCommitmentParity == .even)
     }
 
-    @Test
-    func publicDirectoryListPreservesAuthenticatedMembersFullIdentity() throws {
+    @Test func publicDirectoryListPreservesAuthenticatedMembersFullIdentity() throws {
         let authenticatedMember = Member(
             id: "member_1",
             displayName: "Own profile",

--- a/ios/Reguerta/ReguertaTests/FirestoreCommunityDocumentIdentityTests.swift
+++ b/ios/Reguerta/ReguertaTests/FirestoreCommunityDocumentIdentityTests.swift
@@ -7,8 +7,7 @@ import Testing
 @MainActor
 @Suite("Firestore community document identity")
 struct FirestoreCommunityDocumentIdentityTests {
-    @Test("News and Notification document IDs reject surrounding whitespace")
-    func documentIDsAreExact() {
+    @Test("News and Notification document IDs reject surrounding whitespace") func documentIDsAreExact() {
         #expect(throws: RepositoryError.invalidData(resource: "news/ news_1 ")) {
             try FirestoreNewsRepository.newsArticle(
                 documentID: " news_1 ",
@@ -28,8 +27,7 @@ struct FirestoreCommunityDocumentIdentityTests {
         }
     }
 
-    @Test("Inbox identity compares the exact document and payload IDs")
-    func inboxIdentityIsExact() {
+    @Test("Inbox identity compares the exact document and payload IDs") func inboxIdentityIsExact() {
         var data = notificationData()
         data["notificationEventId"] = "event_1"
         #expect(

--- a/ios/Reguerta/ReguertaTests/FirestoreNewsNotificationDecodingTests.swift
+++ b/ios/Reguerta/ReguertaTests/FirestoreNewsNotificationDecodingTests.swift
@@ -258,19 +258,13 @@ struct FirestoreNewsNotificationDecodingTests {
         }
     }
 
-    private func expectInvalidNews(
-        _ data: [String: Any],
-        documentID: String = "news_1"
-    ) {
+    private func expectInvalidNews(_ data: [String: Any], documentID: String = "news_1") {
         #expect(throws: RepositoryError.invalidData(resource: "news/\(documentID)")) {
             try FirestoreNewsRepository.newsArticle(documentID: documentID, data: data)
         }
     }
 
-    private func expectInvalidNotification(
-        _ data: [String: Any],
-        documentID: String = "event_1"
-    ) {
+    private func expectInvalidNotification(_ data: [String: Any], documentID: String = "event_1") {
         #expect(throws: RepositoryError.invalidData(resource: "notificationEvents/\(documentID)")) {
             try FirestoreNotificationRepository.notificationEvent(
                 documentID: documentID,

--- a/ios/Reguerta/ReguertaTests/FirestoreRepositoryErrorMapperTests.swift
+++ b/ios/Reguerta/ReguertaTests/FirestoreRepositoryErrorMapperTests.swift
@@ -6,8 +6,7 @@ import Testing
 
 @MainActor
 struct FirestoreRepositoryErrorMapperTests {
-    @Test
-    func mapsFirestoreFailuresToDomainErrors() {
+    @Test func mapsFirestoreFailuresToDomainErrors() {
         let resource = "products"
 
         #expect(
@@ -24,8 +23,7 @@ struct FirestoreRepositoryErrorMapperTests {
         )
     }
 
-    @Test
-    func preservesCancellationWithoutDomainMapping() {
+    @Test func preservesCancellationWithoutDomainMapping() {
         let mapped = FirestoreRepositoryErrorMapper.map(
             CancellationError(),
             resource: "products"
@@ -34,8 +32,7 @@ struct FirestoreRepositoryErrorMapperTests {
         #expect(mapped is CancellationError)
     }
 
-    @Test
-    func rejectsMalformedProductAndCommitmentDocumentsAsInvalidData() throws {
+    @Test func rejectsMalformedProductAndCommitmentDocumentsAsInvalidData() throws {
         try assertMalformedProductsAreRejected()
         try assertMalformedCommitmentsAreRejected()
     }
@@ -118,8 +115,7 @@ struct FirestoreRepositoryErrorMapperTests {
         }
     }
 
-    @Test
-    func productMergePayloadDeletesClearedOptionalFields() throws {
+    @Test func productMergePayloadDeletesClearedOptionalFields() throws {
         let product = try FirestoreProductRepository.product(
             documentID: "product",
             data: validProductData()
@@ -133,8 +129,7 @@ struct FirestoreRepositoryErrorMapperTests {
         #expect(payload["commonPurchaseType"] is FieldValue)
     }
 
-    @Test
-    func sharedProfileContractDistinguishesLegacyAbsenceFromCorruption() throws {
+    @Test func sharedProfileContractDistinguishesLegacyAbsenceFromCorruption() throws {
         let timestamp = Timestamp(date: Date(timeIntervalSince1970: 123))
         let minimalProfile: [String: Any] = [
             "userId": "member_1",
@@ -185,8 +180,7 @@ struct FirestoreRepositoryErrorMapperTests {
         }
     }
 
-    @Test
-    func sharedProfileMergePayloadDeletesClearedPhoto() {
+    @Test func sharedProfileMergePayloadDeletesClearedPhoto() {
         let payload = FirestoreSharedProfileRepository.upsertPayload(
             for: SharedProfile(
                 userId: "member_1",
@@ -200,8 +194,7 @@ struct FirestoreRepositoryErrorMapperTests {
         #expect(payload["photoUrl"] is FieldValue)
     }
 
-    @Test
-    func memberDirectoryContractRequiresCanonicalPublicFieldsAndIdentity() throws {
+    @Test func memberDirectoryContractRequiresCanonicalPublicFieldsAndIdentity() throws {
         let validDirectory: [String: Any] = [
             "userId": "member_1",
             "displayName": " Member One ",
@@ -254,8 +247,7 @@ struct FirestoreRepositoryErrorMapperTests {
         }
     }
 
-    @Test
-    func fullMemberContractKeepsLegacyAliasesButRejectsConflictingTypes() throws {
+    @Test func fullMemberContractKeepsLegacyAliasesButRejectsConflictingTypes() throws {
         let legacyMember: [String: Any] = [
             "name": "Ana",
             "surname": "Reguerta",

--- a/ios/Reguerta/ReguertaTests/FirestoreShiftPlanningRequestRepositoryTests.swift
+++ b/ios/Reguerta/ReguertaTests/FirestoreShiftPlanningRequestRepositoryTests.swift
@@ -6,8 +6,7 @@ import Testing
 
 @MainActor
 struct FirestoreShiftPlanningRequestRepositoryTests {
-    @Test
-    func createsOnlyWhenAbsentAndAcknowledgesCompatibleExistingState() throws {
+    @Test func createsOnlyWhenAbsentAndAcknowledgesCompatibleExistingState() throws {
         let request = planningRequest()
 
         #expect(
@@ -35,8 +34,7 @@ struct FirestoreShiftPlanningRequestRepositoryTests {
         }
     }
 
-    @Test
-    func rejectsAnIncompatibleOrMalformedExistingRequest() {
+    @Test func rejectsAnIncompatibleOrMalformedExistingRequest() {
         let request = planningRequest()
         let validData = firestoreData(for: requestWithStatus(.completed, basedOn: request))
         let invalidVariants: [[String: Any]] = [
@@ -88,8 +86,7 @@ struct FirestoreShiftPlanningRequestRepositoryTests {
         }
     }
 
-    @Test
-    func usesAnOnlineCreateIfAbsentTransaction() throws {
+    @Test func usesAnOnlineCreateIfAbsentTransaction() throws {
         let sourceURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()

--- a/ios/Reguerta/ReguertaTests/FoundationModelsBylawsSummaryGeneratorTests.swift
+++ b/ios/Reguerta/ReguertaTests/FoundationModelsBylawsSummaryGeneratorTests.swift
@@ -4,8 +4,7 @@ import Testing
 @testable import Reguerta
 
 struct FoundationModelsBylawsSummaryGeneratorTests {
-    @Test("Las instrucciones españolas fijan solo el idioma español")
-    func spanishInstructionsSelectSpanish() {
+    @Test("Las instrucciones españolas fijan solo el idioma español") func spanishInstructionsSelectSpanish() {
         let instructions = FoundationModelsBylawsSummaryGenerator.instructions(for: .spanish)
 
         #expect(instructions.contains("The person's locale is es_ES."))
@@ -13,8 +12,7 @@ struct FoundationModelsBylawsSummaryGeneratorTests {
         #expect(!instructions.contains("You MUST respond in English"))
     }
 
-    @Test("Las instrucciones inglesas fijan solo el idioma inglés")
-    func englishInstructionsSelectEnglish() {
+    @Test("Las instrucciones inglesas fijan solo el idioma inglés") func englishInstructionsSelectEnglish() {
         let instructions = FoundationModelsBylawsSummaryGenerator.instructions(for: .english)
 
         #expect(instructions.contains("The person's locale is en_US."))
@@ -46,8 +44,7 @@ struct FoundationModelsBylawsSummaryGeneratorTests {
         )
     }
 
-    @Test("Un fallo de decodificacion sigue siendo fallo de generacion")
-    func decodingFailureMapsToGenerationFailed() {
+    @Test("Un fallo de decodificacion sigue siendo fallo de generacion") func decodingFailureMapsToGenerationFailed() {
         let error = LanguageModelSession.GenerationError.decodingFailure(
             .init(debugDescription: "Test decoding failure")
         )

--- a/ios/Reguerta/ReguertaTests/MyOrderFreshnessRefreshBarrierTests.swift
+++ b/ios/Reguerta/ReguertaTests/MyOrderFreshnessRefreshBarrierTests.swift
@@ -236,10 +236,7 @@ private typealias BarrierFreshnessTasks = (
     timeout: Task<Void, Never>
 )
 
-@MainActor
-private func barrierOwnedTasks(
-    in viewModel: MyOrderFreshnessViewModel
-) -> BarrierFreshnessTasks? {
+@MainActor private func barrierOwnedTasks(in viewModel: MyOrderFreshnessViewModel) -> BarrierFreshnessTasks? {
     guard let operation = viewModel.freshnessOperationTask,
           let timeout = viewModel.freshnessTimeoutTask else {
         Issue.record("El refresh no conserva ambas tareas")
@@ -328,9 +325,7 @@ private func barrierFreshnessConfig() -> CriticalDataFreshnessConfig {
 }
 
 private actor ControlledCriticalDataRefresher: CriticalDataRefreshing {
-    private var continuations: [
-        Int: CheckedContinuation<CriticalDataRefreshPayload, any Error>
-    ] = [:]
+    private var continuations: [Int: CheckedContinuation<CriticalDataRefreshPayload, any Error>] = [:]
     private var registeredCount = 0
     private var countWaiters: [Int: CheckedContinuation<Void, Never>] = [:]
 

--- a/ios/Reguerta/ReguertaTests/MyOrderFreshnessViewModelConcurrencyTests.swift
+++ b/ios/Reguerta/ReguertaTests/MyOrderFreshnessViewModelConcurrencyTests.swift
@@ -5,8 +5,7 @@ import Testing
 @Suite(.timeLimit(.minutes(1)))
 @MainActor
 struct MyOrderFreshnessViewModelConcurrencyTests {
-    @Test("Una configuracion valida habilita Mi pedido")
-    func validConfigResolvesReady() async {
+    @Test("Una configuracion valida habilita Mi pedido") func validConfigResolvesReady() async {
         let viewModel = makeImmediateFreshnessViewModel(config: validConcurrencyFreshnessConfig())
         let mode = freshnessAuthorizedMode(uid: "uid_ready")
 
@@ -18,8 +17,7 @@ struct MyOrderFreshnessViewModelConcurrencyTests {
         #expect(viewModel.state == .ready)
     }
 
-    @Test("Una configuracion invalida bloquea Mi pedido")
-    func invalidConfigResolvesUnavailable() async {
+    @Test("Una configuracion invalida bloquea Mi pedido") func invalidConfigResolvesUnavailable() async {
         let viewModel = makeImmediateFreshnessViewModel(config: nil)
         let mode = freshnessAuthorizedMode(uid: "uid_unavailable")
 
@@ -31,8 +29,7 @@ struct MyOrderFreshnessViewModelConcurrencyTests {
         #expect(viewModel.state == .unavailable)
     }
 
-    @Test("La misma sesion autorizada no inicia otro refresh")
-    func samePrincipalDoesNotRefresh() async {
+    @Test("La misma sesion autorizada no inicia otro refresh") func samePrincipalDoesNotRefresh() async {
         let remoteRepository = ControlledCriticalDataFreshnessRemoteRepository()
         let viewModel = makeControlledFreshnessViewModel(remoteRepository: remoteRepository)
         let mode = freshnessAuthorizedMode(uid: "uid_same")
@@ -46,8 +43,7 @@ struct MyOrderFreshnessViewModelConcurrencyTests {
         #expect(viewModel.state == .ready)
     }
 
-    @Test("Cambiar de principal inicia un refresh nuevo")
-    func changedPrincipalRefreshes() async throws {
+    @Test("Cambiar de principal inicia un refresh nuevo") func changedPrincipalRefreshes() async throws {
         let remoteRepository = ControlledCriticalDataFreshnessRemoteRepository()
         let viewModel = makeControlledFreshnessViewModel(remoteRepository: remoteRepository)
 
@@ -212,10 +208,7 @@ struct MyOrderFreshnessViewModelConcurrencyTests {
 
 private typealias OwnedFreshnessTasks = (operation: Task<Void, Never>, timeout: Task<Void, Never>)
 
-@MainActor
-private func ownedRefreshTasks(
-    in viewModel: MyOrderFreshnessViewModel
-) -> OwnedFreshnessTasks? {
+@MainActor private func ownedRefreshTasks(in viewModel: MyOrderFreshnessViewModel) -> OwnedFreshnessTasks? {
     guard let operation = viewModel.freshnessOperationTask,
           let timeout = viewModel.freshnessTimeoutTask else {
         Issue.record("El refresh no conserva sus tareas de operacion y timeout")
@@ -225,9 +218,7 @@ private func ownedRefreshTasks(
 }
 
 @MainActor
-private func makeImmediateFreshnessViewModel(
-    config: CriticalDataFreshnessConfig?
-) -> MyOrderFreshnessViewModel {
+private func makeImmediateFreshnessViewModel(config: CriticalDataFreshnessConfig?) -> MyOrderFreshnessViewModel {
     let localRepository = InMemoryCriticalDataFreshnessLocalRepository()
     return MyOrderFreshnessViewModel(
         resolveCriticalDataFreshness: ResolveCriticalDataFreshnessUseCase(
@@ -304,9 +295,7 @@ private func freshnessAuthorizedMode(
     )
 }
 
-private func validConcurrencyFreshnessConfig(
-    timestamp: Int64 = 1_000
-) -> CriticalDataFreshnessConfig {
+private func validConcurrencyFreshnessConfig(timestamp: Int64 = 1_000) -> CriticalDataFreshnessConfig {
     CriticalDataFreshnessConfig(
         cacheExpirationMinutes: 15,
         remoteTimestampsMillis: concurrencyFreshnessTimestamps(timestamp: timestamp)
@@ -320,9 +309,7 @@ private func invalidConcurrencyFreshnessConfig() -> CriticalDataFreshnessConfig 
     )
 }
 
-private func concurrencyFreshnessMetadata(
-    timestamp: Int64 = 1_000
-) -> CriticalDataFreshnessMetadata {
+private func concurrencyFreshnessMetadata(timestamp: Int64 = 1_000) -> CriticalDataFreshnessMetadata {
     CriticalDataFreshnessMetadata(
         validatedAtMillis: 1_000,
         acknowledgedTimestampsMillis: concurrencyFreshnessTimestamps(timestamp: timestamp),
@@ -332,9 +319,7 @@ private func concurrencyFreshnessMetadata(
     )
 }
 
-private func concurrencyFreshnessTimestamps(
-    timestamp: Int64 = 1_000
-) -> [CriticalCollection: Int64] {
+private func concurrencyFreshnessTimestamps(timestamp: Int64 = 1_000) -> [CriticalCollection: Int64] {
     Dictionary(
         uniqueKeysWithValues: CriticalCollection.allCases.map { ($0, timestamp) }
     )
@@ -345,9 +330,7 @@ private actor ControlledCriticalDataFreshnessRemoteRepository: CriticalDataFresh
     private var registeredRequestCount = 0
     private var requestContinuations: [Int: CheckedContinuation<CriticalDataFreshnessConfig?, Never>] = [:]
     private var nextRequestCountWaiterID = 0
-    private var requestCountWaiters: [
-        Int: (count: Int, continuation: CheckedContinuation<Void, any Error>)
-    ] = [:]
+    private var requestCountWaiters: [Int: (count: Int, continuation: CheckedContinuation<Void, any Error>)] = [:]
 
     func getConfig(environment: SessionEnvironment) async throws -> CriticalDataFreshnessConfig {
         let requestIndex = nextRequestIndex
@@ -383,10 +366,7 @@ private actor ControlledCriticalDataFreshnessRemoteRepository: CriticalDataFresh
         nextRequestIndex
     }
 
-    func completeRequest(
-        at index: Int,
-        with config: CriticalDataFreshnessConfig?
-    ) {
+    func completeRequest(at index: Int, with config: CriticalDataFreshnessConfig?) {
         guard let continuation = requestContinuations.removeValue(forKey: index) else {
             Issue.record("No existe la solicitud de freshness numero \(index)")
             return
@@ -417,9 +397,7 @@ private actor ControlledFreshnessSleeper {
     private var requestContinuations: [Int: CheckedContinuation<Void, any Error>] = [:]
     private var cancelledRequests: Set<Int> = []
     private var nextRequestCountWaiterID = 0
-    private var requestCountWaiters: [
-        Int: (count: Int, continuation: CheckedContinuation<Void, any Error>)
-    ] = [:]
+    private var requestCountWaiters: [Int: (count: Int, continuation: CheckedContinuation<Void, any Error>)] = [:]
 
     func sleep(for _: Duration) async throws {
         let requestIndex = nextRequestIndex

--- a/ios/Reguerta/ReguertaTests/NewsImageDataLoaderTests.swift
+++ b/ios/Reguerta/ReguertaTests/NewsImageDataLoaderTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct NewsImageDataLoaderTests {
-    @Test
-    func loadsNonEmptyDataFromSuccessfulHTTPResponse() async throws {
+    @Test func loadsNonEmptyDataFromSuccessfulHTTPResponse() async throws {
         let expectedData = Data([1, 2, 3])
         let loader = NewsImageDataLoader(
             fetcher: StubNewsImageDataFetcher(
@@ -19,8 +18,7 @@ struct NewsImageDataLoaderTests {
         #expect(data == expectedData)
     }
 
-    @Test
-    func rejectsUnsuccessfulHTTPResponse() async throws {
+    @Test func rejectsUnsuccessfulHTTPResponse() async throws {
         let loader = NewsImageDataLoader(
             fetcher: StubNewsImageDataFetcher(
                 response: NewsImageDataResponse(data: Data([1]), statusCode: 404)
@@ -32,8 +30,7 @@ struct NewsImageDataLoaderTests {
         }
     }
 
-    @Test
-    func rejectsEmptyImagePayload() async throws {
+    @Test func rejectsEmptyImagePayload() async throws {
         let loader = NewsImageDataLoader(
             fetcher: StubNewsImageDataFetcher(
                 response: NewsImageDataResponse(data: Data(), statusCode: 200)

--- a/ios/Reguerta/ReguertaTests/NewsNotificationsFeatureOperationSafetyTestSupport.swift
+++ b/ios/Reguerta/ReguertaTests/NewsNotificationsFeatureOperationSafetyTestSupport.swift
@@ -55,7 +55,10 @@ actor ControlledNewsRepository: NewsRepository {
         await withCheckedContinuation { waiters.append((count, $0)) }
     }
 
-    func completeRead(_ index: Int, with result: Result<[NewsArticle], RepositoryError>) {
+    func completeRead(
+        _ index: Int,
+        with result: Result<[NewsArticle], RepositoryError>
+    ) {
         guard let continuation = continuations.removeValue(forKey: index) else { return }
         continuation.resume(with: result.mapError { $0 as any Error })
     }
@@ -81,10 +84,7 @@ actor SequencedNotificationRepository: NotificationRepository {
     private var notificationOutcomes: [NotificationReadOutcome]
     private var readOutcomes: [NotificationIDsOutcome]
 
-    init(
-        notificationOutcomes: [NotificationReadOutcome],
-        readOutcomes: [NotificationIDsOutcome]
-    ) {
+    init(notificationOutcomes: [NotificationReadOutcome], readOutcomes: [NotificationIDsOutcome]) {
         self.notificationOutcomes = notificationOutcomes
         self.readOutcomes = readOutcomes
     }
@@ -121,11 +121,7 @@ actor ControlledNotificationRepository: NotificationRepository {
     func allNotifications() async throws -> [NotificationEvent] { [] }
     func readNotificationIds(memberId _: String) async throws -> Set<String> { [] }
 
-    func markNotificationsRead(
-        memberId _: String,
-        notificationIds _: [String],
-        readAtMillis _: Int64
-    ) async throws {
+    func markNotificationsRead(memberId _: String, notificationIds _: [String], readAtMillis _: Int64) async throws {
         markCount += 1
         let satisfied = waiters.filter { $0.0 <= markCount }
         waiters.removeAll { $0.0 <= markCount }
@@ -246,8 +242,7 @@ struct ControlledSafetyPermissionProvider: PushNotificationPermissionProvider {
         await state.value()
     }
 
-    @MainActor
-    func openSettings() {}
+    @MainActor func openSettings() {}
 
     func waitForRequest() async {
         await state.waitForRequest()
@@ -320,10 +315,7 @@ func makeSafetyViewModel(
     return viewModel
 }
 
-func safetySession(
-    member: Member,
-    environment: SessionEnvironment
-) -> AuthorizedSession {
+func safetySession(member: Member, environment: SessionEnvironment) -> AuthorizedSession {
     AuthorizedSession(
         principal: AuthPrincipal(uid: "auth_\(member.id)", email: member.normalizedEmail),
         authenticatedMember: member,
@@ -333,10 +325,7 @@ func safetySession(
     )
 }
 
-func safetyMember(
-    id: String = "member_1",
-    roles: Set<MemberRole> = [.member]
-) -> Member {
+func safetyMember(id: String = "member_1", roles: Set<MemberRole> = [.member]) -> Member {
     Member(
         id: id,
         displayName: "Member",
@@ -348,10 +337,7 @@ func safetyMember(
     )
 }
 
-func safetyNewsArticle(
-    id: String,
-    publishedAtMillis: Int64 = 1
-) -> NewsArticle {
+func safetyNewsArticle(id: String, publishedAtMillis: Int64 = 1) -> NewsArticle {
     NewsArticle(
         id: id,
         title: "Title",
@@ -380,8 +366,7 @@ func safetyNotification(id: String) -> NotificationEvent {
     )
 }
 
-@MainActor
-func seedPrivateCommunityState(_ viewModel: NewsNotificationsFeatureViewModel) {
+@MainActor func seedPrivateCommunityState(_ viewModel: NewsNotificationsFeatureViewModel) {
     viewModel.latestNews = [safetyNewsArticle(id: "latest")]
     viewModel.newsFeed = [safetyNewsArticle(id: "news")]
     viewModel.notificationsFeed = [safetyNotification(id: "notification")]
@@ -392,8 +377,7 @@ func seedPrivateCommunityState(_ viewModel: NewsNotificationsFeatureViewModel) {
     viewModel.pendingNewsDeletionId = "news"
 }
 
-@MainActor
-func expectCommunityStateCleared(_ viewModel: NewsNotificationsFeatureViewModel) {
+@MainActor func expectCommunityStateCleared(_ viewModel: NewsNotificationsFeatureViewModel) {
     #expect(viewModel.latestNews.isEmpty)
     #expect(viewModel.newsFeed.isEmpty)
     #expect(viewModel.notificationsFeed.isEmpty)

--- a/ios/Reguerta/ReguertaTests/NewsNotificationsFeatureOperationSafetyTests.swift
+++ b/ios/Reguerta/ReguertaTests/NewsNotificationsFeatureOperationSafetyTests.swift
@@ -28,8 +28,7 @@ struct NewsNotificationsFeatureOperationSafetyTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableLoadData)
     }
 
-    @Test("A valid News retry atomically replaces the preserved snapshot")
-    func newsRetryReplacesSnapshot() async {
+    @Test("A valid News retry atomically replaces the preserved snapshot") func newsRetryReplacesSnapshot() async {
         let old = safetyNewsArticle(id: "old")
         let current = safetyNewsArticle(id: "current", publishedAtMillis: 2)
         let repository = SequencedNewsRepository(
@@ -255,8 +254,7 @@ struct NewsNotificationsFeatureOperationSafetyTests {
         #expect(viewModel.currentEnvironment == .production)
     }
 
-    @Test("A stale mark-read failure cannot publish feedback or read state")
-    func markReadIsSessionFenced() async {
+    @Test("A stale mark-read failure cannot publish feedback or read state") func markReadIsSessionFenced() async {
         let event = safetyNotification(id: "event")
         let repository = ControlledNotificationRepository()
         let viewModel = makeSafetyViewModel(notificationRepository: repository)

--- a/ios/Reguerta/ReguertaTests/NewsNotificationsFeatureReviewSafetyTests.swift
+++ b/ios/Reguerta/ReguertaTests/NewsNotificationsFeatureReviewSafetyTests.swift
@@ -215,8 +215,7 @@ struct NewsNotificationsImageUploadReviewTests {
         #expect(viewModel.isUploadingNewsImage == false)
     }
 
-    @Test("A News refresh never lowers the image upload flag")
-    func refreshDoesNotFinishImageUpload() async {
+    @Test("A News refresh never lowers the image upload flag") func refreshDoesNotFinishImageUpload() async {
         let pipeline = ReviewControlledImagePipelineManager()
         let viewModel = makeSafetyViewModel(
             member: safetyMember(roles: [.member, .admin]),

--- a/ios/Reguerta/ReguertaTests/NewsNotificationsFeatureReviewTestSupport.swift
+++ b/ios/Reguerta/ReguertaTests/NewsNotificationsFeatureReviewTestSupport.swift
@@ -55,11 +55,7 @@ actor ReviewControlledNotificationRepository: NotificationRepository {
         }
     }
 
-    func markNotificationsRead(
-        memberId _: String,
-        notificationIds _: [String],
-        readAtMillis _: Int64
-    ) async throws {
+    func markNotificationsRead(memberId _: String, notificationIds _: [String], readAtMillis _: Int64) async throws {
         let index = markRequests
         markRequests += 1
         resumeWaiters(&markWaiters, count: markRequests)
@@ -237,10 +233,7 @@ actor ReviewControlledImagePipelineManager: ImagePipelineManager {
     private var continuations: [Int: CheckedContinuation<ImageUploadResult, any Error>] = [:]
     private var waiters: [(Int, CheckedContinuation<Void, Never>)] = []
 
-    func processAndUpload(
-        imageData _: Data,
-        request _: ImageUploadRequest
-    ) async throws -> ImageUploadResult {
+    func processAndUpload(imageData _: Data, request _: ImageUploadRequest) async throws -> ImageUploadResult {
         let index = requests
         requests += 1
         let satisfied = waiters.filter { $0.0 <= requests }
@@ -275,11 +268,7 @@ actor ReviewControlledImagePipelineManager: ImagePipelineManager {
     }
 }
 
-@MainActor
-func reviewNotification(
-    id: String,
-    targetRole: MemberRole? = nil
-) -> NotificationEvent {
+@MainActor func reviewNotification(id: String, targetRole: MemberRole? = nil) -> NotificationEvent {
     NotificationEvent(
         id: id,
         title: "Title",

--- a/ios/Reguerta/ReguertaTests/NewsNotificationsMutationBoundaryTests.swift
+++ b/ios/Reguerta/ReguertaTests/NewsNotificationsMutationBoundaryTests.swift
@@ -193,9 +193,7 @@ struct NewsNotificationsMutationBoundaryTests {
         safetyMember(id: id, roles: [.member, .admin])
     }
 
-    private func replaceAuthorizedContext(
-        in viewModel: NewsNotificationsFeatureViewModel
-    ) {
+    private func replaceAuthorizedContext(in viewModel: NewsNotificationsFeatureViewModel) {
         let replacement = safetySession(
             member: adminMember(id: "member_2"),
             environment: .develop
@@ -205,10 +203,7 @@ struct NewsNotificationsMutationBoundaryTests {
         #expect(viewModel.currentMember?.id == replacement.member.id)
     }
 
-    private func prepareNewsDraft(
-        _ viewModel: NewsNotificationsFeatureViewModel,
-        title: String
-    ) {
+    private func prepareNewsDraft(_ viewModel: NewsNotificationsFeatureViewModel, title: String) {
         #expect(viewModel.startCreatingNews())
         viewModel.updateNewsDraft {
             $0.title = title
@@ -216,10 +211,7 @@ struct NewsNotificationsMutationBoundaryTests {
         }
     }
 
-    private func prepareNotificationDraft(
-        _ viewModel: NewsNotificationsFeatureViewModel,
-        title: String
-    ) {
+    private func prepareNotificationDraft(_ viewModel: NewsNotificationsFeatureViewModel, title: String) {
         #expect(viewModel.startCreatingNotification())
         viewModel.updateNotificationDraft {
             $0.title = title

--- a/ios/Reguerta/ReguertaTests/NewsNotificationsMutationOwnershipTestSupport.swift
+++ b/ios/Reguerta/ReguertaTests/NewsNotificationsMutationOwnershipTestSupport.swift
@@ -61,18 +61,12 @@ actor ReviewControlledNewsWriteRepository: NewsRepository {
     func upsertCount() -> Int { upsertRequests.count }
     func deleteCount() -> Int { deleteRequests.count }
 
-    func completeUpsert(
-        _ index: Int,
-        with result: Result<NewsArticle, RepositoryError>
-    ) {
+    func completeUpsert(_ index: Int, with result: Result<NewsArticle, RepositoryError>) {
         guard let continuation = upsertContinuations.removeValue(forKey: index) else { return }
         continuation.resume(with: result.mapError { $0 as any Error })
     }
 
-    func completeDelete(
-        _ index: Int,
-        with result: Result<Bool, RepositoryError>
-    ) {
+    func completeDelete(_ index: Int, with result: Result<Bool, RepositoryError>) {
         guard let continuation = deleteContinuations.removeValue(forKey: index) else { return }
         continuation.resume(with: result.mapError { $0 as any Error })
     }
@@ -125,10 +119,7 @@ actor ReviewControlledNotificationWriteRepository: NotificationRepository {
 
     func sendCount() -> Int { sendRequests.count }
 
-    func completeSend(
-        _ index: Int,
-        with result: Result<NotificationEvent, RepositoryError>
-    ) {
+    func completeSend(_ index: Int, with result: Result<NotificationEvent, RepositoryError>) {
         guard let continuation = sendContinuations.removeValue(forKey: index) else { return }
         continuation.resume(with: result.mapError { $0 as any Error })
     }

--- a/ios/Reguerta/ReguertaTests/NewsNotificationsMutationOwnershipTests.swift
+++ b/ios/Reguerta/ReguertaTests/NewsNotificationsMutationOwnershipTests.swift
@@ -153,8 +153,7 @@ struct NewsNotificationsMutationOwnershipTests {
         #expect(viewModel.latestNews == [second, third, fourth])
     }
 
-    @Test("News save and image upload serialize in both directions")
-    func newsSaveAndImageUploadAreSerialized() async {
+    @Test("News save and image upload serialize in both directions") func newsSaveAndImageUploadAreSerialized() async {
         let repository = ReviewControlledNewsWriteRepository()
         let pipeline = ReviewControlledImagePipelineManager()
         let viewModel = makeSafetyViewModel(
@@ -195,8 +194,7 @@ struct NewsNotificationsMutationOwnershipTests {
         #expect(viewModel.newsDraftRevision == revisionBeforeUpload + 1)
     }
 
-    @Test("A confirmed News save cannot close a reopened editor")
-    func newsConfirmationCannotOwnReopenedEditor() async {
+    @Test("A confirmed News save cannot close a reopened editor") func newsConfirmationCannotOwnReopenedEditor() async {
         let repository = ReviewControlledNewsWriteRepository()
         let viewModel = makeSafetyViewModel(
             member: safetyMember(roles: [.member, .admin]),
@@ -243,10 +241,7 @@ struct NewsNotificationsMutationOwnershipTests {
         #expect(viewModel.notificationsFeed == [sent])
     }
 
-    private func prepareNewsDraft(
-        _ viewModel: NewsNotificationsFeatureViewModel,
-        title: String
-    ) {
+    private func prepareNewsDraft(_ viewModel: NewsNotificationsFeatureViewModel, title: String) {
         #expect(viewModel.startCreatingNews())
         viewModel.updateNewsDraft {
             $0.title = title
@@ -254,10 +249,7 @@ struct NewsNotificationsMutationOwnershipTests {
         }
     }
 
-    private func prepareNotificationDraft(
-        _ viewModel: NewsNotificationsFeatureViewModel,
-        title: String
-    ) {
+    private func prepareNotificationDraft(_ viewModel: NewsNotificationsFeatureViewModel, title: String) {
         #expect(viewModel.startCreatingNotification())
         viewModel.updateNotificationDraft {
             $0.title = title
@@ -265,9 +257,7 @@ struct NewsNotificationsMutationOwnershipTests {
         }
     }
 
-    private func expectNewNewsEditorIsUntouched(
-        _ viewModel: NewsNotificationsFeatureViewModel
-    ) {
+    private func expectNewNewsEditorIsUntouched(_ viewModel: NewsNotificationsFeatureViewModel) {
         #expect(viewModel.newsDraft.title == "New")
         #expect(viewModel.newsDraft.body == "Body")
         #expect(viewModel.editingNewsId == nil)
@@ -277,9 +267,7 @@ struct NewsNotificationsMutationOwnershipTests {
         #expect(viewModel.activeNewsMutationOperationId == nil)
     }
 
-    private func expectNewNotificationEditorIsUntouched(
-        _ viewModel: NewsNotificationsFeatureViewModel
-    ) {
+    private func expectNewNotificationEditorIsUntouched(_ viewModel: NewsNotificationsFeatureViewModel) {
         #expect(viewModel.notificationDraft.title == "New")
         #expect(viewModel.notificationDraft.body == "Body")
         #expect(viewModel.isNotificationSendConfirmationPresented == false)

--- a/ios/Reguerta/ReguertaTests/P101AuthorizedDeviceCoordinatorTests.swift
+++ b/ios/Reguerta/ReguertaTests/P101AuthorizedDeviceCoordinatorTests.swift
@@ -6,8 +6,7 @@ import Testing
 
 @MainActor
 struct P101AuthorizedDeviceCoordinatorTests {
-    @Test
-    func registrationPersistsUidEnvironmentAndLeaseBeforeWriting() async throws {
+    @Test func registrationPersistsUidEnvironmentAndLeaseBeforeWriting() async throws {
         let harness = makeHarness(currentAuthUid: "uid-a")
         let lease = AuthorizedDeviceSessionLease()
 
@@ -36,8 +35,7 @@ struct P101AuthorizedDeviceCoordinatorTests {
         )
     }
 
-    @Test
-    func mismatchedFirebaseUidFailsClosedBeforeFirestore() async throws {
+    @Test func mismatchedFirebaseUidFailsClosedBeforeFirestore() async throws {
         let harness = makeHarness(currentAuthUid: "uid-b")
 
         let result = try await harness.coordinator.register(
@@ -59,8 +57,7 @@ struct P101AuthorizedDeviceCoordinatorTests {
         )
     }
 
-    @Test
-    func lateClearFromSessionADoesNotDeleteSessionB() async throws {
+    @Test func lateClearFromSessionADoesNotDeleteSessionB() async throws {
         let authUid = CurrentAuthUid("uid-a")
         let harness = makeHarness(currentAuthUidProvider: { authUid.value })
         let leaseA = AuthorizedDeviceSessionLease()
@@ -97,8 +94,7 @@ struct P101AuthorizedDeviceCoordinatorTests {
         #expect(storedContext?.lease == leaseB)
     }
 
-    @Test
-    func suspendedRegistrationAIsDiscardedAfterSessionBReplacesIt() async throws {
+    @Test func suspendedRegistrationAIsDiscardedAfterSessionBReplacesIt() async throws {
         let authUid = CurrentAuthUid("uid-a")
         let tokenSource = FirstTokenRequestGate()
         let harness = makeHarness(
@@ -140,8 +136,7 @@ struct P101AuthorizedDeviceCoordinatorTests {
         #expect(harness.repository.registrations.map(\.environment) == [.production])
     }
 
-    @Test
-    func repositoryRevalidationStopsAWriteAfterItsLeaseIsCleared() async throws {
+    @Test func repositoryRevalidationStopsAWriteAfterItsLeaseIsCleared() async throws {
         let started = TestSignal()
         let release = TestGate()
         let repository = RecordingDeviceRegistrationRepository(
@@ -174,8 +169,7 @@ struct P101AuthorizedDeviceCoordinatorTests {
         #expect(repository.registrations.isEmpty)
     }
 
-    @Test
-    func corruptContextDoesNotBecomeAnAbsentSessionDuringTokenRefresh() async {
+    @Test func corruptContextDoesNotBecomeAnAbsentSessionDuringTokenRefresh() async {
         let client = InMemoryKeychainClient()
         client.setRaw(
             Data("not-json".utf8),
@@ -189,8 +183,7 @@ struct P101AuthorizedDeviceCoordinatorTests {
         #expect(harness.repository.registrations.isEmpty)
     }
 
-    @Test
-    func legacyMemberOnlyValueIsNeverUsedForTokenRefresh() async throws {
+    @Test func legacyMemberOnlyValueIsNeverUsedForTokenRefresh() async throws {
         let client = InMemoryKeychainClient()
         client.setRaw(
             Data("member-a".utf8),
@@ -285,11 +278,7 @@ private final class RecordingDeviceRegistrationRepository: DeviceRegistrationRep
     private let release: TestGate?
     var registrations: [RecordedDeviceRegistration] = []
 
-    init(
-        suspendedMemberId: String? = nil,
-        started: TestSignal? = nil,
-        release: TestGate? = nil
-    ) {
+    init(suspendedMemberId: String? = nil, started: TestSignal? = nil, release: TestGate? = nil) {
         self.suspendedMemberId = suspendedMemberId
         self.started = started
         self.release = release

--- a/ios/Reguerta/ReguertaTests/P101InMemoryMemberRepositoryPrivacyTests.swift
+++ b/ios/Reguerta/ReguertaTests/P101InMemoryMemberRepositoryPrivacyTests.swift
@@ -4,8 +4,7 @@ import Testing
 
 @MainActor
 struct P101InMemoryMemberRepositoryPrivacyTests {
-    @Test
-    func nonAdminReadsStablePublicProjectionAndKeepsOwnIdentity() async throws {
+    @Test func nonAdminReadsStablePublicProjectionAndKeepsOwnIdentity() async throws {
         let currentMember = Member(
             id: "member_1",
             displayName: "Current Member",

--- a/ios/Reguerta/ReguertaTests/P101KeychainStoreTests.swift
+++ b/ios/Reguerta/ReguertaTests/P101KeychainStoreTests.swift
@@ -4,8 +4,7 @@ import Testing
 @testable import Reguerta
 
 struct P101KeychainStoreTests {
-    @Test
-    func missingItemIsTheOnlyReadThatBecomesNil() async throws {
+    @Test func missingItemIsTheOnlyReadThatBecomesNil() async throws {
         let store = KeychainStore(
             client: StubKeychainClient(readResult: .init(status: errSecItemNotFound, data: nil))
         )
@@ -13,8 +12,7 @@ struct P101KeychainStoreTests {
         #expect(try await store.loadString(for: .fcmToken) == nil)
     }
 
-    @Test
-    func readFailureIsPropagatedWithItsOperationAndStatus() async {
+    @Test func readFailureIsPropagatedWithItsOperationAndStatus() async {
         let store = KeychainStore(
             client: StubKeychainClient(readResult: .init(status: errSecInteractionNotAllowed, data: nil))
         )
@@ -40,8 +38,7 @@ struct P101KeychainStoreTests {
         }
     }
 
-    @Test
-    func successfulUpdateConfirmsTheSave() async throws {
+    @Test func successfulUpdateConfirmsTheSave() async throws {
         let store = KeychainStore(
             client: StubKeychainClient(updateStatus: errSecSuccess)
         )
@@ -49,8 +46,7 @@ struct P101KeychainStoreTests {
         try await store.saveString(" token ", for: .fcmToken)
     }
 
-    @Test
-    func updateFailureIsNotReportedAsSuccess() async {
+    @Test func updateFailureIsNotReportedAsSuccess() async {
         let store = KeychainStore(
             client: StubKeychainClient(updateStatus: errSecAuthFailed)
         )
@@ -65,8 +61,7 @@ struct P101KeychainStoreTests {
         }
     }
 
-    @Test
-    func missingUpdateAddsAndChecksTheResult() async throws {
+    @Test func missingUpdateAddsAndChecksTheResult() async throws {
         let store = KeychainStore(
             client: StubKeychainClient(
                 updateStatus: errSecItemNotFound,
@@ -77,8 +72,7 @@ struct P101KeychainStoreTests {
         try await store.saveString("token", for: .fcmToken)
     }
 
-    @Test
-    func addFailureIsNotReportedAsSuccess() async {
+    @Test func addFailureIsNotReportedAsSuccess() async {
         let store = KeychainStore(
             client: StubKeychainClient(
                 updateStatus: errSecItemNotFound,
@@ -105,8 +99,7 @@ struct P101KeychainStoreTests {
         try await store.remove(.fcmToken)
     }
 
-    @Test
-    func deleteFailureIsNotReportedAsSuccess() async {
+    @Test func deleteFailureIsNotReportedAsSuccess() async {
         let store = KeychainStore(
             client: StubKeychainClient(deleteStatus: errSecInteractionNotAllowed)
         )
@@ -121,8 +114,7 @@ struct P101KeychainStoreTests {
         }
     }
 
-    @Test
-    func blankSaveUsesTheCheckedDeletePath() async {
+    @Test func blankSaveUsesTheCheckedDeletePath() async {
         let store = KeychainStore(
             client: StubKeychainClient(deleteStatus: errSecNotAvailable)
         )
@@ -137,8 +129,7 @@ struct P101KeychainStoreTests {
         }
     }
 
-    @Test
-    func invalidCodablePayloadIsCorruption() async {
+    @Test func invalidCodablePayloadIsCorruption() async {
         let store = KeychainStore(
             client: StubKeychainClient(
                 readResult: .init(status: errSecSuccess, data: Data("not-json".utf8))

--- a/ios/Reguerta/ReguertaTests/P101MemberFailureTests.swift
+++ b/ios/Reguerta/ReguertaTests/P101MemberFailureTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct P101MemberFailureTests {
-    @Test
-    func confirmedMemberMutationUpdatesSessionWithoutDirectoryReadBack() async {
+    @Test func confirmedMemberMutationUpdatesSessionWithoutDirectoryReadBack() async {
         let admin = makeAdmin()
         let target = makeMember()
         let repository = RejectingMemberRepository(members: [admin, target])
@@ -25,8 +24,7 @@ struct P101MemberFailureTests {
         #expect(viewModel.isTogglingMember == false)
     }
 
-    @Test
-    func staleMemberMutationFromPreviousSessionPublishesNothing() async {
+    @Test func staleMemberMutationFromPreviousSessionPublishesNothing() async {
         let oldAdmin = makeAdmin()
         let target = makeMember()
         let upserter = SuspendedMemberUpserter()
@@ -54,8 +52,7 @@ struct P101MemberFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == nil)
     }
 
-    @Test
-    func revokedAdminReadCannotPublishFullMembersForSameIdentity() async {
+    @Test func revokedAdminReadCannotPublishFullMembersForSameIdentity() async {
         let admin = makeAdmin()
         let target = makeMember()
         let revokedAdmin = admin.replacingForTest(roles: [.member])
@@ -81,8 +78,7 @@ struct P101MemberFailureTests {
         #expect(viewModel.canManageMembers == false)
     }
 
-    @Test
-    func confirmedMemberMutationPublishesAfterTaskCancellation() async {
+    @Test func confirmedMemberMutationPublishesAfterTaskCancellation() async {
         let admin = makeAdmin()
         let target = makeMember()
         let upserter = SuspendedMemberUpserter()
@@ -103,8 +99,7 @@ struct P101MemberFailureTests {
         #expect(viewModel.isTogglingMember == false)
     }
 
-    @Test
-    func confirmedMemberSavePreservesNewerEditorRevision() async {
+    @Test func confirmedMemberSavePreservesNewerEditorRevision() async {
         let admin = makeAdmin()
         let target = makeMember()
         let upserter = SuspendedMemberUpserter()
@@ -133,8 +128,7 @@ struct P101MemberFailureTests {
         #expect(viewModel.isEditorOpen)
     }
 
-    @Test
-    func staleMutationCannotClearNewMutationProgress() async {
+    @Test func staleMutationCannotClearNewMutationProgress() async {
         let oldAdmin = makeAdmin(id: "old_admin")
         let target = makeMember()
         let upserter = MultiSuspendedMemberUpserter()
@@ -164,8 +158,7 @@ struct P101MemberFailureTests {
         #expect(viewModel.isTogglingMember == false)
     }
 
-    @Test
-    func selfRevocationImmediatelyRemovesPrivateMemberData() async {
+    @Test func selfRevocationImmediatelyRemovesPrivateMemberData() async {
         let admin = makeAdmin()
         let target = makeMember()
         let viewModel = makeViewModel(
@@ -184,8 +177,7 @@ struct P101MemberFailureTests {
         })
     }
 
-    @Test
-    func selfDeactivationImmediatelyRemovesPrivateMemberData() async {
+    @Test func selfDeactivationImmediatelyRemovesPrivateMemberData() async {
         let admin = makeAdmin()
         let otherAdmin = makeAdmin(id: "other_admin")
         let target = makeMember()
@@ -206,8 +198,7 @@ struct P101MemberFailureTests {
         })
     }
 
-    @Test
-    func refreshContainingSelfRevocationImmediatelyRemovesPrivateMemberData() async {
+    @Test func refreshContainingSelfRevocationImmediatelyRemovesPrivateMemberData() async {
         let admin = makeAdmin()
         let target = makeMember()
         let revokedAdmin = admin.replacingForTest(roles: [.member])
@@ -232,8 +223,7 @@ struct P101MemberFailureTests {
         #expect(viewModel.isLoadingMembers == false)
     }
 
-    @Test
-    func staleConfirmationCannotClearNewSessionSelection() async {
+    @Test func staleConfirmationCannotClearNewSessionSelection() async {
         let oldAdmin = makeAdmin(id: "old_admin")
         let oldTarget = makeMember(id: "old_target")
         let upserter = MultiSuspendedMemberUpserter()

--- a/ios/Reguerta/ReguertaTests/P101ProductsFailureTestSupport.swift
+++ b/ios/Reguerta/ReguertaTests/P101ProductsFailureTestSupport.swift
@@ -91,10 +91,7 @@ actor SuspendedImagePipelineManager: ImagePipelineManager {
     private var continuation: CheckedContinuation<ImageUploadResult, Never>?
     private(set) var uploadCount = 0
 
-    func processAndUpload(
-        imageData _: Data,
-        request _: ImageUploadRequest
-    ) async throws -> ImageUploadResult {
+    func processAndUpload(imageData _: Data, request _: ImageUploadRequest) async throws -> ImageUploadResult {
         uploadCount += 1
         return await withCheckedContinuation { continuation in
             self.continuation = continuation

--- a/ios/Reguerta/ReguertaTests/P101ProductsFailureTests.swift
+++ b/ios/Reguerta/ReguertaTests/P101ProductsFailureTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct P101ProductsFailureTests {
-    @Test
-    func productsViewModelPreservesCatalogWhenRefreshFails() async {
+    @Test func productsViewModelPreservesCatalogWhenRefreshFails() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let originalProduct = regularProduct(
             id: "tomato",
@@ -31,8 +30,7 @@ struct P101ProductsFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableLoadData)
     }
 
-    @Test
-    func productsViewModelDoesNotShowFailureFeedbackForCancelledRefresh() async {
+    @Test func productsViewModelDoesNotShowFailureFeedbackForCancelledRefresh() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let originalProduct = regularProduct(
             id: "tomato",
@@ -53,8 +51,7 @@ struct P101ProductsFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == nil)
     }
 
-    @Test
-    func productsViewModelCompletesConfirmedSaveWithoutReadBack() async {
+    @Test func productsViewModelCompletesConfirmedSaveWithoutReadBack() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let originalProduct = regularProduct(
             id: "tomato",
@@ -83,8 +80,7 @@ struct P101ProductsFailureTests {
         #expect(repository.readCount == 0)
     }
 
-    @Test
-    func productsViewModelReusesStableIdAfterAmbiguousCreateFailure() async {
+    @Test func productsViewModelReusesStableIdAfterAmbiguousCreateFailure() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let repository = AmbiguousCreateProductRepository()
         let viewModel = await makeProductsViewModel(
@@ -115,8 +111,7 @@ struct P101ProductsFailureTests {
         #expect(pendingIdAfterFirstAttempt?.isEmpty == false)
     }
 
-    @Test
-    func productsViewModelCompletesConfirmedArchiveWithoutReadBack() async {
+    @Test func productsViewModelCompletesConfirmedArchiveWithoutReadBack() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let product = regularProduct(id: "tomato", vendorId: currentProducer.id, name: "Tomates")
         let repository = ControlledProductRepository(items: [product], rejectsReads: true)
@@ -134,8 +129,7 @@ struct P101ProductsFailureTests {
         #expect(repository.readCount == 0)
     }
 
-    @Test
-    func productsViewModelPreservesOrderingSnapshotWhenCommitmentReadFails() async {
+    @Test func productsViewModelPreservesOrderingSnapshotWhenCommitmentReadFails() async {
         let currentMember = member(id: "member_1", ecoCommitmentMode: .weekly)
         let producer = producer(id: "producer_even", parity: .even)
         let product = regularProduct(id: "visible", vendorId: producer.id, name: "Visible")
@@ -160,8 +154,7 @@ struct P101ProductsFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableLoadData)
     }
 
-    @Test
-    func confirmedVacationChangeSurvivesSecondaryRefreshFailure() async {
+    @Test func confirmedVacationChangeSurvivesSecondaryRefreshFailure() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let memberRepository = ConfirmingVisibilityMemberRepository(member: currentProducer)
         let viewModel = await makeProductsViewModel(
@@ -184,8 +177,7 @@ struct P101ProductsFailureTests {
 }
 
 extension P101ProductsFailureTests {
-    @Test
-    func staleSaveFromPreviousLoginPublishesNothing() async {
+    @Test func staleSaveFromPreviousLoginPublishesNothing() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let repository = SuspendedProductRepository()
         let viewModel = await makeProductsViewModel(
@@ -225,8 +217,7 @@ extension P101ProductsFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == nil)
     }
 
-    @Test
-    func sameIdentityAuthRefreshDoesNotInvalidateConfirmedSave() async {
+    @Test func sameIdentityAuthRefreshDoesNotInvalidateConfirmedSave() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let repository = SuspendedProductRepository()
         let viewModel = await makeProductsViewModel(
@@ -252,8 +243,7 @@ extension P101ProductsFailureTests {
         #expect(viewModel.isSaving == false)
     }
 
-    @Test
-    func cancelledNonCooperativeSavePreservesDraftAndPublishesNothing() async {
+    @Test func cancelledNonCooperativeSavePreservesDraftAndPublishesNothing() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let repository = SuspendedProductRepository()
         let viewModel = await makeProductsViewModel(
@@ -277,8 +267,7 @@ extension P101ProductsFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == nil)
     }
 
-    @Test
-    func confirmedOldEditorSaveUpdatesCatalogWithoutClobberingNewEditor() async {
+    @Test func confirmedOldEditorSaveUpdatesCatalogWithoutClobberingNewEditor() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let firstProduct = regularProduct(id: "first", vendorId: currentProducer.id, name: "Primero")
         let secondProduct = regularProduct(id: "second", vendorId: currentProducer.id, name: "Segundo")
@@ -305,8 +294,7 @@ extension P101ProductsFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == nil)
     }
 
-    @Test
-    func confirmedSavePreservesNewerDraftRevisionForSameProduct() async {
+    @Test func confirmedSavePreservesNewerDraftRevisionForSameProduct() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let product = regularProduct(id: "first", vendorId: currentProducer.id, name: "Primero")
         let repository = SuspendedProductRepository()
@@ -335,8 +323,7 @@ extension P101ProductsFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == nil)
     }
 
-    @Test
-    func staleUploadCleanupDoesNotClobberNewerDraftOrBlockEditor() async {
+    @Test func staleUploadCleanupDoesNotClobberNewerDraftOrBlockEditor() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let pipeline = SuspendedImagePipelineManager()
         let repository = ControlledProductRepository(items: [], rejectsReads: false)
@@ -377,8 +364,7 @@ extension P101ProductsFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == nil)
     }
 
-    @Test
-    func newIdentityCanSaveWhileOldIdentityWriteRemainsSuspended() async {
+    @Test func newIdentityCanSaveWhileOldIdentityWriteRemainsSuspended() async {
         let oldProducer = producer(id: "producer_old", parity: .even)
         let newProducer = producer(id: "producer_new", parity: .odd)
         let repository = MultiSuspendedProductRepository()

--- a/ios/Reguerta/ReguertaTests/P101SharedProfileFailureTests.swift
+++ b/ios/Reguerta/ReguertaTests/P101SharedProfileFailureTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct P101SharedProfileFailureTests {
-    @Test
-    func failedRefreshPreservesProfilesAndDraftAndReportsLoadError() async {
+    @Test func failedRefreshPreservesProfilesAndDraftAndReportsLoadError() async {
         let member = makeMember()
         let existing = makeProfile(familyNames: "Familia existente", about: "Último estado válido")
         let pendingDraft = SharedProfileDraft(familyNames: "Edición pendiente", about: "No debe perderse")
@@ -23,8 +22,7 @@ struct P101SharedProfileFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableLoadData)
     }
 
-    @Test
-    func confirmedSaveUpdatesLocalProfileWithoutReadBack() async {
+    @Test func confirmedSaveUpdatesLocalProfileWithoutReadBack() async {
         let member = makeMember()
         let repository = ControlledProfileRepository(items: [], rejectsReads: true)
         let viewModel = makeViewModel(member: member, repository: repository, nowMillis: 123)
@@ -40,8 +38,7 @@ struct P101SharedProfileFailureTests {
         #expect(viewModel.isSaving == false)
     }
 
-    @Test
-    func confirmedSavePreservesNewerDraftRevision() async {
+    @Test func confirmedSavePreservesNewerDraftRevision() async {
         let repository = SuspendedProfileRepository()
         let viewModel = makeViewModel(member: makeMember(), repository: repository)
         viewModel.updateDraft(SharedProfileDraft(familyNames: "Versión enviada", about: "Primera"))
@@ -58,8 +55,7 @@ struct P101SharedProfileFailureTests {
         #expect(viewModel.isSaving == false)
     }
 
-    @Test
-    func confirmedSavePublishesAfterTaskCancellation() async {
+    @Test func confirmedSavePublishesAfterTaskCancellation() async {
         let repository = SuspendedProfileRepository()
         let viewModel = makeViewModel(member: makeMember(), repository: repository)
         viewModel.updateDraft(SharedProfileDraft(familyNames: "Familia confirmada", about: "Guardado"))
@@ -74,8 +70,7 @@ struct P101SharedProfileFailureTests {
         #expect(viewModel.isSaving == false)
     }
 
-    @Test
-    func staleSaveFromPreviousLoginPublishesNothing() async {
+    @Test func staleSaveFromPreviousLoginPublishesNothing() async {
         let member = makeMember()
         let repository = SuspendedProfileRepository()
         let viewModel = makeViewModel(member: member, repository: repository)

--- a/ios/Reguerta/ReguertaTests/P101ShiftsFailureTests.swift
+++ b/ios/Reguerta/ReguertaTests/P101ShiftsFailureTests.swift
@@ -6,8 +6,7 @@ import Testing
 
 @MainActor
 struct P101ShiftsFailureTests {
-    @Test
-    func firestoreShiftContractsRejectCorruptDocuments() throws {
+    @Test func firestoreShiftContractsRejectCorruptDocuments() throws {
         let timestamp = Timestamp(date: Date(timeIntervalSince1970: 123))
         let validShift: [String: Any] = [
             "type": "delivery",
@@ -40,8 +39,7 @@ struct P101ShiftsFailureTests {
         }
     }
 
-    @Test
-    func firestoreSwapContractRejectsPartialDocuments() throws {
+    @Test func firestoreSwapContractRejectsPartialDocuments() throws {
         let timestamp = Timestamp(date: Date(timeIntervalSince1970: 123))
         let validSwap: [String: Any] = [
             "requestedShiftId": "shift_1",
@@ -69,8 +67,7 @@ struct P101ShiftsFailureTests {
         }
     }
 
-    @Test
-    func firestoreCalendarContractsRejectPartialDocuments() throws {
+    @Test func firestoreCalendarContractsRejectPartialDocuments() throws {
         let timestamp = Timestamp(date: Date(timeIntervalSince1970: 123))
         let validOverride: [String: Any] = [
             "weekKey": "2026-W20",
@@ -112,8 +109,7 @@ struct P101ShiftsFailureTests {
         }
     }
 
-    @Test
-    func refreshShiftsPreservesLastSnapshotWhenEitherReadFails() async {
+    @Test func refreshShiftsPreservesLastSnapshotWhenEitherReadFails() async {
         let member = shiftMember(id: "member_1", displayName: "Carmen")
         let previousShift = shift(
             id: "previous",
@@ -143,8 +139,7 @@ struct P101ShiftsFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableLoadData)
     }
 
-    @Test
-    func legitimateEmptyShiftReadsReplaceThePreviousSnapshot() async {
+    @Test func legitimateEmptyShiftReadsReplaceThePreviousSnapshot() async {
         let member = shiftMember(id: "member_1", displayName: "Carmen")
         let previousShift = shift(
             id: "previous",
@@ -164,8 +159,7 @@ struct P101ShiftsFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == nil)
     }
 
-    @Test
-    func refreshCalendarPreservesSnapshotWhenAReadFails() async throws {
+    @Test func refreshCalendarPreservesSnapshotWhenAReadFails() async throws {
         let admin = adminMember(id: "admin_1", displayName: "Admin")
         let existing = try #require(
             buildDeliveryCalendarOverride(
@@ -191,8 +185,7 @@ struct P101ShiftsFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableLoadData)
     }
 
-    @Test
-    func confirmedCalendarWriteSurvivesFailedReadBack() async throws {
+    @Test func confirmedCalendarWriteSurvivesFailedReadBack() async throws {
         let admin = adminMember(id: "admin_1", displayName: "Admin")
         let repository = ConfirmingCalendarWithFailingReadsRepository()
         let viewModel = makeShiftsViewModel(
@@ -215,8 +208,7 @@ struct P101ShiftsFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableLoadData)
     }
 
-    @Test
-    func confirmedSwapCreateIsNotReportedAsSaveFailureWhenReadBackFails() async {
+    @Test func confirmedSwapCreateIsNotReportedAsSaveFailureWhenReadBackFails() async {
         let requester = shiftMember(id: "requester", displayName: "Rosa")
         let candidate = shiftMember(id: "candidate", displayName: "Luis")
         let requestedShift = shift(
@@ -259,8 +251,7 @@ struct P101ShiftsFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableLoadData)
     }
 
-    @Test
-    func rejectedSwapCreatePreservesTheDraftAndReportsSaveFailure() async {
+    @Test func rejectedSwapCreatePreservesTheDraftAndReportsSaveFailure() async {
         let requester = shiftMember(id: "requester", displayName: "Rosa")
         let candidate = shiftMember(id: "candidate", displayName: "Luis")
         let requestedShift = shift(
@@ -294,8 +285,7 @@ struct P101ShiftsFailureTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableSaveChanges)
     }
 
-    @Test
-    func confirmedSwapUpdateSuppressesRetryWhenReadBackFails() async {
+    @Test func confirmedSwapUpdateSuppressesRetryWhenReadBackFails() async {
         let requester = shiftMember(id: "requester", displayName: "Rosa")
         let request = shiftSwapRequest(
             id: "swap_1",

--- a/ios/Reguerta/ReguertaTests/P101ShiftsOperationSafetyTests.swift
+++ b/ios/Reguerta/ReguertaTests/P101ShiftsOperationSafetyTests.swift
@@ -4,8 +4,7 @@ import Testing
 
 @MainActor
 struct P101ShiftsOperationSafetyTests {
-    @Test
-    func planningRetryReusesTheSameLogicalRequest() async {
+    @Test func planningRetryReusesTheSameLogicalRequest() async {
         let admin = adminMember(id: "admin_1", displayName: "Admin")
         let repository = RejectingOncePlanningRepository()
         let now = TestNowProvider(nowMillis: 111)
@@ -30,8 +29,7 @@ struct P101ShiftsOperationSafetyTests {
         #expect(viewModel.pendingShiftPlanningType == nil)
     }
 
-    @Test
-    func cancellationDoesNotPublishFailureFeedback() async {
+    @Test func cancellationDoesNotPublishFailureFeedback() async {
         let member = shiftMember(id: "member_1", displayName: "Carmen")
         let viewModel = makeShiftsViewModel(
             currentMember: member,
@@ -45,8 +43,7 @@ struct P101ShiftsOperationSafetyTests {
         #expect(viewModel.isLoadingShifts == false)
     }
 
-    @Test
-    func staleRefreshFromPreviousLoginCannotReplaceReloggedSnapshot() async {
+    @Test func staleRefreshFromPreviousLoginCannotReplaceReloggedSnapshot() async {
         let member = shiftMember(id: "member_1", displayName: "Carmen")
         let staleShift = shift(id: "stale", type: .market, dateMillis: 10, assignedUserIds: [member.id])
         let currentShift = shift(id: "current", type: .market, dateMillis: 20, assignedUserIds: [member.id])
@@ -75,8 +72,7 @@ struct P101ShiftsOperationSafetyTests {
         #expect(viewModel.feedbackCenter.messageKey == nil)
     }
 
-    @Test
-    func environmentSwitchClearsThePreviousPathAndFencesItsInFlightRead() async {
+    @Test func environmentSwitchClearsThePreviousPathAndFencesItsInFlightRead() async {
         let member = shiftMember(id: "member_1", displayName: "Carmen")
         let staleShift = shift(id: "develop", type: .market, dateMillis: 10, assignedUserIds: [member.id])
         let currentShift = shift(id: "production", type: .market, dateMillis: 20, assignedUserIds: [member.id])

--- a/ios/Reguerta/ReguertaTests/P217AuthorizedDeviceProcessAuthorizationTests.swift
+++ b/ios/Reguerta/ReguertaTests/P217AuthorizedDeviceProcessAuthorizationTests.swift
@@ -6,8 +6,7 @@ import Testing
 
 @MainActor
 struct P217AuthorizedDeviceProcessAuthorizationTests {
-    @Test
-    func coldProcessStoresTokenWithoutAdoptingPersistedAuthorization() async throws {
+    @Test func coldProcessStoresTokenWithoutAdoptingPersistedAuthorization() async throws {
         let harness = makeHarness()
         let context = AuthorizedDeviceSessionContext(
             memberId: "member-a",
@@ -23,8 +22,7 @@ struct P217AuthorizedDeviceProcessAuthorizationTests {
         #expect(harness.repository.registrations.isEmpty)
     }
 
-    @Test
-    func liveAuthorizationAllowsSubsequentTokenRefresh() async throws {
+    @Test func liveAuthorizationAllowsSubsequentTokenRefresh() async throws {
         let sessionFence = P217CurrentSessionFence(true)
         let harness = makeHarness()
 
@@ -38,8 +36,7 @@ struct P217AuthorizedDeviceProcessAuthorizationTests {
         #expect(harness.repository.registrations.map(\.fcmToken) == ["token", "token-b"])
     }
 
-    @Test
-    func sessionFenceInvalidationDuringTokenUploadPreventsCommit() async throws {
+    @Test func sessionFenceInvalidationDuringTokenUploadPreventsCommit() async throws {
         let started = P217TestSignal()
         let release = P217TestGate()
         let repository = P217RecordingDeviceRegistrationRepository(
@@ -65,8 +62,7 @@ struct P217AuthorizedDeviceProcessAuthorizationTests {
         #expect(repository.registrations.map(\.fcmToken) == ["token"])
     }
 
-    @Test
-    func supersededTokenUpdateCannotCommitAfterTheNewestToken() async throws {
+    @Test func supersededTokenUpdateCannotCommitAfterTheNewestToken() async throws {
         let started = P217TestSignal()
         let release = P217TestGate()
         let repository = P217RecordingDeviceRegistrationRepository(
@@ -158,11 +154,7 @@ private final class P217RecordingDeviceRegistrationRepository: DeviceRegistratio
     private let release: P217TestGate?
     var registrations: [P217RecordedDeviceRegistration] = []
 
-    init(
-        suspendedToken: String? = nil,
-        started: P217TestSignal? = nil,
-        release: P217TestGate? = nil
-    ) {
+    init(suspendedToken: String? = nil, started: P217TestSignal? = nil, release: P217TestGate? = nil) {
         self.suspendedToken = suspendedToken
         self.started = started
         self.release = release

--- a/ios/Reguerta/ReguertaTests/ProductsOrderingRefreshGenerationTests.swift
+++ b/ios/Reguerta/ReguertaTests/ProductsOrderingRefreshGenerationTests.swift
@@ -293,8 +293,7 @@ struct ProductsOrderingRefreshGenerationTests {
     }
 }
 
-@MainActor
-private func refreshScope(in viewModel: ProductsRouteViewModel) -> CriticalDataRefreshScope? {
+@MainActor private func refreshScope(in viewModel: ProductsRouteViewModel) -> CriticalDataRefreshScope? {
     guard case .authorized(let session) = viewModel.sessionViewModel.mode else { return nil }
     return CriticalDataRefreshScope(
         principalUID: session.principal.uid,

--- a/ios/Reguerta/ReguertaTests/ReguertaColorContrastTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaColorContrastTests.swift
@@ -90,8 +90,7 @@ struct ReguertaColorContrastTests {
         }
     }
 
-    @Test
-    func productionButtonPressedStatePreservesOpacity() {
+    @Test func productionButtonPressedStatePreservesOpacity() {
         let normal = ReguertaContrastContract.buttonVisualState(isPressed: false)
         let pressed = ReguertaContrastContract.buttonVisualState(isPressed: true)
 
@@ -219,8 +218,7 @@ enum TextContrastCase: CaseIterable {
     case contentOnError
     case pressedContentOnError
 
-    @MainActor
-    func sample(for appearance: ContrastAppearance) throws -> ContrastSample {
+    @MainActor func sample(for appearance: ContrastAppearance) throws -> ContrastSample {
         switch self {
         case .actionOnPrimarySurface,
              .actionOnSecondarySurface,
@@ -239,8 +237,7 @@ enum TextContrastCase: CaseIterable {
         }
     }
 
-    @MainActor
-    private func actionSample(for appearance: ContrastAppearance) throws -> ContrastSample {
+    @MainActor private func actionSample(for appearance: ContrastAppearance) throws -> ContrastSample {
         let action = try ResolvedColor.asset(.actionPrimary, appearance: appearance)
         let actionContent = try ResolvedColor.asset(.mainBack, appearance: appearance)
         let primarySurface = actionContent
@@ -285,8 +282,7 @@ enum TextContrastCase: CaseIterable {
         }
     }
 
-    @MainActor
-    private func feedbackSample(for appearance: ContrastAppearance) throws -> ContrastSample {
+    @MainActor private func feedbackSample(for appearance: ContrastAppearance) throws -> ContrastSample {
         let primarySurface = try ResolvedColor.asset(.mainBack, appearance: appearance)
         let secondarySurface = try ResolvedColor.asset(.secBack, appearance: appearance)
         let warning = try ResolvedColor.asset(.warning, appearance: appearance)
@@ -327,8 +323,7 @@ enum NonTextContrastCase: CaseIterable {
     case controlTrackAgainstSecondarySurface
     case whiteThumbAgainstControlTrack
 
-    @MainActor
-    func sample(for appearance: ContrastAppearance) throws -> ContrastSample {
+    @MainActor func sample(for appearance: ContrastAppearance) throws -> ContrastSample {
         let controlAccent = try ResolvedColor.asset(.controlAccent, appearance: appearance)
 
         return switch self {
@@ -371,11 +366,7 @@ struct ResolvedColor: Equatable {
 
     static let white = ResolvedColor(red: 1, green: 1, blue: 1)
 
-    @MainActor
-    static func asset(
-        _ asset: ColorAsset,
-        appearance: ContrastAppearance
-    ) throws -> ResolvedColor {
+    @MainActor static func asset(_ asset: ColorAsset, appearance: ContrastAppearance) throws -> ResolvedColor {
         let traits = appearance.traitCollection
         guard let color = UIColor(
             named: asset.rawValue,
@@ -401,11 +392,7 @@ struct ResolvedColor: Equatable {
         )
     }
 
-    @MainActor
-    static func swiftUIColor(
-        _ color: Color,
-        appearance: ContrastAppearance
-    ) throws -> ResolvedColor {
+    @MainActor static func swiftUIColor(_ color: Color, appearance: ContrastAppearance) throws -> ResolvedColor {
         let resolved = UIColor(color).resolvedColor(with: appearance.traitCollection)
         var red: CGFloat = 0
         var green: CGFloat = 0

--- a/ios/Reguerta/ReguertaTests/ReguertaCurrencyFormattingTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaCurrencyFormattingTests.swift
@@ -4,8 +4,7 @@ import Testing
 @testable import Reguerta
 
 struct ReguertaCurrencyFormattingTests {
-    @Test
-    func presentationLocaleUsesTheAppLanguageInsteadOfTheSystemRegion() {
+    @Test func presentationLocaleUsesTheAppLanguageInsteadOfTheSystemRegion() {
         let locale = reguertaPresentationLocale(
             preferredLocalizations: ["en"],
             fallback: Locale(identifier: "es_ES")
@@ -17,24 +16,21 @@ struct ReguertaCurrencyFormattingTests {
         #expect(formatted.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("€"))
     }
 
-    @Test
-    func euroCurrencyTextUsesSpanishDecimalSeparatorAndTrailingSymbol() {
+    @Test func euroCurrencyTextUsesSpanishDecimalSeparatorAndTrailingSymbol() {
         let formatted = 12.5.euroCurrencyText(locale: Locale(identifier: "es_ES"))
 
         #expect(formatted.contains("12,50"))
         #expect(formatted.trimmingCharacters(in: .whitespacesAndNewlines).hasSuffix("€"))
     }
 
-    @Test
-    func euroCurrencyTextUsesEnglishDecimalSeparatorAndLeadingSymbol() {
+    @Test func euroCurrencyTextUsesEnglishDecimalSeparatorAndLeadingSymbol() {
         let formatted = 12.5.euroCurrencyText(locale: Locale(identifier: "en_US"))
 
         #expect(formatted.contains("12.50"))
         #expect(formatted.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("€"))
     }
 
-    @Test
-    func productUIDecimalUsesLocaleDecimalSeparator() {
+    @Test func productUIDecimalUsesLocaleDecimalSeparator() {
         #expect(12.5.productUIDecimal(locale: Locale(identifier: "es_ES")) == "12,5")
         #expect(12.5.productUIDecimal(locale: Locale(identifier: "en_US")) == "12.5")
         #expect(1e300.productUIDecimal(locale: Locale(identifier: "en_US")) == "1e+300")
@@ -44,8 +40,7 @@ struct ReguertaCurrencyFormattingTests {
         )
     }
 
-    @Test
-    func orderQuantityUsesUpToThreeDecimalsWithoutTrailingZeros() {
+    @Test func orderQuantityUsesUpToThreeDecimalsWithoutTrailingZeros() {
         let english = Locale(identifier: "en_US")
         let spanish = Locale(identifier: "es_ES")
 

--- a/ios/Reguerta/ReguertaTests/ReguertaHomeNavigationTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaHomeNavigationTests.swift
@@ -4,8 +4,7 @@ import Testing
 
 @MainActor
 struct ReguertaHomeNavigationTests {
-    @Test
-    func notificationEditorBackReturnsToDashboard() {
+    @Test func notificationEditorBackReturnsToDashboard() {
         let rootViewModel = ReguertaAppEnvironment.preview().accessRootViewModel
         rootViewModel.homeDestination = .adminBroadcast
 

--- a/ios/Reguerta/ReguertaTests/ReguertaHomeSummaryTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaHomeSummaryTests.swift
@@ -11,8 +11,7 @@ private let spanishHomeLocalization = HomeWeeklySummaryLocalization(
 
 @MainActor
 struct ReguertaHomeSummaryTests {
-    @Test
-    func homeWeeklySummaryUsesCurrentWeekBeforeDelivery() {
+    @Test func homeWeeklySummaryUsesCurrentWeekBeforeDelivery() {
         let display = resolveHomeWeeklySummaryDisplay(
             nowMillis: testMillis(year: 2026, month: 5, day: 6),
             defaultDeliveryDayOfWeek: .friday,
@@ -32,8 +31,7 @@ struct ReguertaHomeSummaryTests {
         #expect(display.helperName == "Javier")
     }
 
-    @Test
-    func homeWeeklySummaryKeepsScheduledProducerWhileVacationModeIsEnabled() {
+    @Test func homeWeeklySummaryKeepsScheduledProducerWhileVacationModeIsEnabled() {
         let vacationMembers = homeSummaryMembers.map { member in
             guard member.id == "producer_2" else { return member }
             return Member(
@@ -64,8 +62,7 @@ struct ReguertaHomeSummaryTests {
         #expect(display.producerName == "Huerta Sur")
     }
 
-    @Test
-    func homeWeeklySummaryMovesToNextWeekAfterDelivery() {
+    @Test func homeWeeklySummaryMovesToNextWeekAfterDelivery() {
         let display = resolveHomeWeeklySummaryDisplay(
             nowMillis: testMillis(year: 2026, month: 5, day: 9),
             defaultDeliveryDayOfWeek: .friday,
@@ -86,8 +83,7 @@ struct ReguertaHomeSummaryTests {
         #expect(display.myOrderSubtitleKey == AccessL10nKey.homeDashboardMyOrderSubtitleEdit)
     }
 
-    @Test
-    func homeWeeklySummaryAfterWednesdayDeliveryUsesNextDeliveryCycleAndCurrentMarket() {
+    @Test func homeWeeklySummaryAfterWednesdayDeliveryUsesNextDeliveryCycleAndCurrentMarket() {
         let display = resolveHomeWeeklySummaryDisplay(
             nowMillis: testMillis(year: 2026, month: 5, day: 14),
             defaultDeliveryDayOfWeek: .friday,
@@ -126,8 +122,7 @@ struct ReguertaHomeSummaryTests {
         #expect(display.marketResponsibleNames == ["Valle", "Angeles", "Sandra"])
     }
 
-    @Test
-    func homeWeeklySummaryMarketMovesToNextShiftTheDayAfterMarket() {
+    @Test func homeWeeklySummaryMarketMovesToNextShiftTheDayAfterMarket() {
         let display = resolveHomeWeeklySummaryDisplay(
             nowMillis: testMillis(year: 2026, month: 5, day: 17),
             defaultDeliveryDayOfWeek: .friday,
@@ -159,8 +154,7 @@ struct ReguertaHomeSummaryTests {
         #expect(display.marketResponsibleNames == ["Angeles", "Sandra", "Valle"])
     }
 
-    @Test
-    func homeWeeklySummaryUsesWednesdayWhenNoDeliveryCalendarOverrideEvenIfShiftIsLater() {
+    @Test func homeWeeklySummaryUsesWednesdayWhenNoDeliveryCalendarOverrideEvenIfShiftIsLater() {
         let display = resolveHomeWeeklySummaryDisplay(
             nowMillis: testMillis(year: 2026, month: 7, day: 7),
             defaultDeliveryDayOfWeek: .wednesday,
@@ -176,8 +170,7 @@ struct ReguertaHomeSummaryTests {
         #expect(display.helperName == "Javier")
     }
 
-    @Test
-    func homeWeeklySummaryUsesDeliveryCalendarOverrideWhenPresent() {
+    @Test func homeWeeklySummaryUsesDeliveryCalendarOverrideWhenPresent() {
         let override = DeliveryCalendarOverride(
             weekKey: "2026-W28",
             deliveryDateMillis: testMillis(year: 2026, month: 7, day: 9),
@@ -202,8 +195,7 @@ struct ReguertaHomeSummaryTests {
         #expect(display.helperName == "Javier")
     }
 
-    @Test
-    func homeWeeklySummaryUsesEnglishLocaleAndSkipsSummerMarkets() {
+    @Test func homeWeeklySummaryUsesEnglishLocaleAndSkipsSummerMarkets() {
         let nowMillis = testMillis(year: 2026, month: 7, day: 11)
         let display = resolveHomeWeeklySummaryDisplay(
             nowMillis: nowMillis,
@@ -228,8 +220,7 @@ struct ReguertaHomeSummaryTests {
         #expect(display.marketResponsibleNames == ["Pending"])
     }
 
-    @Test
-    func homeOrderStateMappingUsesConfirmedBeforeDraft() {
+    @Test func homeOrderStateMappingUsesConfirmedBeforeDraft() {
         let suiteName = "home-order-state-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defer {
@@ -245,8 +236,7 @@ struct ReguertaHomeSummaryTests {
         #expect(resolveHomeOrderState(userDefaults: defaults, memberId: "member_1", weekKey: "2026-W19") == .completed)
     }
 
-    @Test
-    func homeDisplayedOrderStateUsesConsultationBeforeDelivery() {
+    @Test func homeDisplayedOrderStateUsesConsultationBeforeDelivery() {
         #expect(resolveHomeDisplayedOrderState(isConsultaPhase: true, orderState: .notStarted) == .consultation)
         #expect(resolveHomeDisplayedOrderState(isConsultaPhase: true, orderState: .unconfirmed) == .consultation)
         #expect(resolveHomeDisplayedOrderState(isConsultaPhase: false, orderState: .notStarted) == .notStarted)

--- a/ios/Reguerta/ReguertaTests/ReguertaMyOrderRestorationTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaMyOrderRestorationTests.swift
@@ -4,8 +4,7 @@ import Testing
 
 @MainActor
 struct ReguertaMyOrderRestorationTests {
-    @Test
-    func myOrderViewModelKeepsRestoredDraftWhileProductsLoad() async {
+    @Test func myOrderViewModelKeepsRestoredDraftWhileProductsLoad() async {
         let cartStore = InMemoryMyOrderCartStore()
         let product = regularProduct(id: "tomato", vendorId: "producer_even", name: "Tomates")
         let storageKey = "member_member_1_week_2026-W20"
@@ -28,8 +27,7 @@ struct ReguertaMyOrderRestorationTests {
         #expect(viewModel.selectedUnits == 2)
     }
 
-    @Test
-    func myOrderViewModelKeepsRestoredDraftBeforeProductRefreshStarts() async {
+    @Test func myOrderViewModelKeepsRestoredDraftBeforeProductRefreshStarts() async {
         let cartStore = InMemoryMyOrderCartStore()
         let product = regularProduct(id: "tomato", vendorId: "producer_even", name: "Tomates")
         let storageKey = "member_member_1_week_2026-W20"
@@ -52,8 +50,7 @@ struct ReguertaMyOrderRestorationTests {
         #expect(viewModel.selectedUnits == 2)
     }
 
-    @Test
-    func myOrderViewModelRestoresCartAndConfirmedOrderFromStore() async {
+    @Test func myOrderViewModelRestoresCartAndConfirmedOrderFromStore() async {
         let repository = InMemoryOrdersRepository()
         let cartStore = InMemoryMyOrderCartStore()
         let product = regularProduct(id: "tomato", vendorId: "producer_even", name: "Tomates")

--- a/ios/Reguerta/ReguertaTests/ReguertaNewsNotificationsViewModelSavingTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaNewsNotificationsViewModelSavingTests.swift
@@ -4,8 +4,7 @@ import Testing
 
 @MainActor
 struct ReguertaNewsNotificationsViewModelSavingTests {
-    @Test
-    func newsViewModelSavesNewAndEditedNewsWithExistingMetadataRules() async throws {
+    @Test func newsViewModelSavesNewAndEditedNewsWithExistingMetadataRules() async throws {
         let admin = savingTestAdminMember(displayName: "Ana Admin")
         let repository = InMemoryNewsRepository(items: [])
         let viewModel = makeSavingNewsViewModel(
@@ -88,8 +87,7 @@ private func makeSavingNewsViewModel(
     return viewModel
 }
 
-@MainActor
-private func savingTestAdminMember(displayName: String) -> Member {
+@MainActor private func savingTestAdminMember(displayName: String) -> Member {
     Member(
         id: "admin",
         displayName: displayName,

--- a/ios/Reguerta/ReguertaTests/ReguertaNewsNotificationsViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaNewsNotificationsViewModelTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct ReguertaNewsNotificationsViewModelTests {
-    @Test
-    func newsViewModelLoadsNewsByPermissionAndComputesLatestActiveNews() async {
+    @Test func newsViewModelLoadsNewsByPermissionAndComputesLatestActiveNews() async {
         let admin = newsAdminMember()
         let regular = newsRegularMember()
         let articles = [
@@ -35,8 +34,7 @@ struct ReguertaNewsNotificationsViewModelTests {
         #expect(regularViewModel.newsFeed.map(\.id) == ["active_4", "active_3", "active_2", "active_1"])
     }
 
-    @Test
-    func newsListPresentationCarriesMetadataArchivedStateAndImagePlacement() {
+    @Test func newsListPresentationCarriesMetadataArchivedStateAndImagePlacement() {
         let article = newsArticle(
             id: "archived",
             title: "Archived",
@@ -64,8 +62,7 @@ struct ReguertaNewsNotificationsViewModelTests {
         #expect(item.cardAccessibilityIdentifier == "news.list.articleCard.archived")
     }
 
-    @Test
-    func newsNotificationsViewModelResetsStateWhenSessionLeavesAuthorizedMode() {
+    @Test func newsNotificationsViewModelResetsStateWhenSessionLeavesAuthorizedMode() {
         let admin = newsAdminMember()
         let viewModel = makeNewsNotificationsViewModel(currentMember: admin, members: [admin])
         viewModel.newsFeed = [newsArticle(id: "news")]
@@ -92,8 +89,7 @@ struct ReguertaNewsNotificationsViewModelTests {
         #expect(viewModel.isSendingNotification == false)
     }
 
-    @Test
-    func newsViewModelInitializesEditsNormalizesDraftAndClearsEditor() async {
+    @Test func newsViewModelInitializesEditsNormalizesDraftAndClearsEditor() async {
         let admin = newsAdminMember()
         let article = newsArticle(id: "news_1", title: "Title", body: "Body", urlImage: "https://cdn.test/news.jpg")
         let viewModel = makeNewsNotificationsViewModel(
@@ -119,8 +115,7 @@ struct ReguertaNewsNotificationsViewModelTests {
         #expect(viewModel.newsDraft == NewsDraft())
     }
 
-    @Test
-    func newsViewModelBlocksInvalidSaveInput() async {
+    @Test func newsViewModelBlocksInvalidSaveInput() async {
         let admin = newsAdminMember()
         let viewModel = makeNewsNotificationsViewModel(currentMember: admin, members: [admin])
 
@@ -136,8 +131,7 @@ struct ReguertaNewsNotificationsViewModelTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackNewsTitleBodyRequired)
     }
 
-    @Test
-    func newsViewModelDeletesNewsAndClearsEditorWhenEditingDeletedArticle() async {
+    @Test func newsViewModelDeletesNewsAndClearsEditorWhenEditingDeletedArticle() async {
         let admin = newsAdminMember()
         let article = newsArticle(id: "delete_me")
         let repository = InMemoryNewsRepository(items: [article])
@@ -159,8 +153,7 @@ struct ReguertaNewsNotificationsViewModelTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackNewsDeleted)
     }
 
-    @Test
-    func newsViewModelUploadsImageAndShowsFeedbackOnFailure() async {
+    @Test func newsViewModelUploadsImageAndShowsFeedbackOnFailure() async {
         let admin = newsAdminMember()
         let successViewModel = makeNewsNotificationsViewModel(
             currentMember: admin,
@@ -183,8 +176,7 @@ struct ReguertaNewsNotificationsViewModelTests {
         #expect(failureViewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableSaveChanges)
     }
 
-    @Test
-    func notificationsViewModelLoadsNotificationsVisibleToCurrentAudience() async {
+    @Test func notificationsViewModelLoadsNotificationsVisibleToCurrentAudience() async {
         let regular = newsRegularMember(id: "member_1")
         let repository = InMemoryNotificationRepository(
             items: [
@@ -206,8 +198,7 @@ struct ReguertaNewsNotificationsViewModelTests {
         #expect(viewModel.notificationsFeed.map(\.id) == ["user", "members", "all"])
     }
 
-    @Test
-    func notificationsViewModelCombinesVisibleNotificationsWithReadState() async {
+    @Test func notificationsViewModelCombinesVisibleNotificationsWithReadState() async {
         let regular = newsRegularMember(id: "member_1")
         let repository = InMemoryNotificationRepository(
             items: [
@@ -229,8 +220,7 @@ struct ReguertaNewsNotificationsViewModelTests {
         #expect(viewModel.hasUnreadNotifications)
     }
 
-    @Test
-    func notificationsViewModelMarksVisibleNotificationsReadOnExit() async {
+    @Test func notificationsViewModelMarksVisibleNotificationsReadOnExit() async {
         let regular = newsRegularMember(id: "member_1")
         let repository = InMemoryNotificationRepository(
             items: [
@@ -253,8 +243,7 @@ struct ReguertaNewsNotificationsViewModelTests {
         #expect(!viewModel.hasUnreadNotifications)
     }
 
-    @Test
-    func notificationsViewModelShowsPushPermissionDialogPerVisitWhenInactive() async {
+    @Test func notificationsViewModelShowsPushPermissionDialogPerVisitWhenInactive() async {
         let regular = newsRegularMember(id: "member_1")
         let viewModel = makeNewsNotificationsViewModel(
             currentMember: regular,
@@ -277,8 +266,7 @@ struct ReguertaNewsNotificationsViewModelTests {
         #expect(viewModel.showsPushNotificationPermissionDialog)
     }
 
-    @Test
-    func notificationsViewModelBlocksInvalidOrUnauthorizedSend() async {
+    @Test func notificationsViewModelBlocksInvalidOrUnauthorizedSend() async {
         let regular = newsRegularMember()
         let regularViewModel = makeNewsNotificationsViewModel(currentMember: regular, members: [regular])
 
@@ -297,8 +285,7 @@ struct ReguertaNewsNotificationsViewModelTests {
         #expect(adminViewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackNotificationTitleBodyRequired)
     }
 
-    @Test
-    func notificationsViewModelSendsAdminBroadcastPayloadAndClearsDraft() async {
+    @Test func notificationsViewModelSendsAdminBroadcastPayloadAndClearsDraft() async {
         let admin = newsAdminMember(id: "admin_1")
         let repository = InMemoryNotificationRepository(items: [])
         let viewModel = makeNewsNotificationsViewModel(
@@ -389,11 +376,7 @@ private func makeNewsNotificationsViewModel(
     return viewModel
 }
 
-@MainActor
-private func newsAdminMember(
-    id: String = "admin",
-    displayName: String = "Admin"
-) -> Member {
+@MainActor private func newsAdminMember(id: String = "admin", displayName: String = "Admin") -> Member {
     Member(
         id: id,
         displayName: displayName,
@@ -405,8 +388,7 @@ private func newsAdminMember(
     )
 }
 
-@MainActor
-private func newsRegularMember(id: String = "member") -> Member {
+@MainActor private func newsRegularMember(id: String = "member") -> Member {
     Member(
         id: id,
         displayName: "Member",
@@ -478,10 +460,7 @@ private actor NewsMockImagePipelineManager: ImagePipelineManager {
         self.result = result
     }
 
-    func processAndUpload(
-        imageData _: Data,
-        request _: ImageUploadRequest
-    ) async throws -> ImageUploadResult {
+    func processAndUpload(imageData _: Data, request _: ImageUploadRequest) async throws -> ImageUploadResult {
         switch result {
         case .success(let downloadURL):
             ImageUploadResult(

--- a/ios/Reguerta/ReguertaTests/ReguertaOrderAndHomeTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaOrderAndHomeTests.swift
@@ -6,8 +6,7 @@ import Testing
 
 @MainActor
 struct ReguertaOrderAndHomeTests {
-    @Test
-    func myOrderValidationDoesNotRequireBiweeklyCommitmentOnOppositeWeek() {
+    @Test func myOrderValidationDoesNotRequireBiweeklyCommitmentOnOppositeWeek() {
         let currentMember = member(
             id: "member_1",
             ecoCommitmentMode: .biweekly,
@@ -30,8 +29,7 @@ struct ReguertaOrderAndHomeTests {
         #expect(result.missingCommitmentProductNames.isEmpty)
     }
 
-    @Test
-    func myOrderValidationBlocksMissingSeasonalCommitmentProduct() {
+    @Test func myOrderValidationBlocksMissingSeasonalCommitmentProduct() {
         let currentMember = member(id: "member_1", ecoCommitmentMode: .weekly)
         let producerEven = producer(id: "producer_even", parity: .even)
         let avocados = regularProduct(id: "seasonal_avocado", vendorId: producerEven.id, name: "Aguacates")
@@ -50,8 +48,7 @@ struct ReguertaOrderAndHomeTests {
         #expect(result.missingCommitmentProductNames == ["Aguacates"])
     }
 
-    @Test
-    func myOrderValidationBlocksExceededSeasonalCommitmentQuantity() {
+    @Test func myOrderValidationBlocksExceededSeasonalCommitmentQuantity() {
         let currentMember = member(id: "member_1", ecoCommitmentMode: .weekly)
         let producerEven = producer(id: "producer_even", parity: .even)
         let avocados = regularProduct(id: "seasonal_avocado", vendorId: producerEven.id, name: "Aguacates")
@@ -70,8 +67,7 @@ struct ReguertaOrderAndHomeTests {
         #expect(result.exceededCommitmentProductNames == ["Aguacates"])
     }
 
-    @Test
-    func myOrderValidationFlagsIncompatibleSeasonalCommitmentStep() {
+    @Test func myOrderValidationFlagsIncompatibleSeasonalCommitmentStep() {
         let currentMember = member(id: "member_1", ecoCommitmentMode: .weekly)
         let producerEven = producer(id: "producer_even", parity: .even)
         var avocados = regularProduct(id: "seasonal_avocado", vendorId: producerEven.id, name: "Aguacates")
@@ -117,8 +113,7 @@ struct ReguertaOrderAndHomeTests {
         #expect(result.incompatibleCommitmentProductNames == ["Aguacates"])
     }
 
-    @Test
-    func myOrderValidationIgnoresSeasonalCommitmentWhenProductNotOffered() {
+    @Test func myOrderValidationIgnoresSeasonalCommitmentWhenProductNotOffered() {
         let currentMember = member(id: "member_1", ecoCommitmentMode: .weekly)
 
         let result = validateMyOrderCheckout(
@@ -135,8 +130,7 @@ struct ReguertaOrderAndHomeTests {
         #expect(result.missingCommitmentProductNames.isEmpty)
     }
 
-    @Test
-    func myOrderValidationBlocksMissingSeasonalCommitmentUsingSeasonKeyFallback() {
+    @Test func myOrderValidationBlocksMissingSeasonalCommitmentUsingSeasonKeyFallback() {
         let currentMember = member(id: "member_1", ecoCommitmentMode: .weekly)
         let avocados = regularProduct(
             id: "product_common_avocado",
@@ -164,8 +158,7 @@ struct ReguertaOrderAndHomeTests {
         #expect(result.missingCommitmentProductNames == ["Aguacates"])
     }
 
-    @Test
-    func myOrderValidationBlocksMissingSeasonalCommitmentUsingSeasonCodeFallback() {
+    @Test func myOrderValidationBlocksMissingSeasonalCommitmentUsingSeasonCodeFallback() {
         let currentMember = member(id: "member_1", ecoCommitmentMode: .weekly)
         let avocados = regularProduct(
             id: "product_common_avocado",
@@ -193,8 +186,7 @@ struct ReguertaOrderAndHomeTests {
         #expect(result.missingCommitmentProductNames == ["Aguacates"])
     }
 
-    @Test
-    func myOrderValidationBlocksExceededSeasonalCommitmentUsingSeasonCodeFallback() {
+    @Test func myOrderValidationBlocksExceededSeasonalCommitmentUsingSeasonCodeFallback() {
         let currentMember = member(id: "member_1", ecoCommitmentMode: .weekly)
         let avocados = regularProduct(
             id: "product_common_avocado",
@@ -222,8 +214,7 @@ struct ReguertaOrderAndHomeTests {
         #expect(result.exceededCommitmentProductNames == ["Aguacates"])
     }
 
-    @Test
-    func myOrderValidationFlagsEcoBasketPriceMismatch() {
+    @Test func myOrderValidationFlagsEcoBasketPriceMismatch() {
         let currentMember = member(id: "member_1", ecoCommitmentMode: .weekly)
         let producerEven = producer(id: "producer_even", parity: .even)
         let producerOdd = producer(id: "producer_odd", parity: .odd)
@@ -241,8 +232,7 @@ struct ReguertaOrderAndHomeTests {
         #expect(result.hasEcoBasketPriceMismatch == true)
     }
 
-    @Test
-    func seasonalCommitmentLookupKeysIncludeMemberIdAuthUIDAndEmail() {
+    @Test func seasonalCommitmentLookupKeysIncludeMemberIdAuthUIDAndEmail() {
         let member = Member(
             id: "member_1",
             displayName: "Member",
@@ -256,8 +246,7 @@ struct ReguertaOrderAndHomeTests {
         #expect(member.seasonalCommitmentLookupKeys == ["member_1", "uid_member_1", "member_1@reguerta.app"])
     }
 
-    @Test
-    func seasonalCommitmentLookupKeysRemoveDuplicatesAndBlanks() {
+    @Test func seasonalCommitmentLookupKeysRemoveDuplicatesAndBlanks() {
         let member = Member(
             id: "member_1",
             displayName: "Member",

--- a/ios/Reguerta/ReguertaTests/ReguertaOrdersHistoryViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaOrdersHistoryViewModelTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct ReguertaOrdersHistoryViewModelTests {
-    @Test
-    func myOrdersHistoryPresentationUsesTheActiveEnglishLocale() throws {
+    @Test func myOrdersHistoryPresentationUsesTheActiveEnglishLocale() throws {
         let option = try #require(
             orderHistoryWeekOption(
                 weekKey: "2026-W27",
@@ -27,8 +26,7 @@ struct ReguertaOrdersHistoryViewModelTests {
         #expect(presentation.orderTitle == "Order Jun 29 - Jul 5")
     }
 
-    @Test
-    func orderSummariesLocalizeGenericUnitLabelsOnly() {
+    @Test func orderSummariesLocalizeGenericUnitLabelsOnly() {
         #expect(
             localizedGenericOrderHistoryQuantityLabel(
                 "1 ud.",
@@ -59,8 +57,7 @@ struct ReguertaOrdersHistoryViewModelTests {
         )
     }
 
-    @Test
-    func myOrdersHistorySelectsPreviousIsoWeekAndFormatsHeader() async {
+    @Test func myOrdersHistorySelectsPreviousIsoWeekAndFormatsHeader() async {
         let repository = InMemoryOrdersRepository()
         await repository.setOrderHistoryWeekKeys(["2026-W21"], forMemberId: "member_1")
         await repository.setPreviousOrder(previousOrderSnapshot(weekKey: "2026-W21"), forWeekKey: "2026-W21")
@@ -80,8 +77,7 @@ struct ReguertaOrdersHistoryViewModelTests {
         #expect(snapshot.weekKey == "2026-W21")
     }
 
-    @Test
-    func myOrdersHistoryBuildsContinuousPickerWeeksAndShowsIntermediateEmptyWeek() async {
+    @Test func myOrdersHistoryBuildsContinuousPickerWeeksAndShowsIntermediateEmptyWeek() async {
         let repository = InMemoryOrdersRepository()
         await repository.setOrderHistoryWeekKeys(["2026-W19", "2026-W21"], forMemberId: "member_1")
         await repository.setPreviousOrder(previousOrderSnapshot(weekKey: "2026-W19"), forWeekKey: "2026-W19")
@@ -109,8 +105,7 @@ struct ReguertaOrdersHistoryViewModelTests {
         #expect(snapshot.weekKey == "2026-W19")
     }
 
-    @Test
-    func myOrdersHistoryRetryKeepsSelectedWeek() async {
+    @Test func myOrdersHistoryRetryKeepsSelectedWeek() async {
         let repository = InMemoryOrdersRepository()
         await repository.setOrderHistoryWeekKeys(["2026-W21"], forMemberId: "member_1")
         let viewModel = makeMyOrdersHistoryViewModel(repository: repository)

--- a/ios/Reguerta/ReguertaTests/ReguertaOrdersViewModelTestSupport.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaOrdersViewModelTestSupport.swift
@@ -41,9 +41,7 @@ func makeReceivedOrdersHistoryViewModel(
 }
 
 @MainActor
-func makeMyOrdersHistoryViewModel(
-    repository: InMemoryOrdersRepository? = nil
-) -> MyOrdersHistoryRouteViewModel {
+func makeMyOrdersHistoryViewModel(repository: InMemoryOrdersRepository? = nil) -> MyOrdersHistoryRouteViewModel {
     MyOrdersHistoryRouteViewModel(
         sessionViewModel: SessionViewModel(dependencies: .preview()),
         ordersRepository: repository ?? InMemoryOrdersRepository()
@@ -73,22 +71,14 @@ func myOrderContext(
     )
 }
 
-@MainActor
-func myOrdersHistoryContext(
-    nowMillis: Int64,
-    currentMember: Member? = nil
-) -> MyOrdersHistoryRouteContext {
+@MainActor func myOrdersHistoryContext(nowMillis: Int64, currentMember: Member? = nil) -> MyOrdersHistoryRouteContext {
     MyOrdersHistoryRouteContext(
         currentMember: currentMember ?? member(id: "member_1", ecoCommitmentMode: .weekly),
         nowMillis: nowMillis
     )
 }
 
-@MainActor
-func receivedOrdersContext(
-    currentMember: Member,
-    nowMillis: Int64
-) -> ReceivedOrdersRouteContext {
+@MainActor func receivedOrdersContext(currentMember: Member, nowMillis: Int64) -> ReceivedOrdersRouteContext {
     ReceivedOrdersRouteContext(
         currentMember: currentMember,
         shifts: [],
@@ -99,18 +89,14 @@ func receivedOrdersContext(
 }
 
 @MainActor
-func receivedOrdersHistoryContext(
-    nowMillis: Int64,
-    currentMember: Member? = nil
-) -> ReceivedOrdersHistoryRouteContext {
+func receivedOrdersHistoryContext(nowMillis: Int64, currentMember: Member? = nil) -> ReceivedOrdersHistoryRouteContext {
     ReceivedOrdersHistoryRouteContext(
         currentMember: currentMember ?? producer(id: "producer_even", parity: .even),
         nowMillis: nowMillis
     )
 }
 
-@MainActor
-func previousOrderSnapshot(weekKey: String) -> MyOrderPreviousOrderSnapshot {
+@MainActor func previousOrderSnapshot(weekKey: String) -> MyOrderPreviousOrderSnapshot {
     MyOrderPreviousOrderSnapshot(
         weekKey: weekKey,
         groups: [
@@ -134,8 +120,7 @@ func previousOrderSnapshot(weekKey: String) -> MyOrderPreviousOrderSnapshot {
     )
 }
 
-@MainActor
-func finiteStockProduct(_ product: Product, stock: Double) -> Product {
+@MainActor func finiteStockProduct(_ product: Product, stock: Double) -> Product {
     Product(
         id: product.id,
         vendorId: product.vendorId,
@@ -165,8 +150,7 @@ func finiteStockProduct(_ product: Product, stock: Double) -> Product {
     )
 }
 
-@MainActor
-func receivedOrdersSnapshot(status: ProducerOrderStatus) -> ReceivedOrdersSnapshot {
+@MainActor func receivedOrdersSnapshot(status: ProducerOrderStatus) -> ReceivedOrdersSnapshot {
     ReceivedOrdersSnapshot(
         byProductRows: [
             ReceivedOrdersProductRow(

--- a/ios/Reguerta/ReguertaTests/ReguertaOrdersViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaOrdersViewModelTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct ReguertaOrdersViewModelTests {
-    @Test
-    func myOrderViewModelUsesLocalizedOrderActions() {
+    @Test func myOrderViewModelUsesLocalizedOrderActions() {
         let viewModel = makeMyOrderViewModel()
 
         #expect(viewModel.finalizeCheckoutTitle == l10n(AccessL10nKey.myOrderFinalizeAction))
@@ -16,8 +15,7 @@ struct ReguertaOrdersViewModelTests {
         #expect(viewModel.finalizeCheckoutTitle == l10n(AccessL10nKey.myOrderFinalizeUpdateAction))
     }
 
-    @Test
-    func myOrderDynamicCopyResolvesFromTheLocalizationCatalog() {
+    @Test func myOrderDynamicCopyResolvesFromTheLocalizationCatalog() {
         let total = l10n(AccessL10nKey.myOrderConfirmedTotalFormat, "€4.63")
         let remaining = l10n(AccessL10nKey.myOrderStockRemainingFormat, "3")
         let editableNote = l10n(AccessL10nKey.myOrderEditableUntilSundayNote)
@@ -30,8 +28,7 @@ struct ReguertaOrdersViewModelTests {
         #expect(editableNote.hasPrefix("*"))
     }
 
-    @Test
-    func myOrderPackagingLineKeepsContainerAndMeasureQuantitiesSeparate() {
+    @Test func myOrderPackagingLineKeepsContainerAndMeasureQuantitiesSeparate() {
         #expect(
             myOrderPackagingLine(from: [
                 "packContainerName": "Caja",
@@ -72,8 +69,7 @@ struct ReguertaOrdersViewModelTests {
         )
     }
 
-    @Test
-    func myOrderPackagingLineUsesTheRequestedLocaleForDecimalQuantities() {
+    @Test func myOrderPackagingLineUsesTheRequestedLocaleForDecimalQuantities() {
         #expect(
             myOrderPackagingLine(
                 from: [
@@ -102,8 +98,7 @@ struct ReguertaOrdersViewModelTests {
         )
     }
 
-    @Test
-    func activeProductPackagingLineKeepsContainerAndMeasureQuantitiesSeparate() {
+    @Test func activeProductPackagingLineKeepsContainerAndMeasureQuantitiesSeparate() {
         let viewModel = makeMyOrderViewModel()
         func product(packContainerQty: Double) -> Product {
             Product(
@@ -139,8 +134,7 @@ struct ReguertaOrdersViewModelTests {
         #expect(viewModel.packContainerLine(for: product(packContainerQty: 2)) == "2 Caja 6 ud(s).")
     }
 
-    @Test
-    func receivedOrdersCopyResolvesFromTheLocalizationCatalog() {
+    @Test func receivedOrdersCopyResolvesFromTheLocalizationCatalog() {
         let keys = [
             AccessL10nKey.receivedOrdersTitle,
             AccessL10nKey.receivedOrdersTabsTitle,
@@ -162,8 +156,7 @@ struct ReguertaOrdersViewModelTests {
 }
 
 extension ReguertaOrdersViewModelTests {
-    @Test
-    func myOrderViewModelPersistsDraftImmediatelyInUserDefaultsCartStore() async {
+    @Test func myOrderViewModelPersistsDraftImmediatelyInUserDefaultsCartStore() async {
         let suiteName = "ReguertaOrdersViewModelTests.\(UUID().uuidString)"
         guard let userDefaults = UserDefaults(suiteName: suiteName) else {
             Issue.record("Expected test UserDefaults suite")
@@ -188,8 +181,7 @@ extension ReguertaOrdersViewModelTests {
         #expect(restoredDraft.selectedQuantities == [product.id: 1])
     }
 
-    @Test
-    func myOrderViewModelSanitizesQuantitiesAgainstStockAndCommitments() async {
+    @Test func myOrderViewModelSanitizesQuantitiesAgainstStockAndCommitments() async {
         let product = finiteStockProduct(
             regularProduct(id: "avocado", vendorId: "producer_even", name: "Aguacates"),
             stock: 5
@@ -210,8 +202,7 @@ extension ReguertaOrdersViewModelTests {
         #expect(viewModel.selectedQuantities == [product.id: 3])
     }
 
-    @Test
-    func myOrderViewModelBlocksCheckoutWithExistingValidation() async {
+    @Test func myOrderViewModelBlocksCheckoutWithExistingValidation() async {
         let product = regularProduct(id: "avocado", vendorId: "producer_even", name: "Aguacates")
         let viewModel = makeMyOrderViewModel()
         await viewModel.appear(
@@ -232,8 +223,7 @@ extension ReguertaOrdersViewModelTests {
         #expect(names == ["Aguacates"])
     }
 
-    @Test
-    func myOrderViewModelPersistsSuccessfulCheckoutAndConfirmedSnapshot() async {
+    @Test func myOrderViewModelPersistsSuccessfulCheckoutAndConfirmedSnapshot() async {
         let repository = InMemoryOrdersRepository()
         let cartStore = InMemoryMyOrderCartStore()
         let product = regularProduct(id: "tomato", vendorId: "producer_even", name: "Tomates")
@@ -256,8 +246,7 @@ extension ReguertaOrdersViewModelTests {
         #expect(submissions.first?.weekKey == "2026-W20")
     }
 
-    @Test
-    func myOrderViewModelLoadsEmptyAndErrorPreviousOrderStates() async {
+    @Test func myOrderViewModelLoadsEmptyAndErrorPreviousOrderStates() async {
         let repository = InMemoryOrdersRepository()
         let viewModel = makeMyOrderViewModel(repository: repository)
 
@@ -269,8 +258,7 @@ extension ReguertaOrdersViewModelTests {
         #expect(viewModel.previousOrderState == .error)
     }
 
-    @Test
-    func myOrderViewModelShowsDatabaseOrderForCurrentWeekWhenLocalConfirmationIsMissing() async {
+    @Test func myOrderViewModelShowsDatabaseOrderForCurrentWeekWhenLocalConfirmationIsMissing() async {
         let repository = InMemoryOrdersRepository()
         await repository.setPreviousOrder(previousOrderSnapshot(weekKey: "2026-W20"), forWeekKey: "2026-W20")
         let viewModel = makeMyOrderViewModel(repository: repository, nowMillis: testMillis(year: 2026, month: 5, day: 15))
@@ -286,8 +274,7 @@ extension ReguertaOrdersViewModelTests {
         #expect(snapshot.weekKey == "2026-W20")
     }
 
-    @Test
-    func myOrderViewModelShowsPreviousWeekOrderDuringDeliveryWindow() async {
+    @Test func myOrderViewModelShowsPreviousWeekOrderDuringDeliveryWindow() async {
         let repository = InMemoryOrdersRepository()
         await repository.setPreviousOrder(previousOrderSnapshot(weekKey: "2026-W19"), forWeekKey: "2026-W19")
         let viewModel = makeMyOrderViewModel(repository: repository, nowMillis: testMillis(year: 2026, month: 5, day: 13))
@@ -303,8 +290,7 @@ extension ReguertaOrdersViewModelTests {
         #expect(snapshot.weekKey == "2026-W19")
     }
 
-    @Test
-    func myOrderConsultaWindowUsesWednesdayWhenNoDeliveryCalendarOverrideEvenIfShiftIsLater() {
+    @Test func myOrderConsultaWindowUsesWednesdayWhenNoDeliveryCalendarOverrideEvenIfShiftIsLater() {
         let window = resolveMyOrderConsultaWindow(
             defaultDeliveryDayOfWeek: .wednesday,
             deliveryCalendarOverrides: [],
@@ -316,8 +302,7 @@ extension ReguertaOrdersViewModelTests {
         #expect(window.previousWeekKey == "2026-W27")
     }
 
-    @Test
-    func myOrderConsultaWindowUsesDeliveryCalendarOverrideWhenPresent() {
+    @Test func myOrderConsultaWindowUsesDeliveryCalendarOverrideWhenPresent() {
         let override = DeliveryCalendarOverride(
             weekKey: "2026-W28",
             deliveryDateMillis: testMillis(year: 2026, month: 7, day: 9),
@@ -338,8 +323,7 @@ extension ReguertaOrdersViewModelTests {
         #expect(window.previousWeekKey == "2026-W27")
     }
 
-    @Test
-    func receivedOrdersViewModelDoesNotLoadForNonProducerOrOutsideWindow() async {
+    @Test func receivedOrdersViewModelDoesNotLoadForNonProducerOrOutsideWindow() async {
         let repository = InMemoryOrdersRepository()
         let nonProducerViewModel = makeReceivedOrdersViewModel(repository: repository)
         await nonProducerViewModel.appear(
@@ -360,8 +344,7 @@ extension ReguertaOrdersViewModelTests {
         #expect(producerViewModel.loadState == .idle)
     }
 
-    @Test
-    func receivedOrdersViewModelLoadsSnapshotByProductAndMember() async {
+    @Test func receivedOrdersViewModelLoadsSnapshotByProductAndMember() async {
         let repository = InMemoryOrdersRepository()
         let snapshot = receivedOrdersSnapshot(status: .read)
         await repository.setReceivedOrdersSnapshot(
@@ -389,8 +372,7 @@ extension ReguertaOrdersViewModelTests {
         #expect(loadedSnapshot.generalTotal == 6.0)
     }
 
-    @Test
-    func receivedOrdersViewModelUpdatesProducerStatusAndMutatesLocalSnapshot() async {
+    @Test func receivedOrdersViewModelUpdatesProducerStatusAndMutatesLocalSnapshot() async {
         let repository = InMemoryOrdersRepository()
         await repository.setReceivedOrdersSnapshot(
             receivedOrdersSnapshot(status: .read),
@@ -415,8 +397,7 @@ extension ReguertaOrdersViewModelTests {
         #expect(viewModel.statusWriteFeedback == nil)
     }
 
-    @Test
-    func receivedOrdersViewModelShowsFeedbackWhenStatusUpdateFails() async {
+    @Test func receivedOrdersViewModelShowsFeedbackWhenStatusUpdateFails() async {
         let repository = InMemoryOrdersRepository()
         await repository.setReceivedOrdersSnapshot(
             receivedOrdersSnapshot(status: .read),
@@ -442,8 +423,7 @@ extension ReguertaOrdersViewModelTests {
         #expect(viewModel.statusWriteFeedback == .permissionDenied)
     }
 
-    @Test
-    func previewEnvironmentUsesInMemoryOrdersDependenciesAndSharesRootSession() {
+    @Test func previewEnvironmentUsesInMemoryOrdersDependenciesAndSharesRootSession() {
         let environment = ReguertaAppEnvironment.preview()
 
         #expect(environment.accessRootViewModel.myOrderViewModel.sessionViewModel === environment.sessionViewModel)

--- a/ios/Reguerta/ReguertaTests/ReguertaPermissionMatrixTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaPermissionMatrixTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct ReguertaPermissionMatrixTests {
-    @Test
-    func canonicalMatrixCapabilitiesMatchIOSPermissionMatrix() throws {
+    @Test func canonicalMatrixCapabilitiesMatchIOSPermissionMatrix() throws {
         let matrix = try loadCanonicalMatrix()
 
         for role in CanonicalAccessRole.allCases {
@@ -18,8 +17,7 @@ struct ReguertaPermissionMatrixTests {
         }
     }
 
-    @Test
-    func commonPurchaseManagerOverrideGrantsCatalogManagement() {
+    @Test func commonPurchaseManagerOverrideGrantsCatalogManagement() {
         let member = Member(
             id: "member_common_purchase_001",
             displayName: "Compra común",
@@ -34,8 +32,7 @@ struct ReguertaPermissionMatrixTests {
         #expect(member.canManageProductCatalog)
     }
 
-    @Test
-    func inMemoryFixturesStayAlignedWithCanonicalMatrix() async {
+    @Test func inMemoryFixturesStayAlignedWithCanonicalMatrix() async {
         let repository = InMemoryMemberRepository()
         let membersById = Dictionary(
             uniqueKeysWithValues: await repository.allMembers().map { ($0.id, $0) }
@@ -74,10 +71,7 @@ struct ReguertaPermissionMatrixTests {
             throw MatrixLoadError.invalidPayload
         }
 
-        func resolveCapabilities(
-            roleName: String,
-            visiting: inout Set<String>
-        ) throws -> Set<String> {
+        func resolveCapabilities(roleName: String, visiting: inout Set<String>) throws -> Set<String> {
             guard let role = roles[roleName] else { return [] }
             if visiting.contains(roleName) {
                 throw MatrixLoadError.inheritanceCycle(roleName)

--- a/ios/Reguerta/ReguertaTests/ReguertaProductQuantityOptionsTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaProductQuantityOptionsTests.swift
@@ -4,8 +4,7 @@ import Testing
 
 @MainActor
 struct ReguertaProductQuantityOptionsTests {
-    @Test
-    func editorUsesTypedOptionsAndDefaultsQuantitiesToOne() async {
+    @Test func editorUsesTypedOptionsAndDefaultsQuantitiesToOne() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let viewModel = await makeProductsViewModel(
             currentMember: currentProducer,
@@ -49,16 +48,14 @@ struct ReguertaProductQuantityOptionsTests {
         #expect(input?.maxWeight == 3)
     }
 
-    @Test
-    func stockLevelUsesErrorWarningAndNormalThresholds() {
+    @Test func stockLevelUsesErrorWarningAndNormalThresholds() {
         #expect(productStockLevel(quantity: 0) == .error)
         #expect(productStockLevel(quantity: 1) == .warning)
         #expect(productStockLevel(quantity: 10) == .warning)
         #expect(productStockLevel(quantity: 11) == .normal)
     }
 
-    @Test
-    func weightedProductUsesMinimumMaximumAndStep() {
+    @Test func weightedProductUsesMinimumMaximumAndStep() {
         let product = weightedProduct()
 
         #expect(product.minimumSelectionCount == 2)

--- a/ios/Reguerta/ReguertaTests/ReguertaProductsViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaProductsViewModelTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct ReguertaProductsViewModelTests {
-    @Test
-    func productsViewModelLoadsCatalogOnlyForCatalogManagersAndSplitsArchivedProducts() async {
+    @Test func productsViewModelLoadsCatalogOnlyForCatalogManagersAndSplitsArchivedProducts() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let activeProduct = regularProduct(id: "active", vendorId: currentProducer.id, name: "Acelgas")
         let archivedProduct = regularProduct(id: "archived", vendorId: currentProducer.id, name: "Berenjenas")
@@ -33,8 +32,7 @@ struct ReguertaProductsViewModelTests {
         #expect(regularViewModel.catalogProducts.isEmpty)
     }
 
-    @Test
-    func productsViewModelInitializesEditsNormalizesDraftAndClearsEditor() async {
+    @Test func productsViewModelInitializesEditsNormalizesDraftAndClearsEditor() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let product = regularProduct(id: "tomato", vendorId: currentProducer.id, name: "Tomates")
         let viewModel = await makeProductsViewModel(
@@ -60,8 +58,7 @@ struct ReguertaProductsViewModelTests {
         #expect(viewModel.draft == ProductDraft())
     }
 
-    @Test
-    func productEditorUsesAsymmetricStockStepsWithoutGoingBelowZero() async {
+    @Test func productEditorUsesAsymmetricStockStepsWithoutGoingBelowZero() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let viewModel = await makeProductsViewModel(
             currentMember: currentProducer,
@@ -83,8 +80,7 @@ struct ReguertaProductsViewModelTests {
         #expect(viewModel.draft.stockQty == "0")
     }
 
-    @Test
-    func productsHeaderAndBackActionFollowEditorState() {
+    @Test func productsHeaderAndBackActionFollowEditorState() {
         let rootViewModel = ReguertaAppEnvironment.preview().accessRootViewModel
         rootViewModel.homeDestination = .products
         rootViewModel.productsViewModel.editingProductId = ""
@@ -104,8 +100,7 @@ struct ReguertaProductsViewModelTests {
         #expect(rootViewModel.homeDestination == .dashboard)
     }
 
-    @Test
-    func productsViewModelBlocksInvalidSaveInput() async {
+    @Test func productsViewModelBlocksInvalidSaveInput() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let viewModel = await makeProductsViewModel(currentMember: currentProducer, members: [currentProducer])
 
@@ -121,8 +116,7 @@ struct ReguertaProductsViewModelTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableSaveChanges)
     }
 
-    @Test
-    func productsViewModelRetainsEditorStateWhenRepositoryRejectsSave() async {
+    @Test func productsViewModelRetainsEditorStateWhenRepositoryRejectsSave() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let originalProduct = regularProduct(
             id: "tomato",
@@ -154,8 +148,7 @@ struct ReguertaProductsViewModelTests {
 }
 
 extension ReguertaProductsViewModelTests {
-    @Test
-    func productsViewModelSavesProducerProductWithEcoBasketRules() async {
+    @Test func productsViewModelSavesProducerProductWithEcoBasketRules() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let repository = InMemoryProductRepository()
         let viewModel = await makeProductsViewModel(
@@ -182,8 +175,7 @@ extension ReguertaProductsViewModelTests {
         #expect(products.first?.createdAtMillis == 100)
     }
 
-    @Test
-    func productsViewModelSavesCommonPurchaseOnlyForCommonPurchaseManagers() async {
+    @Test func productsViewModelSavesCommonPurchaseOnlyForCommonPurchaseManagers() async {
         let currentMember = Member(
             id: "common_manager",
             displayName: "Compra comun",
@@ -218,8 +210,7 @@ extension ReguertaProductsViewModelTests {
         #expect(products.first?.isEcoBasket == false)
     }
 
-    @Test
-    func productsViewModelBlocksEcoBasketWithIncompatiblePrice() async {
+    @Test func productsViewModelBlocksEcoBasketWithIncompatiblePrice() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let existingEcoBasket = ecoBasketProduct(id: "eco_existing", vendorId: "other_producer", price: 10)
         let repository = InMemoryProductRepository(items: [existingEcoBasket])
@@ -244,8 +235,7 @@ extension ReguertaProductsViewModelTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableSaveChanges)
     }
 
-    @Test
-    func productsViewModelArchivesProductAndUpdatesLocalSnapshot() async {
+    @Test func productsViewModelArchivesProductAndUpdatesLocalSnapshot() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let product = regularProduct(id: "tomato", vendorId: currentProducer.id, name: "Tomates")
         let repository = InMemoryProductRepository(items: [product])
@@ -262,8 +252,7 @@ extension ReguertaProductsViewModelTests {
         #expect(viewModel.archivedProducts.map(\.id) == [product.id])
     }
 
-    @Test
-    func productsViewModelUploadsImageAndShowsFeedbackOnFailure() async {
+    @Test func productsViewModelUploadsImageAndShowsFeedbackOnFailure() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let successPipeline = MockImagePipelineManager(result: .success("https://cdn.reguerta.test/product.jpg"))
         let viewModel = await makeProductsViewModel(
@@ -288,8 +277,7 @@ extension ReguertaProductsViewModelTests {
         #expect(failingViewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableSaveChanges)
     }
 
-    @Test
-    func productsViewModelEnablesVacationModeAndUpdatesSessionMember() async {
+    @Test func productsViewModelEnablesVacationModeAndUpdatesSessionMember() async {
         let currentProducer = producer(id: "producer_even", parity: .even)
         let memberRepository = InMemoryMemberRepository()
         let viewModel = await makeProductsViewModel(
@@ -308,8 +296,7 @@ extension ReguertaProductsViewModelTests {
         #expect(session.member.producerCatalogEnabled == false)
     }
 
-    @Test
-    func productsViewModelLoadsMyOrderFeedWithVisibilityParityAndCommitments() async {
+    @Test func productsViewModelLoadsMyOrderFeedWithVisibilityParityAndCommitments() async {
         let currentMember = member(id: "member_1", ecoCommitmentMode: .weekly)
         let evenProducer = producer(id: "producer_even", parity: .even)
         let oddProducer = producer(id: "producer_odd", parity: .odd)
@@ -358,8 +345,7 @@ extension ReguertaProductsViewModelTests {
         #expect(viewModel.myOrderSeasonalCommitments.map(\.productId) == [visibleProduct.id])
     }
 
-    @Test
-    func previewEnvironmentUsesInMemoryProductsDependenciesAndSharesRootSession() {
+    @Test func previewEnvironmentUsesInMemoryProductsDependenciesAndSharesRootSession() {
         let environment = ReguertaAppEnvironment.preview()
 
         #expect(environment.accessRootViewModel.productsViewModel.sessionViewModel === environment.sessionViewModel)
@@ -453,10 +439,7 @@ private actor MockImagePipelineManager: ImagePipelineManager {
         self.result = result
     }
 
-    func processAndUpload(
-        imageData _: Data,
-        request _: ImageUploadRequest
-    ) async throws -> ImageUploadResult {
+    func processAndUpload(imageData _: Data, request _: ImageUploadRequest) async throws -> ImageUploadResult {
         switch result {
         case .success(let downloadURL):
             ImageUploadResult(

--- a/ios/Reguerta/ReguertaTests/ReguertaReceivedOrdersHistoryViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaReceivedOrdersHistoryViewModelTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct ReguertaReceivedOrdersHistoryViewModelTests {
-    @Test
-    func receivedOrdersHistoryPresentationUsesTheActiveEnglishLocale() throws {
+    @Test func receivedOrdersHistoryPresentationUsesTheActiveEnglishLocale() throws {
         let option = try #require(
             orderHistoryWeekOption(
                 weekKey: "2026-W27",
@@ -26,8 +25,7 @@ struct ReguertaReceivedOrdersHistoryViewModelTests {
         #expect(presentation.orderTitle == "Received orders Jun 29 - Jul 5")
     }
 
-    @Test
-    func receivedOrdersHistorySelectsPreviousIsoWeekAndFormatsTitle() async {
+    @Test func receivedOrdersHistorySelectsPreviousIsoWeekAndFormatsTitle() async {
         let repository = InMemoryOrdersRepository()
         await repository.setReceivedOrdersHistoryWeekKeys(["2026-W21"], forProducerId: "producer_even")
         await repository.setReceivedOrdersSnapshot(
@@ -52,8 +50,7 @@ struct ReguertaReceivedOrdersHistoryViewModelTests {
         #expect(snapshot.byProductRows.first?.productName == "Tomates")
     }
 
-    @Test
-    func receivedOrdersHistoryBuildsContinuousRangeAndShowsIntermediateEmptyWeek() async {
+    @Test func receivedOrdersHistoryBuildsContinuousRangeAndShowsIntermediateEmptyWeek() async {
         let repository = InMemoryOrdersRepository()
         await repository.setReceivedOrdersHistoryWeekKeys(["2026-W19", "2026-W21"], forProducerId: "producer_even")
         await repository.setReceivedOrdersSnapshot(
@@ -93,8 +90,7 @@ struct ReguertaReceivedOrdersHistoryViewModelTests {
         #expect(!viewModel.canGoNext)
     }
 
-    @Test
-    func receivedOrdersHistoryDoesNotUseGlobalOrderFallbackWhenProducerHasNoOrders() async {
+    @Test func receivedOrdersHistoryDoesNotUseGlobalOrderFallbackWhenProducerHasNoOrders() async {
         let repository = InMemoryOrdersRepository()
         await repository.setOldestOrderHistoryWeekKey("2025-W01")
         let viewModel = makeReceivedOrdersHistoryViewModel(repository: repository)
@@ -120,8 +116,7 @@ struct ReguertaReceivedOrdersHistoryViewModelTests {
         #expect(viewModel.availableWeeks.last?.weekKey == "2026-W27")
     }
 
-    @Test
-    func receivedOrdersHistoryRetryKeepsSelectedWeekAndDoesNotWriteStatus() async {
+    @Test func receivedOrdersHistoryRetryKeepsSelectedWeekAndDoesNotWriteStatus() async {
         let repository = InMemoryOrdersRepository()
         await repository.setReceivedOrdersHistoryWeekKeys(["2026-W21"], forProducerId: "producer_even")
         await repository.setReceivedOrdersSnapshot(

--- a/ios/Reguerta/ReguertaTests/ReguertaReceivedWeightedOrderLineTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaReceivedWeightedOrderLineTests.swift
@@ -2,9 +2,7 @@ import Testing
 
 @testable import Reguerta
 
-@MainActor
-@Test
-func receivedOrdersProductRowsDisplayOrderedUnitsForWeightedLines() {
+@MainActor @Test func receivedOrdersProductRowsDisplayOrderedUnitsForWeightedLines() {
     let line = receivedWeightedOrderLine(
         quantity: 200,
         subtotal: 4,

--- a/ios/Reguerta/ReguertaTests/ReguertaRootDependencyTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaRootDependencyTests.swift
@@ -4,8 +4,7 @@ import Testing
 
 @MainActor
 struct ReguertaRootDependencyTests {
-    @Test
-    func previewEnvironmentSharesSessionWithRootCoordinator() {
+    @Test func previewEnvironmentSharesSessionWithRootCoordinator() {
         let environment = ReguertaAppEnvironment.preview()
 
         #expect(environment.accessRootViewModel.feedbackCenter === environment.feedbackCenter)
@@ -15,16 +14,14 @@ struct ReguertaRootDependencyTests {
         #expect(environment.sessionViewModel.mode == .signedOut)
     }
 
-    @Test
-    func previewDependenciesCreateSignedOutSessionWithoutLiveBootstrap() {
+    @Test func previewDependenciesCreateSignedOutSessionWithoutLiveBootstrap() {
         let viewModel = SessionViewModel(dependencies: .preview())
 
         #expect(viewModel.mode == .signedOut)
         #expect(viewModel.isDevelopImpersonationEnabled == false)
     }
 
-    @Test
-    func uiTestingEnvironmentUsesLocalFixturesWithoutLiveBootstrap() {
+    @Test func uiTestingEnvironmentUsesLocalFixturesWithoutLiveBootstrap() {
         let environment = ReguertaAppEnvironment.uiTesting()
 
         #expect(environment.accessRootViewModel.feedbackCenter === environment.feedbackCenter)
@@ -35,8 +32,7 @@ struct ReguertaRootDependencyTests {
         #expect(environment.sessionViewModel.isDevelopImpersonationEnabled == false)
     }
 
-    @Test
-    func rootCoordinatorSkipsSplashToWelcomeWhenLaunchArgumentRequestsIt() async {
+    @Test func rootCoordinatorSkipsSplashToWelcomeWhenLaunchArgumentRequestsIt() async {
         let rootViewModel = makeRootViewModel(shouldSkipSplash: true)
 
         await rootViewModel.handleSplashIfNeeded()
@@ -46,8 +42,7 @@ struct ReguertaRootDependencyTests {
         #expect(rootViewModel.shellState.currentRoute == .welcome)
     }
 
-    @Test
-    func rootCoordinatorBlocksSplashWhenStartupGateRequiresForcedUpdate() async throws {
+    @Test func rootCoordinatorBlocksSplashWhenStartupGateRequiresForcedUpdate() async throws {
         let rootViewModel = makeRootViewModel(
             startupPolicy: StartupVersionPolicy(
                 currentVersion: "2.0.0",
@@ -67,8 +62,7 @@ struct ReguertaRootDependencyTests {
         #expect(rootViewModel.shellState.currentRoute == .splash)
     }
 
-    @Test
-    func startupTimeoutPublishesWithoutWaitingForRemoteCompletionAndRetryRecovers() async throws {
+    @Test func startupTimeoutPublishesWithoutWaitingForRemoteCompletionAndRetryRecovers() async throws {
         let repository = ControlledStartupVersionPolicyRepository()
         let sleeper = ControlledStartupGateSleeper()
         let rootViewModel = makeRootViewModel(
@@ -126,8 +120,7 @@ struct ReguertaRootDependencyTests {
         #expect(rootViewModel.startupGateState == .ready)
     }
 
-    @Test
-    func startupFailureRequiresExplicitContinuation() async throws {
+    @Test func startupFailureRequiresExplicitContinuation() async throws {
         let rootViewModel = makeRootViewModel()
         rootViewModel.splashDelayCompleted = true
 
@@ -143,8 +136,7 @@ struct ReguertaRootDependencyTests {
         #expect(rootViewModel.shellState.currentRoute == .welcome)
     }
 
-    @Test
-    func rootCoordinatorRoutesAuthenticatedSessionToHomeOutsideSplash() {
+    @Test func rootCoordinatorRoutesAuthenticatedSessionToHomeOutsideSplash() {
         let rootViewModel = makeRootViewModel()
         let currentMember = Member(
             id: "member_root",
@@ -172,8 +164,7 @@ struct ReguertaRootDependencyTests {
         #expect(rootViewModel.shellState.canGoBack == false)
     }
 
-    @Test
-    func rootCoordinatorRoutesSignedOutSessionToWelcomeOutsideSplash() {
+    @Test func rootCoordinatorRoutesSignedOutSessionToWelcomeOutsideSplash() {
         let rootViewModel = makeRootViewModel()
         rootViewModel.shellState = AuthShellState(backStack: [.home])
         rootViewModel.sessionViewModel.mode = .signedOut
@@ -184,8 +175,7 @@ struct ReguertaRootDependencyTests {
         #expect(rootViewModel.shellState.canGoBack == false)
     }
 
-    @Test
-    func homeDrawerSignOutRequestsConfirmationWithoutEndingSession() {
+    @Test func homeDrawerSignOutRequestsConfirmationWithoutEndingSession() {
         let rootViewModel = makeRootViewModel()
         rootViewModel.shellState = AuthShellState(backStack: [.home])
         rootViewModel.sessionViewModel.mode = .authorized(makeAuthorizedSession())
@@ -210,8 +200,7 @@ struct ReguertaRootDependencyTests {
         }
     }
 
-    @Test
-    func homeDrawerSignOutConfirmationSignsOutAndRoutesWelcome() {
+    @Test func homeDrawerSignOutConfirmationSignsOutAndRoutesWelcome() {
         let rootViewModel = makeRootViewModel()
         rootViewModel.shellState = AuthShellState(backStack: [.home])
         rootViewModel.sessionViewModel.mode = .authorized(makeAuthorizedSession())
@@ -280,9 +269,7 @@ private actor ControlledStartupVersionPolicyRepository: StartupVersionPolicyRepo
     private var nextRequestIndex = 0
     private var continuations: [Int: CheckedContinuation<Result<StartupVersionPolicy, RepositoryError>, Never>] = [:]
     private var nextRequestCountWaiterID = 0
-    private var requestCountWaiters: [
-        Int: (count: Int, continuation: CheckedContinuation<Void, any Error>)
-    ] = [:]
+    private var requestCountWaiters: [Int: (count: Int, continuation: CheckedContinuation<Void, any Error>)] = [:]
 
     func policy(for platform: StartupPlatform) async throws -> StartupVersionPolicy {
         let requestIndex = nextRequestIndex
@@ -309,10 +296,7 @@ private actor ControlledStartupVersionPolicyRepository: StartupVersionPolicyRepo
         }
     }
 
-    func completeRequest(
-        at index: Int,
-        with result: Result<StartupVersionPolicy, RepositoryError>
-    ) {
+    func completeRequest(at index: Int, with result: Result<StartupVersionPolicy, RepositoryError>) {
         continuations.removeValue(forKey: index)?.resume(returning: result)
     }
 
@@ -337,9 +321,7 @@ private actor ControlledStartupGateSleeper {
     private var nextRequestIndex = 0
     private var continuations: [Int: CheckedContinuation<Void, any Error>] = [:]
     private var nextRequestCountWaiterID = 0
-    private var requestCountWaiters: [
-        Int: (count: Int, continuation: CheckedContinuation<Void, any Error>)
-    ] = [:]
+    private var requestCountWaiters: [Int: (count: Int, continuation: CheckedContinuation<Void, any Error>)] = [:]
 
     func sleep(for _: Duration) async throws {
         let requestIndex = nextRequestIndex

--- a/ios/Reguerta/ReguertaTests/ReguertaSessionFeatureViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaSessionFeatureViewModelTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct ReguertaSessionFeatureViewModelTests {
-    @Test
-    func previewEnvironmentSharesFeedbackCenterAcrossRootSessionAndFeatures() {
+    @Test func previewEnvironmentSharesFeedbackCenterAcrossRootSessionAndFeatures() {
         let environment = ReguertaAppEnvironment.preview()
         let rootViewModel = environment.accessRootViewModel
 
@@ -20,8 +19,7 @@ struct ReguertaSessionFeatureViewModelTests {
         #expect(rootViewModel.bylawsViewModel.feedbackCenter === environment.feedbackCenter)
     }
 
-    @Test
-    func globalFeedbackCenterStoresAndClearsMessageKey() {
+    @Test func globalFeedbackCenterStoresAndClearsMessageKey() {
         let feedbackCenter = GlobalFeedbackCenter()
 
         feedbackCenter.show("feedback.test")
@@ -31,8 +29,7 @@ struct ReguertaSessionFeatureViewModelTests {
         #expect(feedbackCenter.messageKey == nil)
     }
 
-    @Test
-    func bylawsBlocksEmptyQuestionWithFeedback() {
+    @Test func bylawsBlocksEmptyQuestionWithFeedback() {
         let feedbackCenter = GlobalFeedbackCenter()
         let viewModel = BylawsFeatureViewModel(
             feedbackCenter: feedbackCenter,
@@ -47,8 +44,7 @@ struct ReguertaSessionFeatureViewModelTests {
         #expect(viewModel.isAsking == false)
     }
 
-    @Test
-    func bylawsValidQuestionStoresAnswerAndClearsState() async {
+    @Test func bylawsValidQuestionStoresAnswerAndClearsState() async {
         let consultant = RecordingBylawsConsultant()
         let viewModel = BylawsFeatureViewModel(
             feedbackCenter: GlobalFeedbackCenter(),
@@ -71,8 +67,7 @@ struct ReguertaSessionFeatureViewModelTests {
         #expect(viewModel.answerResult == nil)
     }
 
-    @Test
-    func bylawsPdfUnavailablePublishesFeedback() {
+    @Test func bylawsPdfUnavailablePublishesFeedback() {
         let feedbackCenter = GlobalFeedbackCenter()
         let viewModel = BylawsFeatureViewModel(
             feedbackCenter: feedbackCenter,
@@ -86,8 +81,7 @@ struct ReguertaSessionFeatureViewModelTests {
         #expect(feedbackCenter.messageKey == AccessL10nKey.bylawsPdfViewerUnavailable)
     }
 
-    @Test
-    func previewBylawsDependenciesAnswerWithoutLiveServices() async {
+    @Test func previewBylawsDependenciesAnswerWithoutLiveServices() async {
         let environment = ReguertaAppEnvironment.preview()
         let viewModel = environment.accessRootViewModel.bylawsViewModel
         await viewModel.prepare(responseLanguage: .spanish)
@@ -110,10 +104,7 @@ private actor RecordingBylawsConsultant: BylawsConsulting {
         .localModel
     }
 
-    func consult(
-        question: String,
-        responseLanguage: BylawsResponseLanguage
-    ) async throws -> BylawsConsultationResult {
+    func consult(question: String, responseLanguage: BylawsResponseLanguage) async throws -> BylawsConsultationResult {
         recordedQuestions.append(question)
         recordedResponseLanguages.append(responseLanguage)
         return BylawsConsultationResult(
@@ -149,8 +140,7 @@ private actor RecordingBylawsConsultant: BylawsConsulting {
 private struct FixedBylawsDocumentProvider: BylawsDocumentProviding {
     let pdfURL: URL?
 
-    @MainActor
-    func bundledPdfURL() -> URL? {
+    @MainActor func bundledPdfURL() -> URL? {
         pdfURL
     }
 }

--- a/ios/Reguerta/ReguertaTests/ReguertaSharedProfileViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaSharedProfileViewModelTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct ReguertaSharedProfileViewModelTests {
-    @Test
-    func sharedProfileViewModelLoadsVisibleProfilesAndOwnDraft() async {
+    @Test func sharedProfileViewModelLoadsVisibleProfilesAndOwnDraft() async {
         let currentMember = sharedProfileMember(id: "member_1", displayName: "Member One")
         let ownProfile = sharedProfile(
             userId: currentMember.id,
@@ -32,8 +31,7 @@ struct ReguertaSharedProfileViewModelTests {
         #expect(viewModel.draft == ownProfile.toDraft())
     }
 
-    @Test
-    func sharedProfileViewModelResetsStateWhenSessionLeavesAuthorizedMode() {
+    @Test func sharedProfileViewModelResetsStateWhenSessionLeavesAuthorizedMode() {
         let currentMember = sharedProfileMember(id: "member_1", displayName: "Member One")
         let viewModel = makeSharedProfileViewModel(currentMember: currentMember)
         viewModel.profiles = [sharedProfile(userId: currentMember.id, familyNames: "Familia")]
@@ -55,8 +53,7 @@ struct ReguertaSharedProfileViewModelTests {
         #expect(viewModel.isDeleting == false)
     }
 
-    @Test
-    func sharedProfileViewModelBlocksSaveWithoutVisibleContent() async {
+    @Test func sharedProfileViewModelBlocksSaveWithoutVisibleContent() async {
         let currentMember = sharedProfileMember(id: "member_1", displayName: "Member One")
         let repository = InMemorySharedProfileRepository(items: [])
         let viewModel = makeSharedProfileViewModel(currentMember: currentMember, repository: repository)
@@ -69,8 +66,7 @@ struct ReguertaSharedProfileViewModelTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackSharedProfileContentRequired)
     }
 
-    @Test
-    func sharedProfileViewModelSavesNormalizedProfileAndRefreshesSnapshot() async {
+    @Test func sharedProfileViewModelSavesNormalizedProfileAndRefreshesSnapshot() async {
         let currentMember = sharedProfileMember(id: "member_1", displayName: "Member One")
         let repository = InMemorySharedProfileRepository(items: [])
         let viewModel = makeSharedProfileViewModel(
@@ -103,8 +99,7 @@ struct ReguertaSharedProfileViewModelTests {
         #expect(viewModel.feedbackCenter.messageKey == nil)
     }
 
-    @Test
-    func sharedProfileViewModelRetainsDraftWhenRepositoryRejectsSave() async {
+    @Test func sharedProfileViewModelRetainsDraftWhenRepositoryRejectsSave() async {
         let currentMember = sharedProfileMember(id: "member_1", displayName: "Member One")
         let existingProfile = sharedProfile(
             userId: currentMember.id,
@@ -132,8 +127,7 @@ struct ReguertaSharedProfileViewModelTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableSaveChanges)
     }
 
-    @Test
-    func sharedProfileViewModelDeletesOwnProfileAndClearsDraft() async {
+    @Test func sharedProfileViewModelDeletesOwnProfileAndClearsDraft() async {
         let currentMember = sharedProfileMember(id: "member_1", displayName: "Member One")
         let repository = InMemorySharedProfileRepository(
             items: [sharedProfile(userId: currentMember.id, familyNames: "Familia")]
@@ -150,8 +144,7 @@ struct ReguertaSharedProfileViewModelTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackSharedProfileDeleted)
     }
 
-    @Test
-    func sharedProfileViewModelRetainsProfileWhenRepositoryRejectsDelete() async {
+    @Test func sharedProfileViewModelRetainsProfileWhenRepositoryRejectsDelete() async {
         let currentMember = sharedProfileMember(id: "member_1", displayName: "Member One")
         let existingProfile = sharedProfile(
             userId: currentMember.id,
@@ -175,8 +168,7 @@ struct ReguertaSharedProfileViewModelTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackSharedProfileDeleteFailed)
     }
 
-    @Test
-    func sharedProfileViewModelUploadsImageAndShowsFeedbackOnFailure() async {
+    @Test func sharedProfileViewModelUploadsImageAndShowsFeedbackOnFailure() async {
         let currentMember = sharedProfileMember(id: "member_1", displayName: "Member One")
         let successViewModel = makeSharedProfileViewModel(
             currentMember: currentMember,
@@ -201,8 +193,7 @@ struct ReguertaSharedProfileViewModelTests {
         #expect(failureViewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableSaveChanges)
     }
 
-    @Test
-    func sharedProfileViewModelReportsImageSelectionAndCameraFailures() {
+    @Test func sharedProfileViewModelReportsImageSelectionAndCameraFailures() {
         let currentMember = sharedProfileMember(id: "member_1", displayName: "Member One")
         let viewModel = makeSharedProfileViewModel(currentMember: currentMember)
 
@@ -216,8 +207,7 @@ struct ReguertaSharedProfileViewModelTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackCameraUnavailable)
     }
 
-    @Test
-    func previewEnvironmentUsesInMemorySharedProfileDependencies() {
+    @Test func previewEnvironmentUsesInMemorySharedProfileDependencies() {
         let environment = ReguertaAppEnvironment.preview()
 
         #expect(environment.accessRootViewModel.sharedProfileViewModel.sessionViewModel === environment.sessionViewModel)
@@ -286,8 +276,7 @@ private enum SharedProfileMutationTestError: Error {
     case rejected
 }
 
-@MainActor
-private func sharedProfileMember(id: String, displayName: String) -> Member {
+@MainActor private func sharedProfileMember(id: String, displayName: String) -> Member {
     Member(
         id: id,
         displayName: displayName,
@@ -329,10 +318,7 @@ private final class SharedProfileMockImagePipelineManager: ImagePipelineManager 
         self.result = result
     }
 
-    func processAndUpload(
-        imageData _: Data,
-        request _: ImageUploadRequest
-    ) async throws -> ImageUploadResult {
+    func processAndUpload(imageData _: Data, request _: ImageUploadRequest) async throws -> ImageUploadResult {
         switch result {
         case .success(let downloadURL):
             ImageUploadResult(

--- a/ios/Reguerta/ReguertaTests/ReguertaShiftsAdminViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaShiftsAdminViewModelTests.swift
@@ -4,8 +4,7 @@ import Testing
 
 @MainActor
 struct ReguertaShiftsAdminViewModelTests {
-    @Test
-    func shiftsViewModelConfirmsSwapWithoutDirectShiftWrites() async {
+    @Test func shiftsViewModelConfirmsSwapWithoutDirectShiftWrites() async {
         let scenario = await makeConfirmShiftSwapTestScenario()
 
         scenario.viewModel.confirmShiftSwapRequest(
@@ -26,8 +25,7 @@ struct ReguertaShiftsAdminViewModelTests {
         #expect(updatedCandidateShift == scenario.candidateShift)
     }
 
-    @Test
-    func shiftsViewModelLoadsAndMutatesDeliveryCalendarOnlyForAdmins() async {
+    @Test func shiftsViewModelLoadsAndMutatesDeliveryCalendarOnlyForAdmins() async {
         let regularMember = shiftMember(id: "member_1", displayName: "Carmen")
         let admin = adminMember(id: "admin_1", displayName: "Admin")
         let delivery = shift(
@@ -78,8 +76,7 @@ struct ReguertaShiftsAdminViewModelTests {
         #expect(overrides.isEmpty)
     }
 
-    @Test
-    func shiftsViewModelSubmitsAdminPlanningRequestAndClearsPendingState() async {
+    @Test func shiftsViewModelSubmitsAdminPlanningRequestAndClearsPendingState() async {
         let admin = adminMember(id: "admin_1", displayName: "Admin")
         let planningRepository = RecordingShiftPlanningRequestRepository()
         let viewModel = makeShiftsViewModel(
@@ -99,8 +96,7 @@ struct ReguertaShiftsAdminViewModelTests {
         #expect(viewModel.pendingShiftPlanningType == nil)
     }
 
-    @Test
-    func shiftsViewModelRetainsCalendarEditorWhenRepositoryRejectsMutation() async {
+    @Test func shiftsViewModelRetainsCalendarEditorWhenRepositoryRejectsMutation() async {
         let admin = adminMember(id: "admin_1", displayName: "Admin")
         let delivery = shift(
             id: "delivery",
@@ -132,8 +128,7 @@ struct ReguertaShiftsAdminViewModelTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableSaveChanges)
     }
 
-    @Test
-    func shiftsViewModelRetainsCalendarEditorWhenRepositoryRejectsDelete() async throws {
+    @Test func shiftsViewModelRetainsCalendarEditorWhenRepositoryRejectsDelete() async throws {
         let admin = adminMember(id: "admin_1", displayName: "Admin")
         let delivery = shift(
             id: "delivery",
@@ -173,8 +168,7 @@ struct ReguertaShiftsAdminViewModelTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableSaveChanges)
     }
 
-    @Test
-    func shiftsViewModelRetainsPendingPlanningRequestWhenRepositoryRejectsSubmit() async {
+    @Test func shiftsViewModelRetainsPendingPlanningRequestWhenRepositoryRejectsSubmit() async {
         let admin = adminMember(id: "admin_1", displayName: "Admin")
         let viewModel = makeShiftsViewModel(
             currentMember: admin,
@@ -190,8 +184,7 @@ struct ReguertaShiftsAdminViewModelTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableSaveChanges)
     }
 
-    @Test
-    func chainedShiftRepositoryPropagatesPrimaryRejectionWithoutMutatingFallback() async {
+    @Test func chainedShiftRepositoryPropagatesPrimaryRejectionWithoutMutatingFallback() async {
         let fallback = InMemoryShiftRepository()
         let repository = ChainedShiftRepository(
             primary: RejectingShiftRepository(),
@@ -210,8 +203,7 @@ struct ReguertaShiftsAdminViewModelTests {
         #expect(await fallback.allShifts().isEmpty)
     }
 
-    @Test
-    func previewEnvironmentUsesInMemoryShiftsDependenciesAndSharesRootSession() {
+    @Test func previewEnvironmentUsesInMemoryShiftsDependenciesAndSharesRootSession() {
         let environment = ReguertaAppEnvironment.preview()
 
         #expect(environment.accessRootViewModel.shiftsViewModel.sessionViewModel === environment.sessionViewModel)

--- a/ios/Reguerta/ReguertaTests/ReguertaShiftsPresentationViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaShiftsPresentationViewModelTests.swift
@@ -4,8 +4,7 @@ import Testing
 
 @MainActor
 struct ReguertaShiftsPresentationViewModelTests {
-    @Test
-    func shiftsViewModelComputesNextShiftPresentationByRoleAndMarketAssignment() async {
+    @Test func shiftsViewModelComputesNextShiftPresentationByRoleAndMarketAssignment() async {
         let currentMember = shiftMember(id: "member_1", displayName: "Carmen")
         let leadDelivery = shift(
             id: "lead_delivery",
@@ -39,8 +38,7 @@ struct ReguertaShiftsPresentationViewModelTests {
         #expect(viewModel.nextMarketAssignedShift?.id == market.id)
     }
 
-    @Test
-    func shiftsViewModelDerivesTodayHelperFromFollowingLeadShift() async {
+    @Test func shiftsViewModelDerivesTodayHelperFromFollowingLeadShift() async {
         let currentMember = shiftMember(id: "nohemi", displayName: "Nohemi")
         let helperDelivery = shift(
             id: "delivery_2026_w28",
@@ -70,8 +68,7 @@ struct ReguertaShiftsPresentationViewModelTests {
         #expect(viewModel.highlightedBoardNameIndex(for: helperDelivery, currentMemberId: currentMember.id) == 1)
     }
 
-    @Test
-    func shiftsViewModelUsesFollowingLeadOverPersistedHelperForBoardNames() async {
+    @Test func shiftsViewModelUsesFollowingLeadOverPersistedHelperForBoardNames() async {
         let currentMember = shiftMember(id: "nohemi", displayName: "Nohemi")
         let followingLead = shiftMember(id: "pedro", displayName: "Pedro")
         let delivery = shift(
@@ -102,8 +99,7 @@ struct ReguertaShiftsPresentationViewModelTests {
         #expect(viewModel.resolvedHelperUserId(for: nextDelivery) == nil)
     }
 
-    @Test
-    func shiftsViewModelBoardWindowUsesEffectiveDeliveryDates() async {
+    @Test func shiftsViewModelBoardWindowUsesEffectiveDeliveryDates() async {
         let currentMember = adminMember(id: "admin_1", displayName: "Admin")
         let previousDelivery = shift(
             id: "previous_delivery",
@@ -174,8 +170,7 @@ struct ReguertaShiftsPresentationViewModelTests {
         #expect(!todayViewModel.shiftBoardWindow(for: .delivery).highlights(tomorrowDelivery))
     }
 
-    @Test
-    func shiftsViewModelShowsSwapActivityAcrossDeliveryAndMarket() async {
+    @Test func shiftsViewModelShowsSwapActivityAcrossDeliveryAndMarket() async {
         let currentMember = shiftMember(id: "member_1", displayName: "Carmen")
         let otherMember = shiftMember(id: "member_2", displayName: "Javier")
         let requestRepository = InMemoryShiftSwapRequestRepository()

--- a/ios/Reguerta/ReguertaTests/ReguertaShiftsViewModelTestSupport.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaShiftsViewModelTestSupport.swift
@@ -37,8 +37,7 @@ func makeShiftsViewModel(
     return viewModel
 }
 
-@MainActor
-func shiftMember(id: String, displayName: String) -> Member {
+@MainActor func shiftMember(id: String, displayName: String) -> Member {
     Member(
         id: id,
         displayName: displayName,
@@ -50,8 +49,7 @@ func shiftMember(id: String, displayName: String) -> Member {
     )
 }
 
-@MainActor
-func adminMember(id: String, displayName: String) -> Member {
+@MainActor func adminMember(id: String, displayName: String) -> Member {
     Member(
         id: id,
         displayName: displayName,
@@ -179,8 +177,7 @@ struct ConfirmShiftSwapTestScenario {
     let viewModel: ShiftsFeatureViewModel
 }
 
-@MainActor
-func makeConfirmShiftSwapTestScenario() async -> ConfirmShiftSwapTestScenario {
+@MainActor func makeConfirmShiftSwapTestScenario() async -> ConfirmShiftSwapTestScenario {
     let requester = shiftMember(id: "requester", displayName: "Rosa")
     let candidate = shiftMember(id: "candidate", displayName: "Luis")
     let helper = shiftMember(id: "helper", displayName: "Marta")

--- a/ios/Reguerta/ReguertaTests/ReguertaShiftsViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaShiftsViewModelTests.swift
@@ -4,8 +4,7 @@ import Testing
 
 @MainActor
 struct ReguertaShiftsViewModelTests {
-    @Test
-    func shiftsViewModelLoadsVisibleShiftsAndResetsWhenSignedOut() async {
+    @Test func shiftsViewModelLoadsVisibleShiftsAndResetsWhenSignedOut() async {
         let currentMember = shiftMember(id: "member_1", displayName: "Carmen")
         let otherMember = shiftMember(id: "member_2", displayName: "Javier")
         let requestedShift = shift(
@@ -55,8 +54,7 @@ struct ReguertaShiftsViewModelTests {
         #expect(viewModel.nextDeliveryShift == nil)
     }
 
-    @Test
-    func shiftsViewModelComputesNextShiftsAndRespondsToNowOverride() async {
+    @Test func shiftsViewModelComputesNextShiftsAndRespondsToNowOverride() async {
         let currentMember = shiftMember(id: "member_1", displayName: "Carmen")
         let nowProvider = TestNowProvider(nowMillis: testMillis(year: 2026, month: 5, day: 1))
         let firstDelivery = shift(
@@ -96,8 +94,7 @@ struct ReguertaShiftsViewModelTests {
         #expect(viewModel.nextMarketShift == nil)
     }
 
-    @Test
-    func shiftsViewModelFiltersBoardSegmentAndAppliesDeliveryCalendarOverrides() async {
+    @Test func shiftsViewModelFiltersBoardSegmentAndAppliesDeliveryCalendarOverrides() async {
         let currentMember = adminMember(id: "admin_1", displayName: "Admin")
         let delivery = shift(
             id: "delivery",
@@ -140,8 +137,7 @@ struct ReguertaShiftsViewModelTests {
         #expect(viewModel.visibleShifts.map(\.id) == [market.id])
     }
 
-    @Test
-    func shiftsViewModelBlocksSwapRequestWithoutCandidates() async {
+    @Test func shiftsViewModelBlocksSwapRequestWithoutCandidates() async {
         let currentMember = shiftMember(id: "member_1", displayName: "Carmen")
         let requestedShift = shift(
             id: "delivery_requested",
@@ -164,8 +160,7 @@ struct ReguertaShiftsViewModelTests {
         #expect(viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackShiftSwapNoCandidates)
     }
 
-    @Test
-    func shiftsViewModelCreatesSwapThroughBackendBoundary() async {
+    @Test func shiftsViewModelCreatesSwapThroughBackendBoundary() async {
         let requester = shiftMember(id: "requester", displayName: "Rosa")
         let candidate = shiftMember(id: "candidate", displayName: "Luis")
         let requestedShift = shift(
@@ -206,8 +201,7 @@ struct ReguertaShiftsViewModelTests {
         #expect(viewModel.shiftSwapDraft == ShiftSwapDraft())
     }
 
-    @Test
-    func shiftsViewModelAcceptsCandidateResponseAndPersistsIt() async {
+    @Test func shiftsViewModelAcceptsCandidateResponseAndPersistsIt() async {
         let requester = shiftMember(id: "requester", displayName: "Rosa")
         let candidate = shiftMember(id: "candidate", displayName: "Luis")
         let requestedShift = shift(

--- a/ios/Reguerta/ReguertaTests/ReguertaStartupAndOrderTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaStartupAndOrderTests.swift
@@ -6,8 +6,7 @@ import Testing
 
 @MainActor
 struct ReguertaStartupAndOrderTests {
-    @Test
-    func startupGateBlocksOutdatedVersionWhenForceUpdateIsActive() throws {
+    @Test func startupGateBlocksOutdatedVersionWhenForceUpdateIsActive() throws {
         let useCase = ResolveStartupVersionGateUseCase(
             repository: FixedStartupVersionPolicyRepository(
                 policy: StartupVersionPolicy(
@@ -32,8 +31,7 @@ struct ReguertaStartupAndOrderTests {
         #expect(decision == .forcedUpdate(storeURL: "https://apps.apple.com"))
     }
 
-    @Test
-    func startupGateWarnsWhenVersionIsBelowCurrent() throws {
+    @Test func startupGateWarnsWhenVersionIsBelowCurrent() throws {
         let useCase = ResolveStartupVersionGateUseCase(
             repository: FixedStartupVersionPolicyRepository(
                 policy: StartupVersionPolicy(
@@ -58,8 +56,7 @@ struct ReguertaStartupAndOrderTests {
         #expect(decision == .optionalUpdate(storeURL: "https://apps.apple.com"))
     }
 
-    @Test
-    func criticalDataFreshnessRejectsMissingTimestampKeys() {
+    @Test func criticalDataFreshnessRejectsMissingTimestampKeys() {
         let scope = startupFreshnessScope()
         let useCase = ResolveCriticalDataFreshnessUseCase(
             remoteRepository: FixedCriticalDataFreshnessRemoteRepository(config: nil),
@@ -85,8 +82,7 @@ struct ReguertaStartupAndOrderTests {
         #expect(evaluation == .invalidConfig)
     }
 
-    @Test
-    func criticalDataFreshnessPersistsWhenRemoteTimestampsChange() {
+    @Test func criticalDataFreshnessPersistsWhenRemoteTimestampsChange() {
         let scope = startupFreshnessScope()
         let useCase = ResolveCriticalDataFreshnessUseCase(
             remoteRepository: FixedCriticalDataFreshnessRemoteRepository(config: nil),
@@ -128,8 +124,7 @@ struct ReguertaStartupAndOrderTests {
         )
     }
 
-    @Test
-    func criticalDataFreshnessKeepsMetadataWhenTtlIsStillValid() {
+    @Test func criticalDataFreshnessKeepsMetadataWhenTtlIsStillValid() {
         let scope = startupFreshnessScope()
         let useCase = ResolveCriticalDataFreshnessUseCase(
             remoteRepository: FixedCriticalDataFreshnessRemoteRepository(config: nil),
@@ -158,8 +153,7 @@ struct ReguertaStartupAndOrderTests {
         #expect(evaluation == .accepted(collectionsToRefresh: [], metadataToPersist: nil))
     }
 
-    @Test
-    func sessionRefreshPolicyDebouncesForegroundTransitions() {
+    @Test func sessionRefreshPolicyDebouncesForegroundTransitions() {
         let policy = SessionRefreshPolicy(minimumForegroundIntervalMillis: 15_000)
 
         #expect(policy.shouldRefresh(
@@ -188,8 +182,7 @@ struct ReguertaStartupAndOrderTests {
         ))
     }
 
-    @Test
-    func startupRefreshRestoresAuthorizedSession() async {
+    @Test func startupRefreshRestoresAuthorizedSession() async {
         let provider = TestAuthSessionProvider(
             refreshResult: .active(AuthPrincipal(uid: "uid_admin_restore", email: "ana.admin@reguerta.app"))
         )
@@ -216,8 +209,7 @@ struct ReguertaStartupAndOrderTests {
         #expect(viewModel.showSessionExpiredDialog == false)
     }
 
-    @Test
-    func expiredRefreshSignsOutAndShowsRecoveryDialog() async {
+    @Test func expiredRefreshSignsOutAndShowsRecoveryDialog() async {
         let provider = TestAuthSessionProvider(
             signInResult: .success(AuthPrincipal(uid: "uid_admin_expired", email: "ana.admin@reguerta.app")),
             refreshResult: .expired
@@ -251,8 +243,7 @@ struct ReguertaStartupAndOrderTests {
         #expect(viewModel.showSessionExpiredDialog)
     }
 
-    @Test
-    func myOrderValidationBlocksMissingWeeklyCommitment() {
+    @Test func myOrderValidationBlocksMissingWeeklyCommitment() {
         let currentMember = member(id: "member_1", ecoCommitmentMode: .weekly)
         let producerEven = producer(id: "producer_even", parity: .even)
         let ecoBasket = ecoBasketProduct(id: "eco_even", vendorId: producerEven.id)
@@ -270,8 +261,7 @@ struct ReguertaStartupAndOrderTests {
         #expect(result.hasEcoBasketPriceMismatch == false)
     }
 
-    @Test
-    func myOrderValidationAcceptsNoPickupAsPaidCommitment() {
+    @Test func myOrderValidationAcceptsNoPickupAsPaidCommitment() {
         let currentMember = member(id: "member_1", ecoCommitmentMode: .weekly)
         let producerEven = producer(id: "producer_even", parity: .even)
         let ecoBasket = ecoBasketProduct(id: "eco_even", vendorId: producerEven.id)
@@ -288,8 +278,7 @@ struct ReguertaStartupAndOrderTests {
         #expect(result.missingCommitmentProductNames.isEmpty)
     }
 
-    @Test
-    func myOrderValidationRequiresParityProducerInBiweeklyMode() {
+    @Test func myOrderValidationRequiresParityProducerInBiweeklyMode() {
         let currentMember = member(
             id: "member_1",
             ecoCommitmentMode: .biweekly,

--- a/ios/Reguerta/ReguertaTests/ReguertaTestSupport.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaTestSupport.swift
@@ -23,8 +23,7 @@ func member(
     )
 }
 
-@MainActor
-func producer(id: String, parity: ProducerParity) -> Member {
+@MainActor func producer(id: String, parity: ProducerParity) -> Member {
     Member(
         id: id,
         displayName: id,
@@ -73,12 +72,7 @@ func ecoBasketProduct(
     )
 }
 
-@MainActor
-func regularProduct(
-    id: String,
-    vendorId: String,
-    name: String
-) -> Product {
+@MainActor func regularProduct(id: String, vendorId: String, name: String) -> Product {
     Product(
         id: id,
         vendorId: vendorId,
@@ -128,8 +122,7 @@ func seasonalCommitment(
     )
 }
 
-@MainActor
-func testMillis(year: Int, month: Int, day: Int) -> Int64 {
+@MainActor func testMillis(year: Int, month: Int, day: Int) -> Int64 {
     var calendar = Calendar(identifier: .gregorian)
     calendar.timeZone = TimeZone(identifier: "Europe/Madrid")!
     let date = calendar.date(from: DateComponents(year: year, month: month, day: day))!
@@ -396,8 +389,7 @@ final class TestAuthSessionProvider: AuthSessionProvider {
         refreshResult
     }
 
-    @discardableResult
-    func signOut() -> Bool {
+    @discardableResult func signOut() -> Bool {
         signOutSucceeds
     }
 }

--- a/ios/Reguerta/ReguertaTests/ReguertaTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaTests.swift
@@ -7,16 +7,14 @@ import Testing
 
 @MainActor
 struct ReguertaTests {
-    @Test
-    func appAppearanceMapsSystemLightAndDarkModes() {
+    @Test func appAppearanceMapsSystemLightAndDarkModes() {
         #expect(AppAppearance(rawValue: "unexpected") == nil)
         #expect(AppAppearance.system.preferredColorScheme == nil)
         #expect(AppAppearance.light.preferredColorScheme == .light)
         #expect(AppAppearance.dark.preferredColorScheme == .dark)
     }
 
-    @Test
-    func unauthorizedEmailStaysRestricted() async throws {
+    @Test func unauthorizedEmailStaysRestricted() async throws {
         let repository = InMemoryMemberRepository()
         let useCase = makeInMemoryResolveUseCase(repository: repository)
 
@@ -27,8 +25,7 @@ struct ReguertaTests {
         #expect(result == .unauthorized(.userNotFoundInAuthorizedUsers))
     }
 
-    @Test
-    func existingInactiveMemberDoesNotUseMissingUsersReason() async throws {
+    @Test func existingInactiveMemberDoesNotUseMissingUsersReason() async throws {
         let repository = InMemoryMemberRepository()
         let useCase = makeInMemoryResolveUseCase(repository: repository)
 
@@ -51,8 +48,7 @@ struct ReguertaTests {
         #expect(result == .unauthorized(.userAccessRestricted))
     }
 
-    @Test
-    func firstAuthorizedLoginLinksAuthUid() async throws {
+    @Test func firstAuthorizedLoginLinksAuthUid() async throws {
         let repository = InMemoryMemberRepository()
         let useCase = makeInMemoryResolveUseCase(repository: repository)
 
@@ -68,8 +64,7 @@ struct ReguertaTests {
         #expect(member.authUid == "uid_admin_1")
     }
 
-    @Test
-    func preventRemovingLastActiveAdmin() async {
+    @Test func preventRemovingLastActiveAdmin() async {
         let upsertUseCase = UpsertMemberByAdminUseCase(
             repository: RejectingMemberAdministrationRepository(error: .lastAdminRemoval)
         )
@@ -103,8 +98,7 @@ struct ReguertaTests {
         }
     }
 
-    @Test
-    func adminCanCreatePreAuthorizedMember() async throws {
+    @Test func adminCanCreatePreAuthorizedMember() async throws {
         let repository = InMemoryMemberRepository()
         let resolveUseCase = makeInMemoryResolveUseCase(repository: repository)
         let upsertUseCase = UpsertMemberByAdminUseCase(
@@ -131,8 +125,7 @@ struct ReguertaTests {
         #expect(await repository.findByEmailNormalized("nuevo@reguerta.app") != nil)
     }
 
-    @Test
-    func authUidMatchWinsOverEmailDuplicate() async throws {
+    @Test func authUidMatchWinsOverEmailDuplicate() async throws {
         let repository = InMemoryMemberRepository()
         let useCase = makeInMemoryResolveUseCase(repository: repository)
 
@@ -164,8 +157,7 @@ struct ReguertaTests {
         #expect(member.roles.contains(.admin))
     }
 
-    @Test
-    func authShellRoutesSplashToWelcomeWhenNoSession() {
+    @Test func authShellRoutesSplashToWelcomeWhenNoSession() {
         let reduced = reduceAuthShell(
             state: AuthShellState(),
             action: .splashCompleted(isAuthenticated: false)
@@ -175,8 +167,7 @@ struct ReguertaTests {
         #expect(reduced.canGoBack == false)
     }
 
-    @Test
-    func authShellDeterministicBackFlowForLoginRegister() {
+    @Test func authShellDeterministicBackFlowForLoginRegister() {
         let welcome = AuthShellState(backStack: [.welcome])
         let login = reduceAuthShell(state: welcome, action: .continueFromWelcome)
         let register = reduceAuthShell(state: login, action: .openRegisterFromLogin)
@@ -191,8 +182,7 @@ struct ReguertaTests {
 }
 
 extension ReguertaTests {
-    @Test
-    func authShellCanOpenRegisterDirectlyFromWelcome() {
+    @Test func authShellCanOpenRegisterDirectlyFromWelcome() {
         let welcome = AuthShellState(backStack: [.welcome])
         let register = reduceAuthShell(state: welcome, action: .openRegisterFromWelcome)
         let backToWelcome = reduceAuthShell(state: register, action: .back)
@@ -201,8 +191,7 @@ extension ReguertaTests {
         #expect(backToWelcome.currentRoute == .welcome)
     }
 
-    @Test
-    func authShellResetsToHomeOnAuthenticatedSession() {
+    @Test func authShellResetsToHomeOnAuthenticatedSession() {
         let state = AuthShellState(backStack: [.welcome, .login, .recoverPassword])
         let reduced = reduceAuthShell(state: state, action: .sessionAuthenticated)
 
@@ -210,8 +199,7 @@ extension ReguertaTests {
         #expect(reduced.canGoBack == false)
     }
 
-    @Test
-    func authShellResetsToWelcomeOnSignOut() {
+    @Test func authShellResetsToWelcomeOnSignOut() {
         let state = AuthShellState(backStack: [.home])
         let reduced = reduceAuthShell(state: state, action: .signedOut)
 
@@ -219,8 +207,7 @@ extension ReguertaTests {
         #expect(reduced.canGoBack == false)
     }
 
-    @Test
-    func inMemoryNewsRepositoryReturnsNewestFirst() async {
+    @Test func inMemoryNewsRepositoryReturnsNewestFirst() async {
         let repository = InMemoryNewsRepository()
 
         _ = await repository.upsert(
@@ -240,8 +227,7 @@ extension ReguertaTests {
         #expect(news.first?.id == "news_002")
     }
 
-    @Test
-    func inMemoryNewsRepositoryDeletesExistingNews() async {
+    @Test func inMemoryNewsRepositoryDeletesExistingNews() async {
         let repository = InMemoryNewsRepository()
 
         let deleted = await repository.delete(newsId: "news_welcome_001")
@@ -251,8 +237,7 @@ extension ReguertaTests {
         #expect(remaining.contains(where: { $0.id == "news_welcome_001" }) == false)
     }
 
-    @Test
-    func inMemoryNotificationRepositoryReturnsNewestFirst() async {
+    @Test func inMemoryNotificationRepositoryReturnsNewestFirst() async {
         let repository = InMemoryNotificationRepository()
 
         _ = await repository.send(
@@ -276,8 +261,7 @@ extension ReguertaTests {
         #expect(notifications.first?.id == "notification_002")
     }
 
-    @Test
-    func firebaseAuthErrorMappingCoversKnownCodes() {
+    @Test func firebaseAuthErrorMappingCoversKnownCodes() {
         let invalidEmail = NSError(domain: AuthErrorDomain, code: AuthErrorCode.invalidEmail.rawValue)
         let wrongPassword = NSError(domain: AuthErrorDomain, code: AuthErrorCode.wrongPassword.rawValue)
         let emailAlreadyInUse = NSError(domain: AuthErrorDomain, code: AuthErrorCode.emailAlreadyInUse.rawValue)
@@ -297,8 +281,7 @@ extension ReguertaTests {
         #expect(mapFirebaseAuthError(network) == .network)
     }
 
-    @Test
-    func receivedOrderStatusWriteResultMapsPermissionDenied() {
+    @Test func receivedOrderStatusWriteResultMapsPermissionDenied() {
         let error = NSError(
             domain: "FIRFirestoreErrorDomain",
             code: 7
@@ -307,15 +290,13 @@ extension ReguertaTests {
         #expect(receivedOrderStatusWriteResult(from: error) == .permissionDenied)
     }
 
-    @Test
-    func receivedOrderStatusWriteResultMapsUnknownAsFailure() {
+    @Test func receivedOrderStatusWriteResultMapsUnknownAsFailure() {
         let error = NSError(domain: "example", code: -99)
 
         #expect(receivedOrderStatusWriteResult(from: error) == .failure)
     }
 
-    @Test
-    func authErrorPresentationMappingByFlow() {
+    @Test func authErrorPresentationMappingByFlow() {
         let signIn = mapAuthFailure(.invalidCredentials, flow: .signIn)
         #expect(signIn.passwordErrorKey == AccessL10nKey.authErrorInvalidCredentials)
         #expect(signIn.emailErrorKey == nil)
@@ -327,16 +308,14 @@ extension ReguertaTests {
         #expect(passwordReset.globalMessageKey == AccessL10nKey.authErrorUnknown)
     }
 
-    @Test
-    func semanticComparatorSupportsVariableVersionSegments() {
+    @Test func semanticComparatorSupportsVariableVersionSegments() {
         #expect(SemanticVersionComparator.compare("0.3", "0.3.0") == 0)
         #expect(SemanticVersionComparator.compare("0.3.0.1", "0.3.0") == 1)
         #expect(SemanticVersionComparator.compare("0.2.9", "0.3.0") == -1)
         #expect(SemanticVersionComparator.compare("0.3-beta", "0.3.0") == nil)
     }
 
-    @Test
-    func orderReadsUseBothOwnerAliasesWithinTheRequestedWeek() {
+    @Test func orderReadsUseBothOwnerAliasesWithinTheRequestedWeek() {
         let scopes = myOrderOwnedWeekQueryScopes(
             memberId: "member_1",
             weekKey: "2026-W30"
@@ -358,8 +337,7 @@ extension ReguertaTests {
         )
     }
 
-    @Test
-    func previousOrderCandidatesKeepTheDeterministicIdAndDeduplicateDiscoveredOrders() {
+    @Test func previousOrderCandidatesKeepTheDeterministicIdAndDeduplicateDiscoveredOrders() {
         let candidateIds = myOrderCandidateOrderIds(
             deterministicOrderId: "member_1_2026-W30",
             discoveredOrderIds: [
@@ -373,8 +351,7 @@ extension ReguertaTests {
         #expect(candidateIds == ["member_1_2026-W30", "legacy_member_1_2026-W30"])
     }
 
-    @Test
-    func checkoutUsesTheSingleHistoricalOrderIdInsteadOfCreatingADuplicate() throws {
+    @Test func checkoutUsesTheSingleHistoricalOrderIdInsteadOfCreatingADuplicate() throws {
         let resolvedOrderId = try resolveMyOrderCheckoutDocumentId(
             newOrderId: "member_1_2026-W30",
             existingOrderIds: ["-O-historical-order"]
@@ -383,8 +360,7 @@ extension ReguertaTests {
         #expect(resolvedOrderId == "-O-historical-order")
     }
 
-    @Test
-    func checkoutUsesTheNewIdOnlyWhenTheOwnedWeekHasNoOrder() throws {
+    @Test func checkoutUsesTheNewIdOnlyWhenTheOwnedWeekHasNoOrder() throws {
         let resolvedOrderId = try resolveMyOrderCheckoutDocumentId(
             newOrderId: "member_1_2026-W30",
             existingOrderIds: []
@@ -393,8 +369,7 @@ extension ReguertaTests {
         #expect(resolvedOrderId == "member_1_2026-W30")
     }
 
-    @Test
-    func checkoutRejectsAnAmbiguousOwnedWeekBeforeSelectingAnOrder() {
+    @Test func checkoutRejectsAnAmbiguousOwnedWeekBeforeSelectingAnOrder() {
         #expect(throws: MyOrderCheckoutResolutionError.ambiguousExistingOrders) {
             try resolveMyOrderCheckoutDocumentId(
                 newOrderId: "member_1_2026-W30",
@@ -403,8 +378,7 @@ extension ReguertaTests {
         }
     }
 
-    @Test
-    func memberVisibleFirestorePathsUseSanitizedDirectoryAndConfig() {
+    @Test func memberVisibleFirestorePathsUseSanitizedDirectoryAndConfig() {
         let path = ReguertaFirestorePath(environment: .develop)
 
         #expect(path.collectionPath(.memberDirectory) == "develop/plus-collections/memberDirectory")

--- a/ios/Reguerta/ReguertaTests/ReguertaUsersViewModelTests.swift
+++ b/ios/Reguerta/ReguertaTests/ReguertaUsersViewModelTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 @MainActor
 struct ReguertaUsersViewModelTests {
-    @Test
-    func usersViewModelLoadsMembersAndResetsWhenSignedOut() async {
+    @Test func usersViewModelLoadsMembersAndResetsWhenSignedOut() async {
         let admin = usersAdminMember()
         let member = usersRegularMember(id: "member_1", displayName: "Member One")
         let scenario = makeUsersScenario(currentMember: admin, members: [admin, member], startsAuthorized: false)
@@ -27,8 +26,7 @@ struct ReguertaUsersViewModelTests {
         #expect(scenario.viewModel.isEditorOpen == false)
     }
 
-    @Test
-    func usersViewModelBlocksUnauthorizedMemberManagementActions() async {
+    @Test func usersViewModelBlocksUnauthorizedMemberManagementActions() async {
         let member = usersRegularMember(id: "member_1", displayName: "Member One")
         let scenario = makeUsersScenario(currentMember: member, members: [member])
         scenario.viewModel.draft = validMemberDraft(email: "new@reguerta.app")
@@ -43,8 +41,7 @@ struct ReguertaUsersViewModelTests {
         #expect(scenario.viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackOnlyAdminToggleActive)
     }
 
-    @Test
-    func usersViewModelValidatesDraftBeforeSaving() async {
+    @Test func usersViewModelValidatesDraftBeforeSaving() async {
         let admin = usersAdminMember()
         let existing = usersRegularMember(id: "member_existing", email: "existing@reguerta.app")
         let scenario = makeUsersScenario(currentMember: admin, members: [admin, existing])
@@ -66,8 +63,7 @@ struct ReguertaUsersViewModelTests {
         #expect(scenario.viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackMemberExists)
     }
 
-    @Test
-    func usersViewModelCreatesPreAuthorizedMemberWithNormalizedPayload() async {
+    @Test func usersViewModelCreatesPreAuthorizedMemberWithNormalizedPayload() async {
         let admin = usersAdminMember()
         let scenario = makeUsersScenario(currentMember: admin, members: [admin])
         scenario.viewModel.draft = MemberDraft(
@@ -95,8 +91,7 @@ struct ReguertaUsersViewModelTests {
         #expect(scenario.viewModel.draft == MemberDraft())
     }
 
-    @Test
-    func specializedDraftsAlwaysPersistCanonicalMemberRole() async {
+    @Test func specializedDraftsAlwaysPersistCanonicalMemberRole() async {
         let admin = usersAdminMember()
         let scenario = makeUsersScenario(currentMember: admin, members: [admin])
         scenario.viewModel.draft = MemberDraft(
@@ -123,8 +118,7 @@ struct ReguertaUsersViewModelTests {
         #expect(createdAdmin?.roles == [.member, .admin])
     }
 
-    @Test
-    func memberIdsRemainDistinctWhenLongEmailSlugsShareFirstFortyCharacters() {
+    @Test func memberIdsRemainDistinctWhenLongEmailSlugsShareFirstFortyCharacters() {
         let sharedPrefix = String(repeating: "a", count: 45)
         let firstEmail = "\(sharedPrefix)one@example.com"
         let secondEmail = "\(sharedPrefix)two@example.com"
@@ -139,8 +133,7 @@ struct ReguertaUsersViewModelTests {
         #expect(firstId == buildMemberId(from: firstEmail.uppercased()))
     }
 
-    @Test
-    func usersViewModelEditsMemberAndPreservesExistingMetadata() async {
+    @Test func usersViewModelEditsMemberAndPreservesExistingMetadata() async {
         let admin = usersAdminMember()
         let producer = usersRegularMember(
             id: "producer_1",
@@ -178,8 +171,7 @@ struct ReguertaUsersViewModelTests {
         #expect(updated?.isCommonPurchaseManager == true)
     }
 
-    @Test
-    func usersEditorKeepsProducerAndCommonPurchasesCompanyStateConsistent() {
+    @Test func usersEditorKeepsProducerAndCommonPurchasesCompanyStateConsistent() {
         let admin = usersAdminMember()
         let scenario = makeUsersScenario(currentMember: admin, members: [admin])
 
@@ -203,8 +195,7 @@ struct ReguertaUsersViewModelTests {
         #expect(scenario.viewModel.draft.companyName.isEmpty)
     }
 
-    @Test
-    func usersHeaderAndBackActionFollowEditorState() {
+    @Test func usersHeaderAndBackActionFollowEditorState() {
         let rootViewModel = ReguertaAppEnvironment.preview().accessRootViewModel
         rootViewModel.homeDestination = .users
         rootViewModel.usersViewModel.isEditorOpen = true
@@ -225,8 +216,7 @@ struct ReguertaUsersViewModelTests {
         #expect(rootViewModel.homeDestination == .dashboard)
     }
 
-    @Test
-    func usersViewModelTogglesAdminAndActiveStatusAndUpdatesSession() async {
+    @Test func usersViewModelTogglesAdminAndActiveStatusAndUpdatesSession() async {
         let admin = usersAdminMember()
         let member = usersRegularMember(id: "member_1", displayName: "Member One")
         let scenario = makeUsersScenario(currentMember: admin, members: [admin, member])
@@ -251,8 +241,7 @@ struct ReguertaUsersViewModelTests {
         #expect(session.members.first { $0.id == member.id }?.isActive == false)
     }
 
-    @Test
-    func usersViewModelMapsPersistenceFailuresToFeedback() async {
+    @Test func usersViewModelMapsPersistenceFailuresToFeedback() async {
         let sessionAdmin = usersAdminMember()
         let accessDeniedScenario = makeUsersScenario(
             currentMember: sessionAdmin,
@@ -288,8 +277,7 @@ struct ReguertaUsersViewModelTests {
         #expect(genericScenario.viewModel.feedbackCenter.messageKey == AccessL10nKey.feedbackUnableSaveChanges)
     }
 
-    @Test
-    func previewEnvironmentUsesSharedInMemoryUsersDependencies() throws {
+    @Test func previewEnvironmentUsesSharedInMemoryUsersDependencies() throws {
         let environment = ReguertaAppEnvironment.preview()
 
         #expect(environment.accessRootViewModel.usersViewModel.sessionViewModel === environment.sessionViewModel)

--- a/ios/Reguerta/ReguertaTests/SessionOperationCleanupBarrierTests.swift
+++ b/ios/Reguerta/ReguertaTests/SessionOperationCleanupBarrierTests.swift
@@ -233,8 +233,7 @@ extension SessionOperationInvalidationTests {
         #expect(scenario.provider.signInRequestCount == 0)
     }
 
-    @Test("Un cierre repetido no oculta un cleanup que ya falló")
-    func repeatedSignOutPreservesFailedCleanup() async {
+    @Test("Un cierre repetido no oculta un cleanup que ya falló") func repeatedSignOutPreservesFailedCleanup() async {
         let freshnessRepository = ControlledSessionFreshnessRepository(
             clearResults: [false, true]
         )
@@ -265,10 +264,7 @@ extension SessionOperationInvalidationTests {
     }
 }
 
-@MainActor
-private func expireRefresh(
-    in scenario: SessionTimeoutScenario
-) async throws -> Task<Void, Never>? {
+@MainActor private func expireRefresh(in scenario: SessionTimeoutScenario) async throws -> Task<Void, Never>? {
     scenario.viewModel.refreshSession(trigger: .startup)
     guard await scenario.provider.waitForRefreshRequestCount(1) else { return nil }
     try await scenario.sleeper.waitForRequestCount(1)
@@ -282,8 +278,7 @@ private func expireRefresh(
     return operation
 }
 
-@MainActor
-private func populateValidSignIn(in scenario: SessionTimeoutScenario) {
+@MainActor private func populateValidSignIn(in scenario: SessionTimeoutScenario) {
     scenario.viewModel.emailInput = scenario.member.normalizedEmail
     scenario.viewModel.passwordInput = "secret12"
 }

--- a/ios/Reguerta/ReguertaTests/SessionOperationInvalidationTests.swift
+++ b/ios/Reguerta/ReguertaTests/SessionOperationInvalidationTests.swift
@@ -314,8 +314,7 @@ private func makeViewModel(
     )
 }
 
-@MainActor
-private func authenticatedMember() -> Member {
+@MainActor private func authenticatedMember() -> Member {
     Member(
         id: "member_1",
         displayName: "Member",

--- a/ios/Reguerta/ReguertaTests/SessionOperationPreProviderCancellationTests.swift
+++ b/ios/Reguerta/ReguertaTests/SessionOperationPreProviderCancellationTests.swift
@@ -60,14 +60,12 @@ extension SessionOperationInvalidationTests {
     }
 }
 
-@MainActor
-private func populateValidPreProviderSignIn(in scenario: SessionTimeoutScenario) {
+@MainActor private func populateValidPreProviderSignIn(in scenario: SessionTimeoutScenario) {
     scenario.viewModel.emailInput = scenario.member.normalizedEmail
     scenario.viewModel.passwordInput = "secret12"
 }
 
-@MainActor
-private func assertPreProviderTermination(in scenario: SessionTimeoutScenario) {
+@MainActor private func assertPreProviderTermination(in scenario: SessionTimeoutScenario) {
     #expect(scenario.viewModel.mode == .signedOut)
     #expect(scenario.viewModel.sessionOperationState == .idle)
     #expect(scenario.viewModel.sessionOperationTask == nil)

--- a/ios/Reguerta/ReguertaTests/SessionOperationTimeoutTests.swift
+++ b/ios/Reguerta/ReguertaTests/SessionOperationTimeoutTests.swift
@@ -268,10 +268,7 @@ func makeSessionTimeoutScenario(
     )
 }
 
-@MainActor
-private func expireSignIn(
-    in scenario: SessionTimeoutScenario
-) async throws -> Task<Void, Never>? {
+@MainActor private func expireSignIn(in scenario: SessionTimeoutScenario) async throws -> Task<Void, Never>? {
     scenario.viewModel.emailInput = scenario.member.normalizedEmail
     scenario.viewModel.passwordInput = "secret12"
     scenario.viewModel.signIn()
@@ -288,11 +285,7 @@ private func expireSignIn(
     return operation
 }
 
-@MainActor
-private func populateValidAccessDrafts(
-    in viewModel: SessionViewModel,
-    member: Member
-) {
+@MainActor private func populateValidAccessDrafts(in viewModel: SessionViewModel, member: Member) {
     viewModel.emailInput = member.normalizedEmail
     viewModel.passwordInput = "new-secret12"
     viewModel.registerEmailInput = "new-member@example.com"
@@ -300,8 +293,7 @@ private func populateValidAccessDrafts(
     viewModel.registerRepeatPasswordInput = "new-secret12"
 }
 
-@MainActor
-private func timeoutMember() -> Member {
+@MainActor private func timeoutMember() -> Member {
     Member(
         id: "timeout_member",
         displayName: "Timeout Member",
@@ -313,10 +305,7 @@ private func timeoutMember() -> Member {
     )
 }
 
-func timeoutAuthorizedMode(
-    member: Member,
-    principal: AuthPrincipal
-) -> SessionMode {
+func timeoutAuthorizedMode(member: Member, principal: AuthPrincipal) -> SessionMode {
     .authorized(
         AuthorizedSession(
             principal: principal,

--- a/ios/Reguerta/ReguertaTests/SessionPostAuthenticationFailureTests.swift
+++ b/ios/Reguerta/ReguertaTests/SessionPostAuthenticationFailureTests.swift
@@ -191,10 +191,7 @@ private func makePostAuthenticationViewModel(
 }
 
 @MainActor
-private func startPostAuthenticationSignIn(
-    in viewModel: SessionViewModel,
-    member: Member
-) -> Task<Void, Never>? {
+private func startPostAuthenticationSignIn(in viewModel: SessionViewModel, member: Member) -> Task<Void, Never>? {
     viewModel.emailInput = member.normalizedEmail
     viewModel.passwordInput = "secret12"
     viewModel.signIn()
@@ -206,10 +203,7 @@ private func startPostAuthenticationSignIn(
 }
 
 @MainActor
-private func assertPostAuthenticationFailure(
-    viewModel: SessionViewModel,
-    provider: ControlledSessionAuthProvider
-) {
+private func assertPostAuthenticationFailure(viewModel: SessionViewModel, provider: ControlledSessionAuthProvider) {
     #expect(viewModel.mode == .signedOut)
     #expect(viewModel.sessionOperationState == .idle)
     #expect(viewModel.sessionOperationTask == nil)
@@ -219,8 +213,7 @@ private func assertPostAuthenticationFailure(
     #expect(provider.signOutCallCount == 2)
 }
 
-@MainActor
-private func postAuthenticationMember() -> Member {
+@MainActor private func postAuthenticationMember() -> Member {
     Member(
         id: "post_auth_member",
         displayName: "Post Auth Member",

--- a/ios/Reguerta/ReguertaTests/StartupAndFreshnessConfigurationDecodingTests.swift
+++ b/ios/Reguerta/ReguertaTests/StartupAndFreshnessConfigurationDecodingTests.swift
@@ -6,8 +6,7 @@ import Testing
 
 @MainActor
 struct StartupAndFreshnessConfigurationDecodingTests {
-    @Test
-    func startupConfigurationAcceptsValidDataAndRejectsMalformedData() throws {
+    @Test func startupConfigurationAcceptsValidDataAndRejectsMalformedData() throws {
         let validData: [String: Any] = [
             "versions": [
                 "ios": [
@@ -41,8 +40,7 @@ struct StartupAndFreshnessConfigurationDecodingTests {
         }
     }
 
-    @Test
-    func freshnessConfigurationAcceptsValidDataAndRejectsMalformedData() throws {
+    @Test func freshnessConfigurationAcceptsValidDataAndRejectsMalformedData() throws {
         let timestamp = Timestamp(date: Date(timeIntervalSince1970: 1))
         let validData: [String: Any] = [
             "cacheExpirationMinutes": 15,

--- a/ios/Reguerta/ReguertaTests/StartupVersionPolicyValidationTests.swift
+++ b/ios/Reguerta/ReguertaTests/StartupVersionPolicyValidationTests.swift
@@ -4,8 +4,7 @@ import Testing
 
 @MainActor
 struct StartupVersionPolicyValidationTests {
-    @Test
-    func startupGateRejectsMalformedPolicy() {
+    @Test func startupGateRejectsMalformedPolicy() {
         let policy = StartupVersionPolicy(
             currentVersion: "invalid",
             minimumVersion: "0.3.0",
@@ -21,8 +20,7 @@ struct StartupVersionPolicyValidationTests {
         }
     }
 
-    @Test
-    func semanticVersionComparatorRejectsOverflowingComponents() {
+    @Test func semanticVersionComparatorRejectsOverflowingComponents() {
         let overflowingComponent = String(repeating: "9", count: 100)
 
         #expect(SemanticVersionComparator.compare("1.\(overflowingComponent).0", "1.0.0") == nil)

--- a/ios/Reguerta/ReguertaUITests/ReguertaUITests.swift
+++ b/ios/Reguerta/ReguertaUITests/ReguertaUITests.swift
@@ -38,8 +38,7 @@ final class ReguertaUITests: XCTestCase {
         XCUIApplication().terminate()
     }
 
-    @MainActor
-    func testUnauthorizedUserShowsRestrictedMode() throws {
+    @MainActor func testUnauthorizedUserShowsRestrictedMode() throws {
         let app = configuredApp()
         let emailField = launchAndOpenLogin(app)
 
@@ -61,8 +60,7 @@ final class ReguertaUITests: XCTestCase {
         XCTAssertTrue(app.buttons["Enter the app"].waitForExistence(timeout: 5))
     }
 
-    @MainActor
-    func testPreAuthorizedProducerEntersHomeWithActionRowEnabled() throws {
+    @MainActor func testPreAuthorizedProducerEntersHomeWithActionRowEnabled() throws {
         let app = configuredApp()
         let emailField = launchAndOpenLogin(app)
         emailField.tap()
@@ -91,8 +89,7 @@ final class ReguertaUITests: XCTestCase {
         XCTAssertTrue(receivedOrdersButton.isEnabled, "Received orders should be enabled")
     }
 
-    @MainActor
-    func testHomeShowsLatestNewsWithoutBottomObstruction() throws {
+    @MainActor func testHomeShowsLatestNewsWithoutBottomObstruction() throws {
         let app = configuredApp()
         signInAsProducer(in: app)
 
@@ -147,8 +144,7 @@ final class ReguertaUITests: XCTestCase {
         )
     }
 
-    @MainActor
-    func testMyOrderSearchBarStaysAboveBottomSafeArea() throws {
+    @MainActor func testMyOrderSearchBarStaysAboveBottomSafeArea() throws {
         let app = configuredApp()
         signInAsProducer(in: app)
 
@@ -167,8 +163,7 @@ final class ReguertaUITests: XCTestCase {
         )
     }
 
-    @MainActor
-    func testUsersAddButtonStaysAboveBottomSafeArea() throws {
+    @MainActor func testUsersAddButtonStaysAboveBottomSafeArea() throws {
         let app = configuredApp()
         signInAsAdmin(in: app)
 
@@ -188,8 +183,7 @@ final class ReguertaUITests: XCTestCase {
         )
     }
 
-    @MainActor
-    func testDrawerNavigationOpensSelectedRoute() throws {
+    @MainActor func testDrawerNavigationOpensSelectedRoute() throws {
         let app = configuredApp()
         let emailField = launchAndOpenLogin(app)
         emailField.tap()
@@ -219,8 +213,7 @@ final class ReguertaUITests: XCTestCase {
         XCTAssertEqual(title.label, "News")
     }
 
-    @MainActor
-    func testInvalidCredentialsShowsInlineErrorWithoutCrash() throws {
+    @MainActor func testInvalidCredentialsShowsInlineErrorWithoutCrash() throws {
         let app = configuredApp()
         let emailField = launchAndOpenLogin(app)
 
@@ -241,8 +234,7 @@ final class ReguertaUITests: XCTestCase {
         XCTAssertTrue(app.buttons[signInButtonId].exists, "App should remain alive on invalid credentials")
     }
 
-    @MainActor
-    func testLaunchPerformance() throws {
+    @MainActor func testLaunchPerformance() throws {
         // This measures how long it takes to launch your application.
         measure(metrics: [XCTApplicationLaunchMetric()]) {
             configuredApp().launch()
@@ -286,22 +278,19 @@ final class ReguertaUITests: XCTestCase {
         return query.count >= minimumCount
     }
 
-    @MainActor
-    private func signInAsProducer(in app: XCUIApplication) {
+    @MainActor private func signInAsProducer(in app: XCUIApplication) {
         signIn(email: "pablo.producer@reguerta.app", in: app)
 
         XCTAssertTrue(app.buttons[myOrderButtonId].waitForExistence(timeout: 8), "Home did not load")
     }
 
-    @MainActor
-    private func signInAsAdmin(in app: XCUIApplication) {
+    @MainActor private func signInAsAdmin(in app: XCUIApplication) {
         signIn(email: "ana.admin@reguerta.app", in: app)
 
         XCTAssertTrue(app.buttons[menuButtonId].waitForExistence(timeout: 8), "Home did not load")
     }
 
-    @MainActor
-    private func signIn(email: String, in app: XCUIApplication) {
+    @MainActor private func signIn(email: String, in app: XCUIApplication) {
         let emailField = launchAndOpenLogin(app)
         emailField.tap()
         emailField.typeText(email)
@@ -315,8 +304,7 @@ final class ReguertaUITests: XCTestCase {
         dismissPasswordSavePromptIfNeeded(in: app)
     }
 
-    @MainActor
-    private func openDrawer(in app: XCUIApplication) {
+    @MainActor private func openDrawer(in app: XCUIApplication) {
         let menuButton = app.buttons[menuButtonId]
         XCTAssertTrue(menuButton.waitForExistence(timeout: 8), "Menu button not found")
         dismissPasswordSavePromptIfNeeded(in: app, timeout: 1)
@@ -324,22 +312,19 @@ final class ReguertaUITests: XCTestCase {
         menuButton.tap()
     }
 
-    @MainActor
-    private func waitForHittable(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
+    @MainActor private func waitForHittable(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
         let predicate = NSPredicate(format: "isHittable == true")
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
         return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
     }
 
-    @MainActor
-    private func waitForEnabled(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
+    @MainActor private func waitForEnabled(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
         let predicate = NSPredicate(format: "isEnabled == true")
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
         return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
     }
 
-    @MainActor
-    private func dismissPasswordSavePromptIfNeeded(in app: XCUIApplication, timeout: TimeInterval = 2) {
+    @MainActor private func dismissPasswordSavePromptIfNeeded(in app: XCUIApplication, timeout: TimeInterval = 2) {
         for title in ["Not Now", "Ahora no"] {
             let button = app.buttons[title]
             if button.waitForExistence(timeout: timeout) {
@@ -358,8 +343,7 @@ final class ReguertaUITests: XCTestCase {
         }
     }
 
-    @MainActor
-    private func launchAndOpenLogin(_ app: XCUIApplication) -> XCUIElement {
+    @MainActor private func launchAndOpenLogin(_ app: XCUIApplication) -> XCUIElement {
         app.launch()
 
         let enterButton = app.buttons[enterButtonId]

--- a/ios/Reguerta/ReguertaUITests/ReguertaUITestsLaunchTests.swift
+++ b/ios/Reguerta/ReguertaUITests/ReguertaUITestsLaunchTests.swift
@@ -17,8 +17,7 @@ final class ReguertaUITestsLaunchTests: XCTestCase {
         continueAfterFailure = false
     }
 
-    @MainActor
-    func testLaunch() throws {
+    @MainActor func testLaunch() throws {
         throw XCTSkip("Flaky screenshot launch test in parallel simulator clones; launch behavior is covered by dedicated UI tests.")
     }
 }


### PR DESCRIPTION
## Summary

- normalize Swift `func`, `init`, `subscript`, attribute, and typed-property declarations under the horizontal-first 120-column policy
- keep long, complex, and four-or-more-parameter signatures vertical with one parameter per line
- clarify in `AGENTS.md` that a separated declaration attribute is its own layout unit
- preserve Swift tokens, comments, APIs, bodies, isolation, and behavior
- record the delivery in `CHANGELOG.md`

## Scope

This is **PR 1 — Declarations** of #236.

The guard/helper cleanup and the residual line-length/baseline work remain intentionally deferred to PRs 2 and 3. This PR does not close #236.

## Impact

Readability and consistency only. There are no functional, architectural, API, Firebase, or cross-platform behavior changes.

## Validation

- SwiftSyntax token/comment preservation: **158/158 files**
- Swift parser: **158/158 files**
- `git diff --check`: clean
- SwiftLint 0.61.0 strict with baseline: clean
- declaration inventory: no actionable horizontal, manual, property, vertical, or hybrid candidates
- 17 raw hybrid warnings manually reconciled as attribute-layout false positives
- Xcode MCP `BuildProject` Release: passed
- Xcode MCP `RunAllTests`: **615 passed, 1 deliberate skip, 0 failed, 0 not run**
- independent iOS standards review: no findings
- independent SwiftUI/accessibility review: no findings; previews N/A because the visual tree and preview tokens are unchanged

## Pre-existing warnings

After the full test run, Xcode reports five Swift concurrency warnings already present in the base behavior: one in `AppDelegate.swift` outside this diff and four in UI-test code whose tokens are unchanged. They were not introduced or aggravated here and are intentionally not mixed into this formatting-only PR.

Refs #236