### PR TITLE
💄 style(ios): compact eligible Swift blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- 2026-08-05 | 💄 style(ios): normalize Swift declaration layout
 - 2026-08-02 | ♻️ refactor(ios): reduce existential erasure
 - 2026-07-29 | ♻️ refactor(ios): clear SwiftLint warnings
 - 2026-07-24 | ♻️ refactor(ios): split large feature files

--- a/ios/Reguerta/Reguerta/App/AppDelegate.swift
+++ b/ios/Reguerta/Reguerta/App/AppDelegate.swift
@@ -23,9 +23,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         ReguertaFontRegistrar.registerDesignFonts()
-        guard !Self.usesMockAuth else {
-            return true
-        }
+        guard !Self.usesMockAuth else { return true }
         FirebaseBootstrapper.configureIfNeeded()
         Messaging.messaging().delegate = self
         UNUserNotificationCenter.current().delegate = self
@@ -34,9 +32,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        guard !Self.usesMockAuth else {
-            return
-        }
+        guard !Self.usesMockAuth else { return }
         Messaging.messaging().apnsToken = deviceToken
         Messaging.messaging().token { _, error in
             if let error {
@@ -49,9 +45,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: any Error) {
-        guard !Self.usesMockAuth else {
-            return
-        }
+        guard !Self.usesMockAuth else { return }
         print("APNs registration failed: \(error.localizedDescription)")
     }
 
@@ -74,9 +68,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
 
 extension AppDelegate: MessagingDelegate {
     func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-        guard !Self.usesMockAuth else {
-            return
-        }
+        guard !Self.usesMockAuth else { return }
         guard let authorizedDeviceRegistrar else {
             pendingRegistrationToken = .received(fcmToken)
             return

--- a/ios/Reguerta/Reguerta/App/BylawsFeatureDependencies.swift
+++ b/ios/Reguerta/Reguerta/App/BylawsFeatureDependencies.swift
@@ -37,9 +37,7 @@ struct BylawsFeatureDependencies {
 private struct PreviewBylawsConsultant: BylawsConsulting {
     let configuredCapability: BylawsConsultationCapability
 
-    func capability(for _: BylawsResponseLanguage) async -> BylawsConsultationCapability {
-        configuredCapability
-    }
+    func capability(for _: BylawsResponseLanguage) async -> BylawsConsultationCapability { configuredCapability }
 
     func consult(question: String, responseLanguage: BylawsResponseLanguage) async throws -> BylawsConsultationResult {
         BylawsConsultationResult(

--- a/ios/Reguerta/Reguerta/App/BylawsPreviewSupport.swift
+++ b/ios/Reguerta/Reguerta/App/BylawsPreviewSupport.swift
@@ -109,9 +109,7 @@ extension BylawsConsultationResult {
 private struct PreviewBylawsDocumentProvider: BylawsDocumentProviding {
     let pdfURL: URL
 
-    @MainActor func bundledPdfURL() -> URL? {
-        pdfURL
-    }
+    @MainActor func bundledPdfURL() -> URL? { pdfURL }
 }
 
 @Model

--- a/ios/Reguerta/Reguerta/App/MyOrderFreshnessFeatureDependencies.swift
+++ b/ios/Reguerta/Reguerta/App/MyOrderFreshnessFeatureDependencies.swift
@@ -77,9 +77,7 @@ private final class PreviewCriticalDataFreshnessLocalRepository: CriticalDataFre
     private var metadata: CriticalDataFreshnessMetadata?
     private(set) var writeGeneration: UInt64 = 0
 
-    func getMetadata() -> CriticalDataFreshnessMetadata? {
-        metadata
-    }
+    func getMetadata() -> CriticalDataFreshnessMetadata? { metadata }
 
     func saveMetadata(
         _ metadata: CriticalDataFreshnessMetadata,

--- a/ios/Reguerta/Reguerta/Core/Layout/DeviceScale.swift
+++ b/ios/Reguerta/Reguerta/Core/Layout/DeviceScale.swift
@@ -39,17 +39,11 @@ enum DeviceScale {
         }
     }
 
-    static func resize(_ value: CGFloat) -> CGFloat {
-        value * scaleFactor
-    }
+    static func resize(_ value: CGFloat) -> CGFloat { value * scaleFactor }
 
-    static func resizeStatusBar(_ value: CGFloat) -> CGFloat {
-        resize(value) + statusBarHeight
-    }
+    static func resizeStatusBar(_ value: CGFloat) -> CGFloat { resize(value) + statusBarHeight }
 
-    static func resizeBottom(_ value: CGFloat) -> CGFloat {
-        resize(value) + bottomSafeArea
-    }
+    static func resizeBottom(_ value: CGFloat) -> CGFloat { resize(value) + bottomSafeArea }
 }
 
 private extension UIWindow {

--- a/ios/Reguerta/Reguerta/Data/Access/AuthenticatedFirebaseFunctionsClient.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/AuthenticatedFirebaseFunctionsClient.swift
@@ -85,9 +85,7 @@ struct AuthenticatedFirebaseFunctionsClient {
         } catch {
             throw mapTransportError(error)
         }
-        guard !token.isEmpty else {
-            throw FirebaseFunctionClientError.missingIDToken
-        }
+        guard !token.isEmpty else { throw FirebaseFunctionClientError.missingIDToken }
 
         let endpointURL = baseURL.appendingPathComponent(function.rawValue, isDirectory: false)
         guard endpointURL.scheme == "https", endpointURL.host != nil else {

--- a/ios/Reguerta/Reguerta/Data/Access/FirebaseAuthSessionProvider.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/FirebaseAuthSessionProvider.swift
@@ -22,9 +22,7 @@ struct FirebaseAuthSessionProvider: AuthSessionProvider {
                 } signOut: {
                     signOut()
                 }
-                guard let refreshedUser = auth.currentUser else {
-                    throw FirebaseIDTokenError.noAuthenticatedUser
-                }
+                guard let refreshedUser = auth.currentUser else { throw FirebaseIDTokenError.noAuthenticatedUser }
                 _ = try await awaitFirebaseAuthenticationMutation {
                     try await refreshedUser.getIDTokenResult(forcingRefresh: true)
                 } signOut: {
@@ -96,17 +94,13 @@ struct FirebaseAuthSessionProvider: AuthSessionProvider {
     }
 
     func refreshCurrentSession() async -> AuthSessionRefreshResult {
-        guard let user = auth.currentUser else {
-            return .noSession
-        }
+        guard let user = auth.currentUser else { return .noSession }
 
         do {
             return try await awaitFirebaseAuthenticationFlow {
                 try await user.reload()
             } continuation: {
-                guard let refreshedUser = auth.currentUser else {
-                    return .expired
-                }
+                guard let refreshedUser = auth.currentUser else { return .expired }
                 _ = try await awaitFirebaseAuthenticationMutation {
                     try await refreshedUser.getIDTokenResult(forcingRefresh: true)
                 } signOut: {
@@ -138,13 +132,9 @@ struct FirebaseAuthSessionProvider: AuthSessionProvider {
     }
 
     func validIDToken(forcingRefresh: Bool) async throws -> String {
-        guard let user = auth.currentUser else {
-            throw FirebaseIDTokenError.noAuthenticatedUser
-        }
+        guard let user = auth.currentUser else { throw FirebaseIDTokenError.noAuthenticatedUser }
         try await user.reload()
-        guard let refreshedUser = auth.currentUser else {
-            throw FirebaseIDTokenError.noAuthenticatedUser
-        }
+        guard let refreshedUser = auth.currentUser else { throw FirebaseIDTokenError.noAuthenticatedUser }
         return try await refreshedUser.getIDTokenResult(forcingRefresh: forcingRefresh).token
     }
 
@@ -226,9 +216,7 @@ private func normalizedEmail(_ email: String) -> String {
 
 @MainActor func mapFirebaseAuthError(_ error: Error) -> AuthSignInFailureReason {
     let nsError = error as NSError
-    guard let code = AuthErrorCode(rawValue: nsError.code) else {
-        return .unknown
-    }
+    guard let code = AuthErrorCode(rawValue: nsError.code) else { return .unknown }
 
     switch code {
     case .invalidEmail:
@@ -254,9 +242,7 @@ private func normalizedEmail(_ email: String) -> String {
 
 @MainActor private func isExpiredSessionError(_ error: Error) -> Bool {
     let nsError = error as NSError
-    guard let code = AuthErrorCode(rawValue: nsError.code) else {
-        return false
-    }
+    guard let code = AuthErrorCode(rawValue: nsError.code) else { return false }
 
     switch code {
     case .userDisabled, .userNotFound, .invalidCredential, .userTokenExpired, .invalidUserToken:

--- a/ios/Reguerta/Reguerta/Data/Access/FirebaseAuthorizedMemberResolver.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/FirebaseAuthorizedMemberResolver.swift
@@ -42,9 +42,7 @@ struct FirebaseAuthorizedMemberResolver: AuthorizedMemberResolving {
                 firstLoginLinked: response.firstLoginLinked
             )
         } catch let error as FirebaseFunctionClientError {
-            guard case .forbidden(let code, _) = error else {
-                throw error
-            }
+            guard case .forbidden(let code, _) = error else { throw error }
             switch code {
             case "member_not_found", "unlinked_account":
                 throw AuthorizedMemberResolutionError.unauthorized(.userNotFoundInAuthorizedUsers)

--- a/ios/Reguerta/Reguerta/Data/Access/FirestoreMemberRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/FirestoreMemberRepository.swift
@@ -239,9 +239,7 @@ private extension FirestoreMemberRepository {
         let resource = "members.document"
         let parsedRoles: Set<MemberRole>
         if let rawRoles = data["roles"], !(rawRoles is NSNull) {
-            guard let values = rawRoles as? [Any] else {
-                throw RepositoryError.invalidData(resource: resource)
-            }
+            guard let values = rawRoles as? [Any] else { throw RepositoryError.invalidData(resource: resource) }
             parsedRoles = try Set(values.map { value in
                 guard let value = value as? String,
                       let role = legacyCompatibleRole(from: value) else {
@@ -303,9 +301,7 @@ private extension FirestoreMemberRepository {
     private static func optionalString(_ data: [String: Any], keys: [String], resource: String) throws -> String? {
         for key in keys {
             guard let rawValue = data[key], !(rawValue is NSNull) else { continue }
-            guard let value = rawValue as? String else {
-                throw RepositoryError.invalidData(resource: resource)
-            }
+            guard let value = rawValue as? String else { throw RepositoryError.invalidData(resource: resource) }
             let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
             if !normalized.isEmpty { return normalized }
         }
@@ -327,9 +323,7 @@ private extension FirestoreMemberRepository {
     ) throws -> Bool {
         for key in keys {
             guard let rawValue = data[key], !(rawValue is NSNull) else { continue }
-            guard let value = rawValue as? Bool else {
-                throw RepositoryError.invalidData(resource: resource)
-            }
+            guard let value = rawValue as? Bool else { throw RepositoryError.invalidData(resource: resource) }
             return value
         }
         return defaultValue
@@ -337,9 +331,7 @@ private extension FirestoreMemberRepository {
 
     private static func optionalMap(_ data: [String: Any], field: String, resource: String) throws -> [String: Any]? {
         guard let rawValue = data[field], !(rawValue is NSNull) else { return nil }
-        guard let value = rawValue as? [String: Any] else {
-            throw RepositoryError.invalidData(resource: resource)
-        }
+        guard let value = rawValue as? [String: Any] else { throw RepositoryError.invalidData(resource: resource) }
         return value
     }
 
@@ -349,9 +341,7 @@ private extension FirestoreMemberRepository {
         acceptsLegacyCasing: Bool
     ) throws -> ProducerParity? {
         guard let rawValue, !(rawValue is NSNull) else { return nil }
-        guard let value = rawValue as? String else {
-            throw RepositoryError.invalidData(resource: resource)
-        }
+        guard let value = rawValue as? String else { throw RepositoryError.invalidData(resource: resource) }
         let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
         let candidate = acceptsLegacyCasing ? normalized.lowercased() : normalized
         guard let parity = ProducerParity(rawValue: candidate) else {
@@ -376,9 +366,7 @@ private extension FirestoreMemberRepository {
         acceptsLegacyCasing: Bool
     ) throws -> EcoCommitmentMode {
         guard let rawValue, !(rawValue is NSNull) else { return defaultValue }
-        guard let value = rawValue as? String else {
-            throw RepositoryError.invalidData(resource: resource)
-        }
+        guard let value = rawValue as? String else { throw RepositoryError.invalidData(resource: resource) }
         let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
         let candidate = acceptsLegacyCasing ? normalized.lowercased() : normalized
         guard let mode = EcoCommitmentMode(rawValue: candidate) else {

--- a/ios/Reguerta/Reguerta/Data/Access/InMemoryMemberRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/InMemoryMemberRepository.swift
@@ -43,9 +43,7 @@ actor InMemoryMemberRepository: LocalMemberRepository {
         )
     ]
 
-    func member(id: String) async throws -> Member? {
-        members[id]
-    }
+    func member(id: String) async throws -> Member? { members[id] }
 
     func members(visibleTo member: Member) async throws -> [Member] {
         let canReadAll = await MainActor.run { member.canManageMembers }
@@ -61,9 +59,7 @@ actor InMemoryMemberRepository: LocalMemberRepository {
     }
 
     func updateOwnProducerCatalogEnabled(member: Member, enabled: Bool) async throws -> Member {
-        guard let existing = members[member.id] else {
-            throw InMemoryMemberRepositoryError.memberNotFound
-        }
+        guard let existing = members[member.id] else { throw InMemoryMemberRepositoryError.memberNotFound }
         let updated = Member(
             id: existing.id,
             displayName: existing.displayName,
@@ -92,9 +88,7 @@ actor InMemoryMemberRepository: LocalMemberRepository {
     }
 
     func linkAuthUid(memberId: String, authUid: String) async -> Member? {
-        guard let existing = members[memberId] else {
-            return nil
-        }
+        guard let existing = members[memberId] else { return nil }
 
         let updated = Member(
             id: existing.id,

--- a/ios/Reguerta/Reguerta/Data/Access/MockAuthSessionProvider.swift
+++ b/ios/Reguerta/Reguerta/Data/Access/MockAuthSessionProvider.swift
@@ -35,21 +35,15 @@ final class MockAuthSessionProvider: AuthSessionProvider {
         return .success
     }
 
-    func sendCurrentUserEmailVerification() async -> Bool {
-        currentPrincipal != nil
-    }
+    func sendCurrentUserEmailVerification() async -> Bool { currentPrincipal != nil }
 
     func refreshCurrentSession() async -> AuthSessionRefreshResult {
-        guard let currentPrincipal else {
-            return .noSession
-        }
+        guard let currentPrincipal else { return .noSession }
         return .active(currentPrincipal)
     }
 
     func validIDToken(forcingRefresh _: Bool) async throws -> String {
-        guard let currentPrincipal else {
-            throw MockAuthTokenError.noSession
-        }
+        guard let currentPrincipal else { throw MockAuthTokenError.noSession }
         return "mock-token-\(currentPrincipal.uid)"
     }
 

--- a/ios/Reguerta/Reguerta/Data/Calendar/FirestoreDeliveryCalendarRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Calendar/FirestoreDeliveryCalendarRepository.swift
@@ -102,9 +102,7 @@ final class FirestoreDeliveryCalendarRepository: @unchecked Sendable, DeliveryCa
             return try weekday(from: data[key])
         }
         if let rawOtherConfig = data["otherConfig"] {
-            guard let otherConfig = rawOtherConfig as? [String: Any] else {
-                throw invalidConfigurationError
-            }
+            guard let otherConfig = rawOtherConfig as? [String: Any] else { throw invalidConfigurationError }
             for key in ["deliveryDayOfWeek", "deliveryDateOfWeek"] where otherConfig[key] != nil {
                 return try weekday(from: otherConfig[key])
             }

--- a/ios/Reguerta/Reguerta/Data/Calendar/InMemoryDeliveryCalendarRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Calendar/InMemoryDeliveryCalendarRepository.swift
@@ -8,9 +8,7 @@ actor InMemoryDeliveryCalendarRepository: DeliveryCalendarRepository {
         self.defaultDay = defaultDay
     }
 
-    func defaultDeliveryDayOfWeek() async -> DeliveryWeekday {
-        defaultDay
-    }
+    func defaultDeliveryDayOfWeek() async -> DeliveryWeekday { defaultDay }
 
     func allOverrides() async -> [DeliveryCalendarOverride] {
         overrides.values.sorted { $0.weekKey < $1.weekKey }

--- a/ios/Reguerta/Reguerta/Data/Commitments/FirestoreSeasonalCommitmentRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Commitments/FirestoreSeasonalCommitmentRepository.swift
@@ -67,9 +67,7 @@ final class FirestoreSeasonalCommitmentRepository: @unchecked Sendable, Seasonal
         source: SeasonalCommitmentReadSource
     ) async throws -> [SeasonalCommitment] {
         let normalizedLookup = userId.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !normalizedLookup.isEmpty else {
-            return []
-        }
+        guard !normalizedLookup.isEmpty else { return [] }
 
         do {
             var documentsById = Dictionary(

--- a/ios/Reguerta/Reguerta/Data/Devices/FirestoreDeviceRegistrationRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Devices/FirestoreDeviceRegistrationRepository.swift
@@ -14,9 +14,7 @@ final class FirestoreDeviceRegistrationRepository: @unchecked Sendable, DeviceRe
         device: RegisteredDevice,
         isRegistrationCurrent: @escaping @Sendable () async throws -> Bool
     ) async throws -> RegisteredDevice {
-        guard try await isRegistrationCurrent() else {
-            throw DeviceRegistrationRepositoryError.staleSession
-        }
+        guard try await isRegistrationCurrent() else { throw DeviceRegistrationRepositoryError.staleSession }
         let userDocument = db.document(
             ReguertaFirestorePath(environment: environment)
                 .documentPath(in: .users, documentId: memberId)
@@ -41,9 +39,7 @@ final class FirestoreDeviceRegistrationRepository: @unchecked Sendable, DeviceRe
         }
 
         let existing = try await deviceDocument.getDocument()
-        guard try await isRegistrationCurrent() else {
-            throw DeviceRegistrationRepositoryError.staleSession
-        }
+        guard try await isRegistrationCurrent() else { throw DeviceRegistrationRepositoryError.staleSession }
         if !existing.exists {
             payload["firstSeenAt"] = Timestamp(date: Date(timeIntervalSince1970: TimeInterval(device.firstSeenAtMillis) / 1_000))
         }
@@ -55,9 +51,7 @@ final class FirestoreDeviceRegistrationRepository: @unchecked Sendable, DeviceRe
         let batch = db.batch()
         batch.setData(payload, forDocument: deviceDocument, merge: true)
         batch.setData(["lastDeviceId": device.deviceId], forDocument: userDocument, merge: true)
-        guard try await isRegistrationCurrent() else {
-            throw DeviceRegistrationRepositoryError.staleSession
-        }
+        guard try await isRegistrationCurrent() else { throw DeviceRegistrationRepositoryError.staleSession }
         try await batch.commit()
         return device
     }

--- a/ios/Reguerta/Reguerta/Data/Freshness/FirestoreCriticalDataFreshnessRemoteRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Freshness/FirestoreCriticalDataFreshnessRemoteRepository.swift
@@ -14,12 +14,8 @@ struct FirestoreCriticalDataFreshnessRemoteRepository: CriticalDataFreshnessRemo
                 .reguertaDocument(.memberConfiguration, in: .config, environment: environment)
                 .getDocument(source: .server)
 
-            guard snapshot.exists else {
-                throw RepositoryError.notFound(resource: "config.member")
-            }
-            guard let data = snapshot.data() else {
-                throw RepositoryError.invalidData(resource: "config.member")
-            }
+            guard snapshot.exists else { throw RepositoryError.notFound(resource: "config.member") }
+            guard let data = snapshot.data() else { throw RepositoryError.invalidData(resource: "config.member") }
             return try Self.config(data: data)
         } catch {
             throw FirestoreRepositoryErrorMapper.map(error, resource: "config.member")
@@ -43,9 +39,7 @@ struct FirestoreCriticalDataFreshnessRemoteRepository: CriticalDataFreshnessRemo
                 throw RepositoryError.invalidData(resource: "config.member.lastTimestamps")
             }
             let milliseconds = Int64(timestamp.dateValue().timeIntervalSince1970 * 1_000)
-            guard milliseconds > 0 else {
-                throw RepositoryError.invalidData(resource: "config.member.lastTimestamps")
-            }
+            guard milliseconds > 0 else { throw RepositoryError.invalidData(resource: "config.member.lastTimestamps") }
             remoteTimestamps[collection] = milliseconds
         }
 

--- a/ios/Reguerta/Reguerta/Data/Freshness/FirestoreCriticalDataRefresher.swift
+++ b/ios/Reguerta/Reguerta/Data/Freshness/FirestoreCriticalDataRefresher.swift
@@ -142,9 +142,7 @@ private extension FirestoreCriticalDataRefresher {
                 documentID: snapshot.documentID,
                 data: data
             )
-            guard member.isActive else {
-                throw RepositoryError.permissionDenied(resource: resource)
-            }
+            guard member.isActive else { throw RepositoryError.permissionDenied(resource: resource) }
             return member
         } catch {
             throw FirestoreRepositoryErrorMapper.map(error, resource: resource)

--- a/ios/Reguerta/Reguerta/Data/Freshness/UserDefaultsCriticalDataFreshnessLocalRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Freshness/UserDefaultsCriticalDataFreshnessLocalRepository.swift
@@ -15,9 +15,7 @@ struct UserDefaultsCriticalDataFreshnessLocalRepository: CriticalDataFreshnessLo
     func getMetadata() -> CriticalDataFreshnessMetadata? {
         let validatedAtMillis = (userDefaults.object(forKey: Keys.validatedAt) as? NSNumber)?.int64Value
             ?? Int64(userDefaults.integer(forKey: Keys.validatedAt))
-        guard validatedAtMillis > 0 else {
-            return nil
-        }
+        guard validatedAtMillis > 0 else { return nil }
         guard let environmentRawValue = userDefaults.string(forKey: Keys.environment),
               let environment = SessionEnvironment(rawValue: environmentRawValue)
         else {
@@ -38,9 +36,7 @@ struct UserDefaultsCriticalDataFreshnessLocalRepository: CriticalDataFreshnessLo
         for collection in CriticalCollection.allCases {
             let value = (userDefaults.object(forKey: timestampKey(for: collection)) as? NSNumber)?.int64Value
                 ?? Int64(userDefaults.integer(forKey: timestampKey(for: collection)))
-            guard value > 0 else {
-                return nil
-            }
+            guard value > 0 else { return nil }
             timestamps[collection] = value
         }
 

--- a/ios/Reguerta/Reguerta/Data/Media/FirebaseImagePipelineManager.swift
+++ b/ios/Reguerta/Reguerta/Data/Media/FirebaseImagePipelineManager.swift
@@ -37,7 +37,9 @@ final class FirebaseImagePipelineManager: @unchecked Sendable, ImagePipelineMana
             width: cropSquare.size,
             height: cropSquare.size
         )
-        guard let croppedCgImage = resizedCgImage.cropping(to: cropRect) else { throw ImagePipelineError.processingFailed }
+        guard let croppedCgImage = resizedCgImage.cropping(to: cropRect) else {
+            throw ImagePipelineError.processingFailed
+        }
         let finalImage = UIImage(cgImage: croppedCgImage)
         guard let outputData = finalImage.jpegData(compressionQuality: jpegCompressionQuality), !outputData.isEmpty else {
             throw ImagePipelineError.processingFailed

--- a/ios/Reguerta/Reguerta/Data/Media/ImagePipelineSizingContract.swift
+++ b/ios/Reguerta/Reguerta/Data/Media/ImagePipelineSizingContract.swift
@@ -13,9 +13,7 @@ struct CropSquare: Equatable, Sendable {
 
 enum ImagePipelineSizingContract {
     static func scaledDimensions(sourceWidth: Int, sourceHeight: Int, targetShortSidePx: Int) -> PixelSize? {
-        guard sourceWidth > 0, sourceHeight > 0, targetShortSidePx > 0 else {
-            return nil
-        }
+        guard sourceWidth > 0, sourceHeight > 0, targetShortSidePx > 0 else { return nil }
         let shortSide = Double(min(sourceWidth, sourceHeight))
         let scale = Double(targetShortSidePx) / shortSide
         let scaledWidth = max(targetShortSidePx, Int((Double(sourceWidth) * scale).rounded()))

--- a/ios/Reguerta/Reguerta/Data/Media/NewsImageDataLoader.swift
+++ b/ios/Reguerta/Reguerta/Data/Media/NewsImageDataLoader.swift
@@ -45,15 +45,9 @@ struct NewsImageDataLoader: Sendable {
             timeoutInterval: 30
         )
         let response = try await fetcher.data(for: request)
-        guard let statusCode = response.statusCode else {
-            throw NewsImageDataLoaderError.invalidResponse
-        }
-        guard (200 ..< 300).contains(statusCode) else {
-            throw NewsImageDataLoaderError.httpStatus(statusCode)
-        }
-        guard !response.data.isEmpty else {
-            throw NewsImageDataLoaderError.emptyData
-        }
+        guard let statusCode = response.statusCode else { throw NewsImageDataLoaderError.invalidResponse }
+        guard (200 ..< 300).contains(statusCode) else { throw NewsImageDataLoaderError.httpStatus(statusCode) }
+        guard !response.data.isEmpty else { throw NewsImageDataLoaderError.emptyData }
         return response.data
     }
 }

--- a/ios/Reguerta/Reguerta/Data/News/FirestoreNewsRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/News/FirestoreNewsRepository.swift
@@ -137,13 +137,9 @@ private enum FirestoreNewsDocumentDecoder {
     private static func optionalString(_ data: [String: Any], field: String, resource: String) throws -> String? {
         guard let value = data[field] else { return nil }
         if value is NSNull { return nil }
-        guard let string = value as? String else {
-            throw RepositoryError.invalidData(resource: resource)
-        }
+        guard let string = value as? String else { throw RepositoryError.invalidData(resource: resource) }
         let normalized = string.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !normalized.isEmpty else {
-            throw RepositoryError.invalidData(resource: resource)
-        }
+        guard !normalized.isEmpty else { throw RepositoryError.invalidData(resource: resource) }
         return normalized
     }
 
@@ -160,9 +156,7 @@ private enum FirestoreNewsDocumentDecoder {
         field: String,
         resource: String
     ) throws -> Int64 {
-        guard let timestamp = data[field] as? Timestamp else {
-            throw RepositoryError.invalidData(resource: resource)
-        }
+        guard let timestamp = data[field] as? Timestamp else { throw RepositoryError.invalidData(resource: resource) }
         return Int64(timestamp.dateValue().timeIntervalSince1970 * 1_000)
     }
 }

--- a/ios/Reguerta/Reguerta/Data/Notifications/FirestoreNotificationRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Notifications/FirestoreNotificationRepository.swift
@@ -244,15 +244,11 @@ private enum FirestoreNotificationDocumentDecoder {
                 field: "notificationEventId",
                 resource: resource
             )
-            guard eventID == documentID else {
-                throw RepositoryError.invalidData(resource: resource)
-            }
+            guard eventID == documentID else { throw RepositoryError.invalidData(resource: resource) }
         }
 
         let type = try exactRequiredString(data, field: "type", resource: resource)
-        guard canonicalTypes.contains(type) else {
-            throw RepositoryError.invalidData(resource: resource)
-        }
+        guard canonicalTypes.contains(type) else { throw RepositoryError.invalidData(resource: resource) }
         let target = try exactRequiredString(data, field: "target", resource: resource)
         let audience = try decodeAudience(data, target: target, resource: resource)
 
@@ -281,9 +277,7 @@ private enum FirestoreNotificationDocumentDecoder {
         }
         switch target {
         case "all":
-            guard payload.isEmpty else {
-                throw RepositoryError.invalidData(resource: resource)
-            }
+            guard payload.isEmpty else { throw RepositoryError.invalidData(resource: resource) }
             return FirestoreNotificationAudienceDTO(
                 userIDs: [],
                 segmentType: nil,
@@ -341,13 +335,9 @@ private enum FirestoreNotificationDocumentDecoder {
     private static func optionalString(_ data: [String: Any], field: String, resource: String) throws -> String? {
         guard let value = data[field] else { return nil }
         if value is NSNull { return nil }
-        guard let string = value as? String else {
-            throw RepositoryError.invalidData(resource: resource)
-        }
+        guard let string = value as? String else { throw RepositoryError.invalidData(resource: resource) }
         let normalized = string.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !normalized.isEmpty else {
-            throw RepositoryError.invalidData(resource: resource)
-        }
+        guard !normalized.isEmpty else { throw RepositoryError.invalidData(resource: resource) }
         return normalized
     }
 
@@ -356,9 +346,7 @@ private enum FirestoreNotificationDocumentDecoder {
         field: String,
         resource: String
     ) throws -> Int64 {
-        guard let timestamp = data[field] as? Timestamp else {
-            throw RepositoryError.invalidData(resource: resource)
-        }
+        guard let timestamp = data[field] as? Timestamp else { throw RepositoryError.invalidData(resource: resource) }
         return Int64(timestamp.dateValue().timeIntervalSince1970 * 1_000)
     }
 }

--- a/ios/Reguerta/Reguerta/Data/Notifications/IOSPushNotificationPermissionProvider.swift
+++ b/ios/Reguerta/Reguerta/Data/Notifications/IOSPushNotificationPermissionProvider.swift
@@ -15,9 +15,7 @@ struct IOSPushNotificationPermissionProvider: PushNotificationPermissionProvider
     }
 
     @MainActor func openSettings() {
-        guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else {
-            return
-        }
+        guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else { return }
         UIApplication.shared.open(settingsURL)
     }
 }

--- a/ios/Reguerta/Reguerta/Data/Notifications/InMemoryNotificationRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Notifications/InMemoryNotificationRepository.swift
@@ -61,9 +61,7 @@ actor InMemoryNotificationRepository: NotificationRepository {
         return localized.sorted { $0.sentAtMillis > $1.sentAtMillis }
     }
 
-    func readNotificationIds(memberId: String) async -> Set<String> {
-        readNotificationIdsByMember[memberId] ?? []
-    }
+    func readNotificationIds(memberId: String) async -> Set<String> { readNotificationIdsByMember[memberId] ?? [] }
 
     func markNotificationsRead(memberId: String, notificationIds: [String], readAtMillis _: Int64) async {
         guard !notificationIds.isEmpty else { return }

--- a/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderCheckout.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderCheckout.swift
@@ -80,18 +80,14 @@ func submitCheckoutOrderToFirestore(
     environment: ReguertaFirestoreEnvironment = ReguertaRuntimeEnvironment.currentFirestoreEnvironment,
     nowMillis: Int64 = Int64(Date().timeIntervalSince1970 * 1_000)
 ) async throws -> Bool {
-    guard let member = currentMember else {
-        return false
-    }
+    guard let member = currentMember else { return false }
 
     let lineSnapshots = buildMyOrderCheckoutLineSnapshots(
         products: products,
         selectedQuantities: selectedQuantities,
         selectedEcoBasketOptions: selectedEcoBasketOptions
     )
-    guard !lineSnapshots.isEmpty else {
-        return false
-    }
+    guard !lineSnapshots.isEmpty else { return false }
 
     let firestorePath = ReguertaFirestorePath(environment: environment)
     let writeTargets = resolveMyOrderCheckoutWriteTargets(
@@ -337,7 +333,9 @@ nonisolated func normalizedUniqueMyOrderIds(_ orderIds: [String]) -> [String] {
     var seen = Set<String>()
     return orderIds.compactMap { orderId in
         let normalized = orderId.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !normalized.isEmpty, seen.insert(normalized).inserted else { return nil }
+        guard !normalized.isEmpty, seen.insert(normalized).inserted else {
+            return nil
+        }
         return normalized
     }
 }

--- a/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderPreviousOrder.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/FirestoreMyOrderPreviousOrder.swift
@@ -93,9 +93,7 @@ func fetchOrderSummarySnapshot(
     db: Firestore = Firestore.firestore(),
     environment: ReguertaFirestoreEnvironment = ReguertaRuntimeEnvironment.currentFirestoreEnvironment
 ) async throws -> MyOrderPreviousOrderSnapshot? {
-    guard let member = currentMember else {
-        return nil
-    }
+    guard let member = currentMember else { return nil }
     let firestorePath = ReguertaFirestorePath(environment: environment)
     let readTargets = resolvePreviousOrderReadTargets(
         firestorePath: firestorePath
@@ -168,9 +166,7 @@ func fetchPreviousWeekOrderSnapshot(
         myOrderPreviousLine(from: data)
     }
     let groups = buildMyOrderPreviousGroups(from: lines)
-    guard !groups.isEmpty else {
-        return nil
-    }
+    guard !groups.isEmpty else { return nil }
 
     let documentedTotals = orderDocuments.values.compactMap { data in
         (data["total"] as? NSNumber)?.doubleValue
@@ -281,9 +277,7 @@ func myOrderPreviousLine(from data: [String: Any]) -> MyOrderPreviousOrderLine {
 }
 
 func myOrderProducerStatusesByVendor(from data: [String: Any]) -> [String: ProducerOrderStatus] {
-    guard let rawMap = data["producerStatusesByVendor"] as? [String: Any] else {
-        return [:]
-    }
+    guard let rawMap = data["producerStatusesByVendor"] as? [String: Any] else { return [:] }
     return rawMap.reduce(into: [:]) { partialResult, entry in
         let vendorId = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
         guard vendorId.isNotEmpty else { return }

--- a/ios/Reguerta/Reguerta/Data/Orders/FirestoreOrderHistoryWeekKeys.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/FirestoreOrderHistoryWeekKeys.swift
@@ -6,9 +6,7 @@ func fetchOrderHistoryWeekKeys(
     db: Firestore = Firestore.firestore(),
     environment: ReguertaFirestoreEnvironment = ReguertaRuntimeEnvironment.currentFirestoreEnvironment
 ) async throws -> [String] {
-    guard let member = currentMember else {
-        return []
-    }
+    guard let member = currentMember else { return [] }
 
     let firestorePath = ReguertaFirestorePath(environment: environment)
     let targets = resolvePreviousOrderReadTargets(firestorePath: firestorePath)

--- a/ios/Reguerta/Reguerta/Data/Orders/FirestoreReceivedOrdersData.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/FirestoreReceivedOrdersData.swift
@@ -189,9 +189,7 @@ private func synchronizeUnreadReceivedOrderStatuses(
     let unreadOrderIds = statusesByOrderId
         .filter { $0.value == .unread }
         .map(\.key)
-    guard !unreadOrderIds.isEmpty else {
-        return statusesByOrderId
-    }
+    guard !unreadOrderIds.isEmpty else { return statusesByOrderId }
 
     let markedAsRead = await markReceivedOrdersAsRead(
         orderIds: unreadOrderIds,
@@ -199,9 +197,7 @@ private func synchronizeUnreadReceivedOrderStatuses(
         db: db,
         environment: environment
     )
-    guard !markedAsRead.isEmpty else {
-        return statusesByOrderId
-    }
+    guard !markedAsRead.isEmpty else { return statusesByOrderId }
 
     var synchronizedStatuses = statusesByOrderId
     for orderId in markedAsRead {

--- a/ios/Reguerta/Reguerta/Data/Orders/InMemoryOrdersRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/InMemoryOrdersRepository.swift
@@ -162,19 +162,11 @@ actor InMemoryOrdersRepository: OrdersRepository {
         updateResultsByOrderId[orderId] = result
     }
 
-    func submissions() -> [SubmittedOrder] {
-        submittedOrders
-    }
+    func submissions() -> [SubmittedOrder] { submittedOrders }
 
-    func receivedStatusUpdates() -> [ReceivedStatusUpdate] {
-        receivedStatusUpdateRequests
-    }
+    func receivedStatusUpdates() -> [ReceivedStatusUpdate] { receivedStatusUpdateRequests }
 
-    private func receivedKey(producerId: String, weekKey: String) -> String {
-        "\(producerId)|\(weekKey)"
-    }
+    private func receivedKey(producerId: String, weekKey: String) -> String { "\(producerId)|\(weekKey)" }
 
-    private func producerStatusKey(memberId: String, weekKey: String) -> String {
-        "\(memberId)|\(weekKey)"
-    }
+    private func producerStatusKey(memberId: String, weekKey: String) -> String { "\(memberId)|\(weekKey)" }
 }

--- a/ios/Reguerta/Reguerta/Data/Orders/MyOrderCartStores.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/MyOrderCartStores.swift
@@ -46,17 +46,13 @@ actor InMemoryMyOrderCartStore: MyOrderCartStore {
 
     init() {}
 
-    func readCart(storageKey: String) async -> MyOrderCartSnapshot {
-        cartSnapshots[storageKey] ?? .empty
-    }
+    func readCart(storageKey: String) async -> MyOrderCartSnapshot { cartSnapshots[storageKey] ?? .empty }
 
     func persistCart(storageKey: String, snapshot: MyOrderCartSnapshot) async {
         cartSnapshots[storageKey] = snapshot.normalized
     }
 
-    func readConfirmed(storageKey: String) async -> MyOrderCartSnapshot {
-        confirmedSnapshots[storageKey] ?? .empty
-    }
+    func readConfirmed(storageKey: String) async -> MyOrderCartSnapshot { confirmedSnapshots[storageKey] ?? .empty }
 
     func persistConfirmed(storageKey: String, snapshot: MyOrderCartSnapshot) async {
         confirmedSnapshots[storageKey] = snapshot.normalized

--- a/ios/Reguerta/Reguerta/Data/Orders/MyOrderPersistenceHelpers.swift
+++ b/ios/Reguerta/Reguerta/Data/Orders/MyOrderPersistenceHelpers.swift
@@ -145,9 +145,7 @@ extension String {
 
 extension Member {
     func committedEcoBasketProducerId(in members: [Member]) -> String? {
-        guard let parity = ecoCommitmentParity else {
-            return nil
-        }
+        guard let parity = ecoCommitmentParity else { return nil }
         return members.first { producer in
             producer.id != id &&
                 producer.isProducer &&

--- a/ios/Reguerta/Reguerta/Data/Profiles/FirestoreSharedProfileRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Profiles/FirestoreSharedProfileRepository.swift
@@ -34,9 +34,7 @@ final class FirestoreSharedProfileRepository: @unchecked Sendable, SharedProfile
         do {
             let document = try await profilesCollection.document(userId).getDocument()
             guard document.exists else { return nil }
-            guard let data = document.data() else {
-                throw Self.invalidDocumentError
-            }
+            guard let data = document.data() else { throw Self.invalidDocumentError }
             return try Self.sharedProfile(documentID: document.documentID, data: data)
         } catch {
             throw FirestoreRepositoryErrorMapper.map(error, resource: "sharedProfiles.document")
@@ -92,9 +90,7 @@ final class FirestoreSharedProfileRepository: @unchecked Sendable, SharedProfile
     }
 
     private static func requiredString(_ data: [String: Any], field: String) throws -> String {
-        guard let value = try optionalString(data, field: field) else {
-            throw invalidDocumentError
-        }
+        guard let value = try optionalString(data, field: field) else { throw invalidDocumentError }
         return value
     }
 

--- a/ios/Reguerta/Reguerta/Data/Profiles/InMemorySharedProfileRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Profiles/InMemorySharedProfileRepository.swift
@@ -30,9 +30,7 @@ actor InMemorySharedProfileRepository: SharedProfileRepository {
         profiles.values.sorted { $0.updatedAtMillis > $1.updatedAtMillis }
     }
 
-    func sharedProfile(userId: String) async -> SharedProfile? {
-        profiles[userId]
-    }
+    func sharedProfile(userId: String) async -> SharedProfile? { profiles[userId] }
 
     func upsert(profile: SharedProfile) async -> SharedProfile {
         profiles[profile.userId] = profile

--- a/ios/Reguerta/Reguerta/Data/Shifts/FirestoreShiftRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Shifts/FirestoreShiftRepository.swift
@@ -65,9 +65,7 @@ final class FirestoreShiftRepository: @unchecked Sendable, ShiftRepository {
 
         let helperUserId: String?
         if let rawHelper = data["helperUserId"], !(rawHelper is NSNull) {
-            guard let parsedHelper = requiredTrimmedString(rawHelper) else {
-                throw invalidDocumentError
-            }
+            guard let parsedHelper = requiredTrimmedString(rawHelper) else { throw invalidDocumentError }
             helperUserId = parsedHelper
         } else {
             helperUserId = nil

--- a/ios/Reguerta/Reguerta/Data/Startup/FirestoreStartupVersionPolicyRepository.swift
+++ b/ios/Reguerta/Reguerta/Data/Startup/FirestoreStartupVersionPolicyRepository.swift
@@ -16,9 +16,7 @@ final class FirestoreStartupVersionPolicyRepository: @unchecked Sendable, Startu
                 .reguertaDocument(.publicConfiguration, in: .config, environment: environment)
                 .getDocument(source: .server)
 
-            guard snapshot.exists else {
-                throw RepositoryError.notFound(resource: "config.public")
-            }
+            guard snapshot.exists else { throw RepositoryError.notFound(resource: "config.public") }
             guard let data = snapshot.data() else {
                 throw RepositoryError.invalidData(resource: "config.public.versions.\(platform.rawValue)")
             }
@@ -50,9 +48,7 @@ final class FirestoreStartupVersionPolicyRepository: @unchecked Sendable, Startu
 
 nonisolated private extension Dictionary where Key == String, Value == Any {
     func requiredString(for key: String) -> String? {
-        guard let value = self[key] as? String else {
-            return nil
-        }
+        guard let value = self[key] as? String else { return nil }
         let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return normalized.isEmpty ? nil : normalized
     }

--- a/ios/Reguerta/Reguerta/DesignSystem/ReguertaFontRegistrar.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/ReguertaFontRegistrar.swift
@@ -12,9 +12,7 @@ enum ReguertaFontRegistrar {
     }
 
     private static func registerFontIfAvailable(named fileName: String) {
-        guard let fontURL = Bundle.main.url(forResource: fileName, withExtension: nil) else {
-            return
-        }
+        guard let fontURL = Bundle.main.url(forResource: fileName, withExtension: nil) else { return }
 
         CTFontManagerRegisterFontsForURL(fontURL as CFURL, .process, nil)
     }

--- a/ios/Reguerta/Reguerta/DesignSystem/ReguertaTheme.swift
+++ b/ios/Reguerta/Reguerta/DesignSystem/ReguertaTheme.swift
@@ -163,9 +163,7 @@ struct ReguertaTheme<Content: View>: View {
 
 private extension Color {
     static func reguertaAsset(_ name: String, fallback: Color) -> Color {
-        guard let uiColor = UIColor(named: name) else {
-            return fallback
-        }
+        guard let uiColor = UIColor(named: name) else { return fallback }
         return Color(uiColor: uiColor)
     }
 

--- a/ios/Reguerta/Reguerta/Domain/Freshness/ResolveCriticalDataFreshnessUseCase.swift
+++ b/ios/Reguerta/Reguerta/Domain/Freshness/ResolveCriticalDataFreshnessUseCase.swift
@@ -89,9 +89,7 @@ struct ResolveCriticalDataFreshnessUseCase: Sendable {
         nowMillis: Int64,
         scope: CriticalDataRefreshScope
     ) -> FreshnessEvaluation {
-        guard config.cacheExpirationMinutes > 0 else {
-            return .invalidConfig
-        }
+        guard config.cacheExpirationMinutes > 0 else { return .invalidConfig }
 
         let remoteTimestamps = config.remoteTimestampsMillis
         guard CriticalCollection.allCases.allSatisfy({ collection in

--- a/ios/Reguerta/Reguerta/Domain/Notifications/NotificationEvent.swift
+++ b/ios/Reguerta/Reguerta/Domain/Notifications/NotificationEvent.swift
@@ -20,9 +20,7 @@ struct NotificationEvent: Identifiable, Equatable, Sendable {
         case "users":
             return userIds.contains(member.id)
         case "segment":
-            guard segmentType == "role", let targetRole else {
-                return false
-            }
+            guard segmentType == "role", let targetRole else { return false }
             return member.roles.contains(targetRole)
         default:
             return false

--- a/ios/Reguerta/Reguerta/Domain/Notifications/PushNotificationPermissionProvider.swift
+++ b/ios/Reguerta/Reguerta/Domain/Notifications/PushNotificationPermissionProvider.swift
@@ -8,9 +8,7 @@ protocol PushNotificationPermissionProvider: Sendable {
 struct FixedPushNotificationPermissionProvider: PushNotificationPermissionProvider {
     let isActive: Bool
 
-    func isPushNotificationPermissionActive() async -> Bool {
-        isActive
-    }
+    func isPushNotificationPermissionActive() async -> Bool { isActive }
 
     @MainActor func openSettings() {}
 }

--- a/ios/Reguerta/Reguerta/Domain/Orders/MyOrderCommitmentValidation.swift
+++ b/ios/Reguerta/Reguerta/Domain/Orders/MyOrderCommitmentValidation.swift
@@ -144,20 +144,14 @@ private func requiredEcoBasketCommitmentProducts(
         .filter(\.isEcoBasket)
         .filter(\.isVisibleInOrdering)
 
-    guard !ecoBasketProducts.isEmpty else {
-        return []
-    }
+    guard !ecoBasketProducts.isEmpty else { return [] }
 
     switch member.ecoCommitmentMode {
     case .weekly:
         return ecoBasketProducts
     case .biweekly:
-        guard let parity = member.ecoCommitmentParity else {
-            return ecoBasketProducts
-        }
-        guard parity == currentWeekParity else {
-            return []
-        }
+        guard let parity = member.ecoCommitmentParity else { return ecoBasketProducts }
+        guard parity == currentWeekParity else { return [] }
 
         let eligibleProducerIds = Set(
             members
@@ -192,9 +186,7 @@ private func requiredSeasonalCommitmentProducts(
     products: [Product],
     seasonalCommitments: [SeasonalCommitment]
 ) -> [SeasonalProductRequirement] {
-    guard !seasonalCommitments.isEmpty else {
-        return []
-    }
+    guard !seasonalCommitments.isEmpty else { return [] }
 
     let index = buildSeasonalVisibleProductsIndex(products: products)
     let requiredQuantityByProductID = mergeRequiredSeasonalQuantities(

--- a/ios/Reguerta/Reguerta/Domain/Orders/OrderHistoryWeek.swift
+++ b/ios/Reguerta/Reguerta/Domain/Orders/OrderHistoryWeek.swift
@@ -64,9 +64,7 @@ func orderHistoryContinuousWeekOptions(
     calendar.timeZone = timeZone
     let seedWeekKeys = Set(realWeekKeys.filter(\.isValidIsoWeekKey) + [preferredWeekKey].filter(\.isValidIsoWeekKey))
     let starts = seedWeekKeys.compactMap { orderHistoryWeekStart(forWeekKey: $0, calendar: calendar) }.sorted()
-    guard let firstStart = starts.first, let lastStart = starts.last else {
-        return []
-    }
+    guard let firstStart = starts.first, let lastStart = starts.last else { return [] }
 
     var options: [OrderHistoryWeekOption] = []
     var cursor = firstStart
@@ -134,9 +132,7 @@ func orderHistoryWeekOption(
 ) -> OrderHistoryWeekOption? {
     var calendar = Calendar(identifier: .iso8601)
     calendar.timeZone = timeZone
-    guard let start = orderHistoryWeekStart(forWeekKey: weekKey, calendar: calendar) else {
-        return nil
-    }
+    guard let start = orderHistoryWeekStart(forWeekKey: weekKey, calendar: calendar) else { return nil }
     return orderHistoryWeekOption(for: start, calendar: calendar, locale: locale)
 }
 
@@ -169,9 +165,7 @@ private func orderHistoryWeekStart(forWeekKey weekKey: String, calendar: Calenda
     components.yearForWeekOfYear = year
     components.weekOfYear = week
     components.weekday = 2
-    guard let date = calendar.date(from: components) else {
-        return nil
-    }
+    guard let date = calendar.date(from: components) else { return nil }
     let start = calendar.startOfDay(for: date)
     return orderHistoryWeekKey(for: start, calendar: calendar) == weekKey ? start : nil
 }

--- a/ios/Reguerta/Reguerta/Domain/Orders/ReceivedOrdersModels.swift
+++ b/ios/Reguerta/Reguerta/Domain/Orders/ReceivedOrdersModels.swift
@@ -53,16 +53,12 @@ struct ReceivedOrderLineRecord: Identifiable, Equatable, Sendable {
     }
 
     var orderedQuantity: Double {
-        guard isWeightPricing, measureQuantityPerUnit > 0 else {
-            return quantity
-        }
+        guard isWeightPricing, measureQuantityPerUnit > 0 else { return quantity }
         return weightQuantityRepresentsMeasure ? quantity / measureQuantityPerUnit : quantity
     }
 
     private var weightQuantityRepresentsMeasure: Bool {
-        guard isWeightPricing, measureQuantityPerUnit > 0 else {
-            return true
-        }
+        guard isWeightPricing, measureQuantityPerUnit > 0 else { return true }
         return quantity >= measureQuantityPerUnit
     }
 }
@@ -142,9 +138,7 @@ struct ReceivedOrdersSnapshot: Equatable, Sendable {
     let generalTotal: Double
 }
 
-func receivedOrdersIsApproximatelyOne(_ value: Double) -> Bool {
-    abs(value - 1) < 0.000_1
-}
+func receivedOrdersIsApproximatelyOne(_ value: Double) -> Bool { abs(value - 1) < 0.000_1 }
 
 func receivedOrdersMeasureLabel(
     quantity: Double,

--- a/ios/Reguerta/Reguerta/Domain/Products/ProductDraft.swift
+++ b/ios/Reguerta/Reguerta/Domain/Products/ProductDraft.swift
@@ -77,9 +77,7 @@ struct ProductSaveInput: Equatable, Sendable {
 /// - Returns: Parsed values ready for product construction, or `nil` when any invariant fails.
 func resolveProductSaveInput(draft: ProductDraft, existing: Product?, nowMillis: Int64) -> ProductSaveInput? {
     let draft = draft.normalized
-    guard let price = draft.price.productPositiveDouble, !draft.name.isEmpty else {
-        return nil
-    }
+    guard let price = draft.price.productPositiveDouble, !draft.name.isEmpty else { return nil }
     let isBulk = ProductContainerOption.matching(name: draft.packContainerName) == .bulk
     let weightStep = isBulk ? draft.weightStep.productPositiveDouble : nil
     let minWeight = isBulk ? draft.minWeight.productPositiveDouble : nil
@@ -93,15 +91,11 @@ func resolveProductSaveInput(draft: ProductDraft, existing: Product?, nowMillis:
         return nil
     }
     let stockQty = draft.stockMode == .finite ? draft.stockQty.productNonNegativeDouble : nil
-    guard draft.stockMode != .finite || stockQty != nil else {
-        return nil
-    }
+    guard draft.stockMode != .finite || stockQty != nil else { return nil }
     let packContainerQty = (draft.packContainerName.isEmpty || isBulk)
         ? nil
         : draft.packContainerQty.productPositiveDouble
-    guard draft.packContainerName.isEmpty || isBulk || packContainerQty != nil else {
-        return nil
-    }
+    guard draft.packContainerName.isEmpty || isBulk || packContainerQty != nil else { return nil }
 
     return ProductSaveInput(
         draft: draft,

--- a/ios/Reguerta/Reguerta/Domain/Shifts/ShiftAssignment.swift
+++ b/ios/Reguerta/Reguerta/Domain/Shifts/ShiftAssignment.swift
@@ -22,7 +22,5 @@ struct ShiftAssignment: Identifiable, Equatable, Sendable {
     let createdAtMillis: Int64
     let updatedAtMillis: Int64
 
-    func isAssigned(to userId: String) -> Bool {
-        assignedUserIds.contains(userId) || helperUserId == userId
-    }
+    func isAssigned(to userId: String) -> Bool { assignedUserIds.contains(userId) || helperUserId == userId }
 }

--- a/ios/Reguerta/Reguerta/Domain/Startup/SemanticVersionComparator.swift
+++ b/ios/Reguerta/Reguerta/Domain/Startup/SemanticVersionComparator.swift
@@ -15,9 +15,7 @@ enum SemanticVersionComparator {
     /// - Returns: `-1` when `lhs` is older, `0` when equal, `1` when newer, or `nil` when either
     ///   value is not a supported numeric version.
     static func compare(_ lhs: String, _ rhs: String) -> Int? {
-        guard let leftParts = parse(lhs), let rightParts = parse(rhs) else {
-            return nil
-        }
+        guard let leftParts = parse(lhs), let rightParts = parse(rhs) else { return nil }
 
         let maxCount = max(leftParts.count, rightParts.count)
         for index in 0..<maxCount {
@@ -41,9 +39,7 @@ enum SemanticVersionComparator {
 
         var components: [Int] = []
         for component in value.split(separator: ".") {
-            guard let parsed = Int(component) else {
-                return nil
-            }
+            guard let parsed = Int(component) else { return nil }
             components.append(parsed)
         }
         return components

--- a/ios/Reguerta/Reguerta/Presentation/Auth/AuthInputValidation.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/AuthInputValidation.swift
@@ -11,6 +11,4 @@ func isValidAccessEmail(_ email: String) -> Bool {
     ) != nil
 }
 
-func isValidAccessPassword(_ password: String) -> Bool {
-    (6...16).contains(password.count)
-}
+func isValidAccessPassword(_ password: String) -> Bool { (6...16).contains(password.count) }

--- a/ios/Reguerta/Reguerta/Presentation/Auth/AuthShellRouting.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/AuthShellRouting.swift
@@ -62,13 +62,9 @@ private extension AuthShellState {
         return AuthShellState(backStack: backStack + [route])
     }
 
-    func resetTo(_ route: AuthShellRoute) -> AuthShellState {
-        AuthShellState(backStack: [route])
-    }
+    func resetTo(_ route: AuthShellRoute) -> AuthShellState { AuthShellState(backStack: [route]) }
 
-    func resetTo(_ routes: [AuthShellRoute]) -> AuthShellState {
-        AuthShellState(backStack: routes)
-    }
+    func resetTo(_ routes: [AuthShellRoute]) -> AuthShellState { AuthShellState(backStack: routes) }
 
     func popOrStay() -> AuthShellState {
         guard canGoBack else { return self }

--- a/ios/Reguerta/Reguerta/Presentation/Auth/ContentView+AuthOverlaysAndHandlers.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/ContentView+AuthOverlaysAndHandlers.swift
@@ -209,9 +209,7 @@ extension AccessRootRoutingView {
     }
 
     func openStoreURL(_ rawURL: String) {
-        guard let url = URL(string: rawURL.trimmingCharacters(in: .whitespacesAndNewlines)) else {
-            return
-        }
+        guard let url = URL(string: rawURL.trimmingCharacters(in: .whitespacesAndNewlines)) else { return }
         openURL(url)
     }
 

--- a/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+AuthActions.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+AuthActions.swift
@@ -9,9 +9,7 @@ extension SessionViewModel {
         emailErrorKey = nil
         passwordErrorKey = nil
 
-        guard validateSignInInputs(email: email, password: password) else {
-            return
-        }
+        guard validateSignInInputs(email: email, password: password) else { return }
 
         guard let operation = beginSessionOperation(principalEmail: email) else { return }
         let provider = authSessionProvider
@@ -53,9 +51,7 @@ extension SessionViewModel {
         registerPasswordErrorKey = nil
         registerRepeatPasswordErrorKey = nil
 
-        guard validateSignUpInputs(email: email, password: password, repeatedPassword: repeatedPassword) else {
-            return
-        }
+        guard validateSignUpInputs(email: email, password: password, repeatedPassword: repeatedPassword) else { return }
 
         guard let operation = beginSessionOperation(principalEmail: email) else { return }
         let provider = authSessionProvider

--- a/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+SessionOperationLifecycle.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Auth/SessionViewModel+SessionOperationLifecycle.swift
@@ -86,9 +86,7 @@ extension SessionViewModel {
     }
 
     func isCurrentSessionOperation(_ generation: UInt64) -> Bool {
-        guard !Task.isCancelled, generation == sessionOperationGeneration else {
-            return false
-        }
+        guard !Task.isCancelled, generation == sessionOperationGeneration else { return false }
         return sessionOperationState != .draining(generation: generation)
     }
 
@@ -230,9 +228,7 @@ extension SessionViewModel {
     }
 
     private func startStandaloneSessionTerminationBarrier(firebaseSignOutSucceeded: Bool, principalEmail: String) {
-        guard !firebaseSignOutSucceeded || sessionTerminationCleanupTask != nil else {
-            return
-        }
+        guard !firebaseSignOutSucceeded || sessionTerminationCleanupTask != nil else { return }
         let generation = sessionOperationGeneration
         sessionOperationPrincipalEmail = principalEmail
         sessionOperationState = .draining(generation: generation)

--- a/ios/Reguerta/Reguerta/Presentation/Freshness/MyOrderFreshnessViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Freshness/MyOrderFreshnessViewModel.swift
@@ -158,15 +158,11 @@ final class MyOrderFreshnessViewModel {
         let resolver = resolveCriticalDataFreshness
         return Task { @MainActor [weak self, resolver] in
             defer { self?.finishFreshnessOperation(generation) }
-            guard self?.isCurrentFreshnessOperation(generation, identity: identity) == true else {
-                return
-            }
+            guard self?.isCurrentFreshnessOperation(generation, identity: identity) == true else { return }
 
             do {
                 let resolution = try await resolver.execute(scope: identity.refreshScope)
-                guard let self, isCurrentFreshnessOperation(generation, identity: identity) else {
-                    return
-                }
+                guard let self, isCurrentFreshnessOperation(generation, identity: identity) else { return }
                 try await applyAndPublish(
                     resolution,
                     identity: identity,
@@ -238,9 +234,7 @@ final class MyOrderFreshnessViewModel {
                 return
             }
 
-            guard let self, isCurrentFreshnessOperation(generation, identity: identity) else {
-                return
-            }
+            guard let self, isCurrentFreshnessOperation(generation, identity: identity) else { return }
             freshnessOperationTask?.cancel()
             freshnessTimeoutTask = nil
             state = .timedOut

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeDashboardCards.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeDashboardCards.swift
@@ -8,9 +8,7 @@ struct NextShiftsCardView: View {
     let nextMarketSummary: String
     let onViewAll: () -> Void
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
     var body: some View {
         reguertaCard {
@@ -135,9 +133,7 @@ struct LatestNewsCardView: View {
     let tokens: ReguertaDesignTokens
     let latestNews: [HomeLatestNewsItemPresentation]
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: tokens.spacing.sm) {
@@ -282,9 +278,7 @@ struct OperationalModulesCardView: View {
     let onOpenBylaws: () -> Void
     let onRetryFreshness: () -> Void
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
     var body: some View {
         reguertaCard {

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeDrawerComponents.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeDrawerComponents.swift
@@ -20,9 +20,7 @@ struct HomeDrawerContentView: View {
         currentMember?.canAccessReceivedOrders == true
     }
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
     private var homeDrawerVersionText: String {
         let version = l10n(AccessL10nKey.homeShellVersion, installedVersion).lowercased()

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellComponents.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeShellComponents.swift
@@ -83,9 +83,7 @@ struct HomeWeeklySummaryCardView: View {
 
     private let compactColumnWidth: CGFloat = 96.resize
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: tokens.spacing.md) {
@@ -252,9 +250,7 @@ struct HomeActionRowView: View {
     let onOpenReceivedOrders: () -> Void
     let onRetryFreshness: () -> Void
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: tokens.spacing.sm) {

--- a/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeWeeklySummaryResolution.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Home/ContentView+HomeWeeklySummaryResolution.swift
@@ -223,9 +223,7 @@ private func resolveHomeNextScheduledMarketDate(onOrAfter today: Date, calendar:
                 return thirdSaturday
             }
         }
-        guard let nextMonth = calendar.date(byAdding: .month, value: 1, to: monthStart) else {
-            return nil
-        }
+        guard let nextMonth = calendar.date(byAdding: .month, value: 1, to: monthStart) else { return nil }
         monthStart = nextMonth
     }
     return nil

--- a/ios/Reguerta/Reguerta/Presentation/Localization/AccessLocalization.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Localization/AccessLocalization.swift
@@ -330,9 +330,7 @@ extension AccessL10nKey {
     static let bylawsPdfViewerUnavailable = "bylaws.pdf.viewer.unavailable"
 }
 
-func l10n(_ key: String) -> String {
-    NSLocalizedString(key, comment: "")
-}
+func l10n(_ key: String) -> String { NSLocalizedString(key, comment: "") }
 
 func l10n(_ key: String, _ arguments: CVarArg...) -> String {
     String(format: NSLocalizedString(key, comment: ""), locale: Locale.current, arguments: arguments)

--- a/ios/Reguerta/Reguerta/Presentation/News/NewsNotificationsFeatureSupport.swift
+++ b/ios/Reguerta/Reguerta/Presentation/News/NewsNotificationsFeatureSupport.swift
@@ -45,14 +45,7 @@ struct NotificationListItem: Identifiable, Equatable, Sendable {
 }
 
 extension NewsArticle {
-    func toDraft() -> NewsDraft {
-        NewsDraft(
-            title: title,
-            body: body,
-            urlImage: urlImage ?? "",
-            active: active
-        )
-    }
+    func toDraft() -> NewsDraft { NewsDraft(title: title, body: body, urlImage: urlImage ?? "", active: active) }
 }
 
 extension NotificationEvent {

--- a/ios/Reguerta/Reguerta/Presentation/News/NewsNotificationsFeatureViewModel+Actions.swift
+++ b/ios/Reguerta/Reguerta/Presentation/News/NewsNotificationsFeatureViewModel+Actions.swift
@@ -40,7 +40,9 @@ extension NewsNotificationsFeatureViewModel {
             feedbackCenter.show(AccessL10nKey.feedbackOnlyAdminEditNews)
             return false
         }
-        guard let article = newsFeed.first(where: { $0.id == newsId }) else { return false }
+        guard let article = newsFeed.first(where: { $0.id == newsId }) else {
+            return false
+        }
 
         invalidateNewsImageUploadForEditorTransition()
         newsDraft = article.toDraft()
@@ -222,9 +224,7 @@ extension NewsNotificationsFeatureViewModel {
             feedbackCenter.show(AccessL10nKey.feedbackNotificationTitleBodyRequired)
             return false
         }
-        guard let mutationOperationId = beginNotificationMutationOperation() else {
-            return false
-        }
+        guard let mutationOperationId = beginNotificationMutationOperation() else { return false }
 
         let editorOwnership = captureNotificationMutationEditorOwnership()
         let event = notificationEventForSend(draft: normalizedDraft, context: context)

--- a/ios/Reguerta/Reguerta/Presentation/Orders/MyOrderProducerParity.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/MyOrderProducerParity.swift
@@ -14,9 +14,7 @@ func producerParityForISOWeek(nowMillis: Int64) -> ProducerParity {
 
 extension Product {
     func matchesCurrentProducerWeek(membersById: [String: Member], currentWeekParity: ProducerParity) -> Bool {
-        guard let producerParity = membersById[vendorId]?.producerParity else {
-            return true
-        }
+        guard let producerParity = membersById[vendorId]?.producerParity else { return true }
         return producerParity == currentWeekParity
     }
 }

--- a/ios/Reguerta/Reguerta/Presentation/Orders/MyOrderRouteViewModel+Actions.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Orders/MyOrderRouteViewModel+Actions.swift
@@ -148,9 +148,7 @@ extension MyOrderRouteViewModel {
         return currentQuantity < finiteLimit
     }
 
-    func quantity(for product: Product) -> Int {
-        selectedQuantities[product.id, default: 0]
-    }
+    func quantity(for product: Product) -> Int { selectedQuantities[product.id, default: 0] }
 
     func selectedEcoBasketOption(for product: Product) -> String {
         selectedEcoBasketOptions[product.id] ?? ecoBasketOptionPickup

--- a/ios/Reguerta/Reguerta/Presentation/Products/ContentView+ProductsRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Products/ContentView+ProductsRoute.swift
@@ -12,9 +12,7 @@ struct ProductsRouteView: View {
         viewModel.archivedProducts
     }
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -64,9 +62,7 @@ private struct ProductsListRouteView: View {
     let activeProducts: [Product]
     let archivedProducts: [Product]
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: tokens.spacing.lg) {
@@ -131,9 +127,7 @@ private struct ProductCardRowView: View {
         product.description.isEmpty ? l10n(AccessL10nKey.productsCardDescriptionEmpty) : product.description
     }
 
-    private func decimalText(_ value: Double) -> String {
-        value.productUIDecimal
-    }
+    private func decimalText(_ value: Double) -> String { value.productUIDecimal }
 
     private var priceText: String {
         product.price.euroCurrencyText()

--- a/ios/Reguerta/Reguerta/Presentation/Products/ProductEditorFieldPairLayout.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Products/ProductEditorFieldPairLayout.swift
@@ -90,7 +90,5 @@ struct ProductEditorFieldPairLayout: Layout {
         return (first, contentWidth - first)
     }
 
-    private func usesStackedLayout(width: CGFloat) -> Bool {
-        width < stackedWidthThreshold
-    }
+    private func usesStackedLayout(width: CGFloat) -> Bool { width < stackedWidthThreshold }
 }

--- a/ios/Reguerta/Reguerta/Presentation/Products/ProductEditorView.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Products/ProductEditorView.swift
@@ -45,9 +45,7 @@ struct ProductEditorView: View {
             : AccessL10nKey.productsEditorTitleNew
     }
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 }
 
 private struct ProductEditorHeroView: View {
@@ -176,9 +174,7 @@ private struct ProductEditorHeroView: View {
         .accessibilityLabel(Text(localizedKey(accessibilityKey)))
     }
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 }
 
 private struct ProductEditorSalesFieldsView: View {
@@ -252,9 +248,7 @@ private struct ProductEditorSalesFieldsView: View {
         }
     }
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
     private var containerSelection: Binding<String> {
         Binding(
@@ -475,7 +469,5 @@ private struct ProductEditorOptionsView: View {
         }
     }
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 }

--- a/ios/Reguerta/Reguerta/Presentation/Products/ProductsRouteViewModel+Actions.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Products/ProductsRouteViewModel+Actions.swift
@@ -415,9 +415,7 @@ private extension ProductsRouteViewModel {
         price: Double,
         existingProduct: Product?
     ) async throws -> Bool {
-        guard sessionMember.isProducer, draft.isEcoBasket else {
-            return true
-        }
+        guard sessionMember.isProducer, draft.isEcoBasket else { return true }
         let allProducts = try await productRepository.allProducts()
         let activeEcoBasketPrice = allProducts
             .first(where: { $0.isEcoBasket && !$0.archived && $0.id != existingProduct?.id })?

--- a/ios/Reguerta/Reguerta/Presentation/Root/ContentView+Bindings.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Root/ContentView+Bindings.swift
@@ -8,9 +8,7 @@ extension AccessRootRoutingView {
         )
     }
 
-    func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
     var currentHomeMember: Member? {
         switch viewModel.mode {

--- a/ios/Reguerta/Reguerta/Presentation/Root/DevelopmentTimeMachine.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Root/DevelopmentTimeMachine.swift
@@ -14,9 +14,7 @@ nonisolated final class DevelopmentTimeMachine: @unchecked Sendable {
     var overrideNowMillis: Int64? {
         lock.lock()
         defer { lock.unlock() }
-        guard defaults.object(forKey: overrideKey) != nil else {
-            return nil
-        }
+        guard defaults.object(forKey: overrideKey) != nil else { return nil }
         return Int64(defaults.integer(forKey: overrideKey))
     }
 

--- a/ios/Reguerta/Reguerta/Presentation/Root/ReguertaImagePickerField.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Root/ReguertaImagePickerField.swift
@@ -292,9 +292,7 @@ private struct ReguertaCameraCaptureView: UIViewControllerRepresentable {
 
     func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(onCapture: onCapture)
-    }
+    func makeCoordinator() -> Coordinator { Coordinator(onCapture: onCapture) }
 
     final class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
         private let onCapture: (UIImage?) -> Void

--- a/ios/Reguerta/Reguerta/Presentation/Settings/ContentView+DeliveryCalendarSheets.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Settings/ContentView+DeliveryCalendarSheets.swift
@@ -82,9 +82,7 @@ struct DeliveryCalendarWeekPickerSheet: View {
         return localizedDateOnly(effectiveMillis)
     }
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 }
 
 private struct DeliveryDayNavigationControl: View {
@@ -129,23 +127,17 @@ private struct DeliveryDayNavigationControl: View {
     }
 
     private func selectPrevious() {
-        guard let index = DeliveryWeekday.allCases.firstIndex(of: selectedWeekday), index > 0 else {
-            return
-        }
+        guard let index = DeliveryWeekday.allCases.firstIndex(of: selectedWeekday), index > 0 else { return }
         selectedWeekday = DeliveryWeekday.allCases[index - 1]
     }
 
     private func selectNext() {
         let weekdays = DeliveryWeekday.allCases
-        guard let index = weekdays.firstIndex(of: selectedWeekday), index < weekdays.count - 1 else {
-            return
-        }
+        guard let index = weekdays.firstIndex(of: selectedWeekday), index < weekdays.count - 1 else { return }
         selectedWeekday = weekdays[index + 1]
     }
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 }
 
 private struct DeliveryDayNavigationButton: View {
@@ -288,7 +280,5 @@ struct SettingsDeliveryCalendarSectionView: View {
         Task { await shiftsViewModel.saveDeliveryCalendarOverride() }
     }
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 }

--- a/ios/Reguerta/Reguerta/Presentation/Settings/ContentView+SettingsAdminRoutes.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Settings/ContentView+SettingsAdminRoutes.swift
@@ -83,9 +83,7 @@ struct AdminToolsCardView: View {
         )
     }
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 }
 
 private struct AdminMemberRowView: View {
@@ -143,9 +141,7 @@ private struct AdminMemberRowView: View {
         .clipShape(RoundedRectangle(cornerRadius: tokens.radius.sm))
     }
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
     private func localizedFormat(_ key: String, _ argument: String) -> LocalizedStringKey {
         LocalizedStringKey("\(key) \(argument)")
@@ -292,8 +288,6 @@ struct SettingsRouteView: View {
         }
     }
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
 }

--- a/ios/Reguerta/Reguerta/Presentation/Settings/DeliveryCalendarSupport.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Settings/DeliveryCalendarSupport.swift
@@ -6,9 +6,7 @@ func buildDeliveryCalendarOverride(
     updatedByUserId: String,
     updatedAtMillis: Int64
 ) -> DeliveryCalendarOverride? {
-    guard let weekStart = isoWeekStartDate(from: weekKey) else {
-        return nil
-    }
+    guard let weekStart = isoWeekStartDate(from: weekKey) else { return nil }
     let deliveryDate = Calendar.current.date(byAdding: .day, value: weekday.dayOffset, to: weekStart) ?? weekStart
     let blockedDate = Calendar.current.date(byAdding: .day, value: 1, to: deliveryDate) ?? deliveryDate
     let openDate = Calendar.current.date(byAdding: .day, value: 2, to: deliveryDate) ?? deliveryDate

--- a/ios/Reguerta/Reguerta/Presentation/SharedProfile/ContentView+SharedProfileRoute.swift
+++ b/ios/Reguerta/Reguerta/Presentation/SharedProfile/ContentView+SharedProfileRoute.swift
@@ -61,9 +61,7 @@ struct SharedProfileHubRoute: View {
         )
     }
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
     var body: some View {
         Group {

--- a/ios/Reguerta/Reguerta/Presentation/Shifts/ContentView+ShiftsRoutes.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Shifts/ContentView+ShiftsRoutes.swift
@@ -48,9 +48,7 @@ private struct MyNextShiftsSectionView: View {
     let tokens: ReguertaDesignTokens
     let viewModel: ShiftsFeatureViewModel
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
     var body: some View {
         VStack(alignment: .center, spacing: tokens.spacing.sm) {
@@ -141,9 +139,7 @@ private struct ShiftBoardSectionView: View {
     let shiftSwapCopy: ShiftSwapCopy
     let onStartSwapRequestForShift: (String) -> Void
 
-    private func localizedKey(_ key: String) -> LocalizedStringKey {
-        LocalizedStringKey(key)
-    }
+    private func localizedKey(_ key: String) -> LocalizedStringKey { LocalizedStringKey(key) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: tokens.spacing.md) {

--- a/ios/Reguerta/Reguerta/Presentation/Shifts/ShiftsFeatureSupport.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Shifts/ShiftsFeatureSupport.swift
@@ -51,9 +51,7 @@ struct ShiftBoardWindow: Equatable, Sendable {
         highlightedShiftId
     }
 
-    func highlights(_ shift: ShiftAssignment) -> Bool {
-        shift.id == highlightedShiftId
-    }
+    func highlights(_ shift: ShiftAssignment) -> Bool { shift.id == highlightedShiftId }
 }
 
 struct ShiftSwapResponseOption: Equatable, Sendable {

--- a/ios/Reguerta/Reguerta/Presentation/Shifts/ShiftsFeatureViewModel+Loading.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Shifts/ShiftsFeatureViewModel+Loading.swift
@@ -86,9 +86,7 @@ extension ShiftsFeatureViewModel {
     }
 
     func openCalendarWeekPicker() {
-        guard let weekKey = selectedDeliveryCalendarWeekKey ?? futureDeliveryWeeks.first?.weekKey else {
-            return
-        }
+        guard let weekKey = selectedDeliveryCalendarWeekKey ?? futureDeliveryWeeks.first?.weekKey else { return }
         selectCalendarWeekForEditing(weekKey)
         isDeliveryCalendarWeekPickerPresented = true
     }

--- a/ios/Reguerta/Reguerta/Presentation/Shifts/ShiftsFeatureViewModel+SwapActions.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Shifts/ShiftsFeatureViewModel+SwapActions.swift
@@ -182,8 +182,14 @@ private extension ShiftsFeatureViewModel {
         guard let context = authorizedSessionContext else { return }
         let session = context.session
         guard !acknowledgedShiftSwapRequestIds.contains(requestId) else { return }
-        guard let request = shiftSwapRequests.first(where: { $0.id == requestId }) else { return }
-        guard let candidate = request.candidates.first(where: { $0.userId == session.member.id && $0.shiftId == candidateShiftId }) else { return }
+        guard let request = shiftSwapRequests.first(where: { $0.id == requestId }) else {
+            return
+        }
+        guard let candidate = request.candidates.first(where: {
+            $0.userId == session.member.id && $0.shiftId == candidateShiftId
+        }) else {
+            return
+        }
         guard let mutationOperationId = beginSwapMutation() else { return }
         Task { @MainActor in
             defer { finishSwapMutation(mutationOperationId, context: context) }
@@ -253,10 +259,18 @@ private extension ShiftsFeatureViewModel {
 
     func confirmShiftSwapContext(requestId: String, candidateShiftId: String) -> ConfirmShiftSwapContext? {
         guard let session = authorizedSession else { return nil }
-        guard let request = shiftSwapRequests.first(where: { $0.id == requestId }) else { return nil }
-        guard let requestedShift = shiftsFeed.first(where: { $0.id == request.requestedShiftId }) else { return nil }
-        guard let candidate = request.candidates.first(where: { $0.shiftId == candidateShiftId }) else { return nil }
-        guard let candidateShift = shiftsFeed.first(where: { $0.id == candidate.shiftId }) else { return nil }
+        guard let request = shiftSwapRequests.first(where: { $0.id == requestId }) else {
+            return nil
+        }
+        guard let requestedShift = shiftsFeed.first(where: { $0.id == request.requestedShiftId }) else {
+            return nil
+        }
+        guard let candidate = request.candidates.first(where: { $0.shiftId == candidateShiftId }) else {
+            return nil
+        }
+        guard let candidateShift = shiftsFeed.first(where: { $0.id == candidate.shiftId }) else {
+            return nil
+        }
 
         return ConfirmShiftSwapContext(
             session: session,

--- a/ios/Reguerta/Reguerta/Presentation/Users/UsersFeatureSupport.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Users/UsersFeatureSupport.swift
@@ -71,9 +71,7 @@ extension MemberDraft {
     }
 
     func normalizedCompanyName(roles: Set<MemberRole>) -> String? {
-        guard roles.contains(.producer) else {
-            return nil
-        }
+        guard roles.contains(.producer) else { return nil }
         let trimmed = companyName.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }

--- a/ios/Reguerta/Reguerta/Presentation/Users/UsersFeatureViewModel.swift
+++ b/ios/Reguerta/Reguerta/Presentation/Users/UsersFeatureViewModel.swift
@@ -120,7 +120,9 @@ final class UsersFeatureViewModel {
             feedbackCenter.show(AccessL10nKey.feedbackOnlyAdminCreate)
             return
         }
-        guard let member = sortedMembers.first(where: { $0.id == memberId }) else { return }
+        guard let member = sortedMembers.first(where: { $0.id == memberId }) else {
+            return
+        }
 
         draft = member.toDraft()
         if draft.isCommonPurchaseManager {
@@ -175,7 +177,9 @@ final class UsersFeatureViewModel {
             feedbackCenter.show(AccessL10nKey.feedbackOnlyAdminEditRoles)
             return false
         }
-        guard let target = sortedMembers.first(where: { $0.id == memberId }) else { return false }
+        guard let target = sortedMembers.first(where: { $0.id == memberId }) else {
+            return false
+        }
 
         var roles = target.roles
         if roles.contains(.admin) {
@@ -198,7 +202,9 @@ final class UsersFeatureViewModel {
             feedbackCenter.show(AccessL10nKey.feedbackOnlyAdminToggleActive)
             return false
         }
-        guard let target = sortedMembers.first(where: { $0.id == memberId }) else { return false }
+        guard let target = sortedMembers.first(where: { $0.id == memberId }) else {
+            return false
+        }
 
         return await persistMember(
             target: target.replacing(isActive: !target.isActive),


### PR DESCRIPTION
## Resumen

Completa el bloque PR 2 del issue #236: normaliza guards elegibles y helpers inequívocamente triviales/puramente adaptadores en el código Swift iOS, manteniendo verticales los casos complejos, con efectos, cierres o mutación.

## Alcance

- 148 compactaciones de layout.
- 12 expansiones conservadoras para preservar legibilidad en guards con `first(where:)` y cierres.
- 79 archivos Swift afectados.
- `CHANGELOG.md` actualizado.
- Sin cambios funcionales, de API, Android, Firebase o contenido de cadenas.

## Validación

- Equivalencia exacta de tokens/comentarios y parseo Swift en 79/79 archivos.
- `git diff --check` limpio.
- 188 líneas añadidas, máximo 120 columnas.
- SwiftLint estricto: 0 violaciones en 338 archivos.
- Build/tests completos omitidos bajo la excepción documentada para cambios exclusivamente no funcionales de layout.

## Seguimiento

Esta PR completa el bloque PR 2 del issue #236. No usa `Fixes #236` porque el issue conserva pendiente la PR 3 de longitud residual y baseline.